### PR TITLE
Robot Upgrade: cert-manager chart upgrade from 1.11.0 to v1.11.0

### DIFF
--- a/charts/cert-manager/cert-manager/Chart.yaml
+++ b/charts/cert-manager/cert-manager/Chart.yaml
@@ -4,10 +4,10 @@ description: cert-manager is a Kubernetes addon to automate the management and i
 type: application
 version: 1.11.0
 appVersion: "v1.11.0"
-dependencies:
-  - name: cert-manager
-    repository: https://charts.jetstack.io
-    version: v1.11.0
 keywords:
   - security
-icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png  
+icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png
+dependencies:
+  - name: cert-manager
+    version: "v1.11.0"
+    repository: "https://charts.jetstack.io"

--- a/charts/cert-manager/config
+++ b/charts/cert-manager/config
@@ -3,7 +3,7 @@ export DAOCLOUD_REPO_PROJECT=addon
 export REPO_URL=https://charts.jetstack.io
 export REPO_NAME=cert-manager
 export CHART_NAME=cert-manager
-export VERSION=1.11.0
+export VERSION=v1.11.0
 
 export UPGRADE_METHOD=pr
 export UPGRADE_REVIWER=lou-lan


### PR DESCRIPTION
I am robot, upgrade: project cert-manager chart upgrade from 1.11.0 to v1.11.0