### PR TITLE
fix: some image is empty, like in crd

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,9 +149,9 @@ jobs:
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do
               source ${BASE}/charts/${PROJECT}/config && [ "${NO_IMAGE}" == "true" ] && continue
               CHART_PATH=${BASE}/charts/${PROJECT}/${PROJECT}
-              if helm template test ${CHART_PATH} | grep image: | cut -d ":" -f2,3 | grep -v "daocloud" &>/dev/null ; then
+              if helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3 | grep -v "daocloud" &>/dev/null ; then
                   echo "error, image is not in daocloud repo"
-                  helm template test ${CHART_PATH} | grep image: | cut -d ":" -f2,3
+                  helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3
                   exit 1
               fi
           done


### PR DESCRIPTION
* chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

---
某些crd里有类似情况, 会失败，认为镜像没有daocloud关键字
```yaml
image:
  type: string
```
    
