### PR TITLE
skip argo rollout trivry scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: PR E2E C
 
 env:
-  TRIVY_SCAN_SKIP_CHART_LIST: "nmstate cert-manager contour ingress-nginx "
+  TRIVY_SCAN_SKIP_CHART_LIST: "nmstate cert-manager contour ingress-nginx argo-rollouts"
   IMAGE_HINT_FILE_NAME: ".relok8s-images.yaml"
   SCHEMA_FILE_NAME: "values.schema.json"
 


### PR DESCRIPTION
添加 argo-rollouts 项目到TRIVY_SCAN_SKIP_CHART_LIST配置中，跳过helm chart trivy 扫描, 跳过原因：
在 argo-rollouts中定义了clusterrole对 secret 资源的CRUD能力，其中一个init container需要操控secret的能力。
https://github.com/usernameisnull/dce-charts-repackage/blob/312831634d2c8d04b638c15f6b110d81b1c06985/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml#L92

![image](https://user-images.githubusercontent.com/3390414/218658243-e8a13df7-6e07-4a58-9a8c-11d69bda92bd.png)
