### PR TITLE
in some situations, grep image will fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,9 +133,9 @@ jobs:
           BASE=$PWD
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do
               CHART_PATH=${BASE}/charts/${PROJECT}/${PROJECT}
-              if helm template test ${CHART_PATH} | grep ' image: ' | tr -d '"' | awk '{print $2}' | grep -v "daocloud" &>/dev/null ; then
+              if helm template test ${CHART_PATH} | grep image: | cut -d ":" -f2,3 | grep -v "daocloud" &>/dev/null ; then
                   echo "error, image is not in daocloud repo"
-                  helm template test ${CHART_PATH} | grep ' image: ' | tr -d '"' | awk '{print $2}'
+                  helm template test ${CHART_PATH} | grep image: | cut -d ":" -f2,3
                   exit 1
               fi
           done


### PR DESCRIPTION
- 在如下的情况下，image字段前有个-，grep image会失败，参见：https://github.com/DaoCloud/dce-charts-repackage/actions/runs/4120445892/jobs/7197938426#step:7:83
  ```bash
     echo -n '      - image: "quay.m.daocloud.io/argoproj/argo-rollouts:master"'| grep ' image: ' |tr -d '"' | awk '{print $2}'
     image:
  ```

