### PR TITLE
more grep image fix

### DIFF
--- a/scripts/offline.sh
+++ b/scripts/offline.sh
@@ -27,7 +27,7 @@ for PRO in ${CHART_LIST} ; do
 
     grep " ${PRO} " <<< "$IGNORE_IMAGE_PRO" &>/dev/null && continue
 
-    IMAGE_LIST=$( helm template ${CHART_DIR} | grep " image: " | awk '{print $2}' | sort  | uniq | tr -d '"' )
+    IMAGE_LIST=$( helm template ${CHART_DIR} | grep " image: " | cut -d ":" -f2,3 | sort  | uniq | tr -d '"' )
     if [ -z "$IMAGE_LIST" ] ; then
         echo "failed to get image from ${CHART_DIR}"
         exit 1

--- a/test/Makefile
+++ b/test/Makefile
@@ -134,7 +134,7 @@ checkImages: PROJECT=
 checkImages: checkBin
 	@ echo "check $(PROJECT) images registry"
 	helm repo update chart-museum  --kubeconfig $(KIND_KUBECONFIG) || { echo "error, failed to update helm chart-museum repo " ; exit 1 ; } ; \
-    IMAGE_LIST=` helm template test chart-museum/$${PROJECT}  | grep " image: " | tr -d '"'| awk '{print $$2}' ` ;\
+    IMAGE_LIST=` helm template test chart-museum/$${PROJECT}  | grep " image: " | cut -d ":" -f2,3 ` ;\
 	if [ -z "$${IMAGE_LIST}" ] ; then \
 		echo "error, failed to find image from chart template for $(PROJECT)" ; exit 1 ; \
 	else \
@@ -157,7 +157,7 @@ deploy: checkBin
 		[ -d "$${CHART_DIR}" ] || { echo "error, failed to find chart $${CHART_DIR}" ; exit 1 ; } ; \
 		if [ "$(TRY_LOAD_LOCAL_IMAGE)" == "true" ] ; then \
 			echo "try to load local image for $(PROJECT)" ; \
-			IMAGE_LIST=` helm template test $${CHART_DIR}  | grep " image: " | tr -d '"'| awk '{print $$2}' ` ; \
+			IMAGE_LIST=` helm template test $${CHART_DIR}  | grep " image: " | cut -d ":" -f2,3 ` ; \
 			if [ -z "$${IMAGE_LIST}" ] ; then \
 			  	echo "warning, failed to find image from chart template for $(PROJECT)" ; \
 			else \

--- a/test/multus-underlay/install.sh
+++ b/test/multus-underlay/install.sh
@@ -24,7 +24,7 @@ HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG
 
 set -x
 
-HELM_IMAGES_LIST=` helm template test chart-museum/multus-underlay  ${HELM_MUST_OPTION} | grep " image: " | tr -d '"'| awk '{print $2}' `
+HELM_IMAGES_LIST=` helm template test chart-museum/multus-underlay  ${HELM_MUST_OPTION} | grep " image: " | cut -d ":" -f2,3 `
 
 [ -z "${HELM_IMAGES_LIST}" ] && echo "can't found image of multus-underlay" && exit 1
 LOCAL_IMAGE_LIST=`docker images | awk '{printf("%s:%s\n",$1,$2)}'`


### PR DESCRIPTION
* chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

--- 
统一获取image的grep方式
