### PR TITLE
fix falco

### DIFF
--- a/charts/falco/custom.sh
+++ b/charts/falco/custom.sh
@@ -17,10 +17,14 @@ set -o nounset
 APP_VERSION=` cat charts/falco/Chart.yaml | grep appVersion | awk '{print $2}'`
 sed -iE "s?tag:.*?tag: ${APP_VERSION}?g" values.yaml
 
-yq -i ' .falco.falcosidekick.image.registry = "docker.m.daocloud.io" ' values.yaml
 yq -i ' .falco.image.registry = "docker.m.daocloud.io" ' values.yaml
 yq -i ' .falco.falco.json_output = true ' values.yaml
 yq -i ' .falco.driver.loader.initContainer.image.registry = "docker.m.daocloud.io" ' values.yaml
+
+KICKAPP_VERSION=` cat charts/falco/charts/falcosidekick/Chart.yaml | grep appVersion | awk '{print $2}'`
+yq -i ' .falco.falcosidekick.image.registry = "docker.m.daocloud.io" ' values.yaml
+yq -i ' .falco.falcosidekick.image.repository = "falcosecurity/falcosidekick" ' values.yaml
+yq -i " .falco.falcosidekick.image.tag = \"${KICKAPP_VERSION}\" " values.yaml
 
 rm -f values.yamlE || true
 rm -rf charts/falco/charts/falcosidekick/templates/tests

--- a/charts/falco/falco/.relok8s-images.yaml
+++ b/charts/falco/falco/.relok8s-images.yaml
@@ -1,2 +1,3 @@
 - "{{ .falco.image.registry }}/{{ .falco.image.repository }}:{{ .falco.image.tag }}"
 - "{{ .falco.driver.loader.initContainer.image.registry }}/{{ .falco.driver.loader.initContainer.image.repository }}:{{ .falco.driver.loader.initContainer.image.tag }}"
+- "{{ .falco.falcosidekick.image.registry }}/{{ .falco.falcosidekick.image.repository }}:{{ .falco.falcosidekick.image.tag }}"

--- a/charts/falco/falco/values.yaml
+++ b/charts/falco/falco/values.yaml
@@ -283,6 +283,8 @@ falco:
     listenPort: ""
     image:
       registry: docker.m.daocloud.io
+      repository: falcosecurity/falcosidekick
+      tag: 2.26.0
   ######################
   # falco.yaml config  #
   ######################

--- a/charts/falco/parent/.relok8s-images.yaml
+++ b/charts/falco/parent/.relok8s-images.yaml
@@ -1,2 +1,3 @@
 - "{{ .falco.image.registry }}/{{ .falco.image.repository }}:{{ .falco.image.tag }}"
 - "{{ .falco.driver.loader.initContainer.image.registry }}/{{ .falco.driver.loader.initContainer.image.repository }}:{{ .falco.driver.loader.initContainer.image.tag }}"
+- "{{ .falco.falcosidekick.image.registry }}/{{ .falco.falcosidekick.image.repository }}:{{ .falco.falcosidekick.image.tag }}"


### PR DESCRIPTION
* chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”
