### PR TITLE
add skip harbor-operator chart trivy scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: PR E2E C
 
 env:
-  TRIVY_SCAN_SKIP_CHART_LIST: "nmstate cert-manager contour ingress-nginx "
+  TRIVY_SCAN_SKIP_CHART_LIST: "nmstate cert-manager contour ingress-nginx harbor-operator"
   IMAGE_HINT_FILE_NAME: ".relok8s-images.yaml"
   SCHEMA_FILE_NAME: "values.schema.json"
 


### PR DESCRIPTION
添加 harbor-operator 项目到TRIVY_SCAN_SKIP_CHART_LIST配置中，跳过helm chart trivy 扫描, 跳过原因：
   在harbor-operator  中定义了clusterrole对 secret 资源的 CRUD 管理能力，harbor-operator 服务需要对用户部署在某个namespace空间下的secret资源需要进行管理，所以这个功能是必须存在的，但是在 trivy 的安全扫描中，提示不允许配置对 secret 的管理权限。
   
- clusterrole.yamll

<img width="502" alt="image" src="https://user-images.githubusercontent.com/15009201/218655065-8a1ba1e5-b16c-4b7d-b84f-4fbd9cd1efbb.png">

- trivy 扫描报错：
```
CRITICAL: Role permits management of secret(s)
════════════════════════════════════════
Check whether role permits managing secrets

See https://avd.aquasec.com/misconfig/ksv041
```
   

