### PR TITLE
fix f5 test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -67,6 +67,8 @@ e2e:
 					make deploy -e INSTALL_PATH=$${INSTALL_PATH}  -e PROJECT=$${ITEM} || { echo "error, failed to deploy $${ITEM}" ; exit 1 ; } ; \
 				done ; \
   	    fi ;\
+  	    echo "============== show final result ====================" ; \
+  	    kubectl --kubeconfig $(KIND_KUBECONFIG) get pod -A -o wide || true ; \
 	  	exit 0
 
 

--- a/test/f5networks/install.sh
+++ b/test/f5networks/install.sh
@@ -17,13 +17,17 @@ HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG
 
 set -x
 
+
+KIND_STROAGECLASS=` kubectl get storageclass | grep -v "NAME" | awk '{print $1}' `
+[ -n "${KIND_STROAGECLASS}" ] || { echo "error, failed to find any storageclass "  ; kubectl get storageclass ; exit 1 ; }
+
 helm install f5networks chart-museum/f5networks  ${HELM_MUST_OPTION} \
   --namespace kube-public \
   --set f5-bigip-ctlr.args.bigip_url=https://172.17.8.10:10443 \
   --set f5-bigip-ctlr.args.bigip_partition="kubernetes" \
   --set f5-bigip-ctlr.args.pool_member_type=nodeport \
   --set f5-ipam-controller.args.ip_range='"{\"welanipam\":\"10.0.2.100-10.0.2.200\"}"' \
-  --set f5-ipam-controller.pvc.create=false \
+  --set f5-ipam-controller.pvc.storageClassName="${KIND_STROAGECLASS}" \
   --set cis-secret.username="admin" \
   --set cis-secret.password="admin"
 


### PR DESCRIPTION
* chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找
