### PR TITLE
bug: find chart version

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -110,7 +110,8 @@ sync: PROJECT=
 sync: checkBin
 	@ echo "sync $(PROJECT) charts and images to local registry"
 	set -x ; CHART_PATH=$(ROOT_DIR)/charts/$(PROJECT) ; \
-	VERSION=`sed -n  '/VERSION/p' $${CHART_PATH}/config | awk -F = '{print $$2}'` || { echo "error, failed to get charts version" ; exit 1 ; } ;\
+	VERSION=` grep -E "^version:" $(ROOT_DIR)/charts/$(PROJECT)/$(PROJECT)/Chart.yaml  | awk '{print $$2}' ` || { echo "error, failed to get charts version" ; exit 1 ; } ;\
+	echo "chart move $(PROJECT) $${VERSION}" ; \
 	mkdir -p _tmp && DIR=_tmp ;\
     relok8s chart move $${CHART_PATH}/$(PROJECT) --to-intermediate-bundle $${DIR}/$(PROJECT)_$${VERSION}.bundle.tar -y || { echo "error, failed to save charts and images to local" ; exit 1 ; } ; \
     CONFIG=" \


### PR DESCRIPTION
* chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找
