### PR TITLE
add prometheus-adapter

### DIFF
--- a/charts/prometheus-adapter/config
+++ b/charts/prometheus-adapter/config
@@ -1,0 +1,21 @@
+export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://prometheus-community.github.io/helm-charts
+export REPO_NAME=kube-state-metrics
+export CHART_NAME=prometheus-adapter
+export VERSION=4.1.1
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=z-anshun,hermaproditus,Haleygo
+export TEST_ASSIGNER=z-anshun,hermaproditus,Haleygo
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=community
+
+# NO_TRIVY
+export NO_TRIVY=true

--- a/charts/prometheus-adapter/custom.sh
+++ b/charts/prometheus-adapter/custom.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#==============================
+
+if [ "$(uname)" == "Darwin" ];then
+  sed  -i '' 's?"{{ .Values.image.repository }}:{{ .Values.image.tag }}"?"{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"?'   charts/prometheus-adapter/templates/deployment.yaml
+else
+  sed  -i  's?"{{ .Values.image.repository }}:{{ .Values.image.tag }}"?"{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"?'   charts/prometheus-adapter/templates/deployment.yaml
+fi

--- a/charts/prometheus-adapter/parent/.relok8s-images.yaml
+++ b/charts/prometheus-adapter/parent/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .prometheus-adapter.image.registry }}/{{ .prometheus-adapter.image.repository }}:{{ .prometheus-adapter.image.tag }}"

--- a/charts/prometheus-adapter/parent/values.yaml
+++ b/charts/prometheus-adapter/parent/values.yaml
@@ -1,0 +1,12 @@
+prometheus-adapter:
+  image:
+    registry: k8s-gcr.m.daocloud.io
+    repository: prometheus-adapter/prometheus-adapter
+    tag: v0.10.0
+  resources:
+    limits:
+      cpu: 250m
+      memory: 250Mi
+    requests:
+      cpu: 50m
+      memory: 25Mi

--- a/charts/prometheus-adapter/prometheus-adapter/.relok8s-images.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .prometheus-adapter.image.registry }}/{{ .prometheus-adapter.image.repository }}:{{ .prometheus-adapter.image.tag }}"

--- a/charts/prometheus-adapter/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+appVersion: v0.10.0
+description: A Helm chart for k8s prometheus adapter
+home: https://github.com/kubernetes-sigs/prometheus-adapter
+keywords:
+  - hpa
+  - metrics
+  - prometheus
+  - adapter
+maintainers:
+  - email: mattias.gees@jetstack.io
+    name: mattiasgees
+  - name: steven-sheehy
+  - email: hfernandez@mesosphere.com
+    name: hectorj2f
+name: prometheus-adapter
+sources:
+  - https://github.com/kubernetes/charts
+  - https://github.com/kubernetes-sigs/prometheus-adapter
+version: 4.1.1
+dependencies:
+  - name: prometheus-adapter
+    version: "4.1.1"
+    repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/prometheus-adapter/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/prometheus-adapter/README.md
@@ -1,0 +1,156 @@
+# Prometheus Adapter
+
+Installs the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter) for the Custom Metrics API. Custom metrics are used in Kubernetes by [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to scale workloads based upon your own metric pulled from an external metrics provider like Prometheus. This chart complements the [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server) chart that provides resource only metrics.
+
+## Prerequisites
+
+Kubernetes 1.14+
+
+## Get Helm Repositories Info
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Helm Chart
+
+```console
+helm install [RELEASE_NAME] prometheus-community/prometheus-adapter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Helm Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Helm Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 4.0.0
+
+Previously, security context of the container was set directly in the deployment template. This release makes it configurable through the new configuration variable `securityContext` whilst keeping the previously set values as defaults. Furthermore, previous variable `runAsUser` is now set in `securityContext` and is not used any longer. Please, use `securityContext.runAsUser` instead. In the same security context, `seccompProfile` has been enabled and set to type `RuntimeDefault`.
+
+### To 3.0.0
+
+Due to a change in deployment labels, the upgrade requires `helm upgrade --force` in order to re-create the deployment.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/prometheus-adapter
+```
+
+### Prometheus Service Endpoint
+
+To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
+
+### Adapter Rules
+
+Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/docs/config.md) for the proper format).
+
+### Horizontal Pod Autoscaler Metrics
+
+Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
+
+The Prometheus Adapter can serve three different [metrics APIs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-metrics-apis):
+
+### Custom Metrics
+
+Enabling this option will cause custom metrics to be served at `/apis/custom.metrics.k8s.io/v1beta1`. Enabled by default when `rules.default` is true, but can be customized by populating `rules.custom`:
+
+```yaml
+rules:
+  custom:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_custom_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+### External Metrics
+
+Enabling this option will cause external metrics to be served at `/apis/external.metrics.k8s.io/v1beta1`. Can be enabled by populating `rules.external`:
+
+```yaml
+rules:
+  external:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_external_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+### Resource Metrics
+
+Enabling this option will cause resource metrics to be served at `/apis/metrics.k8s.io/v1beta1`. Resource metrics will allow pod CPU and Memory metrics to be used in [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) as well as the `kubectl top` command. Can be enabled by populating `rules.resource`:
+
+```yaml
+rules:
+  resource:
+    cpu:
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          rate(container_cpu_usage_seconds_total{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum  by (<<.GroupBy>>) (
+          rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",<<.LabelMatchers>>}[3m])
+        )
+      resources:
+        overrides:
+          node:
+            resource: node
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      containerLabel: container
+    memory:
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
+          -
+          avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
+        )
+      resources:
+        overrides:
+          node:
+            resource: node
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      containerLabel: container
+    window: 3m
+```
+
+**NOTE:** Setting a value for `rules.resource` will also deploy the resource metrics API service, providing the same functionality as [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server). As such it is not possible to deploy them both in the same cluster.

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/.helmignore
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+appVersion: v0.10.0
+description: A Helm chart for k8s prometheus adapter
+home: https://github.com/kubernetes-sigs/prometheus-adapter
+keywords:
+- hpa
+- metrics
+- prometheus
+- adapter
+maintainers:
+- email: mattias.gees@jetstack.io
+  name: mattiasgees
+- name: steven-sheehy
+- email: hfernandez@mesosphere.com
+  name: hectorj2f
+name: prometheus-adapter
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/kubernetes-sigs/prometheus-adapter
+version: 4.1.1

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/README.md
@@ -1,0 +1,156 @@
+# Prometheus Adapter
+
+Installs the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter) for the Custom Metrics API. Custom metrics are used in Kubernetes by [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to scale workloads based upon your own metric pulled from an external metrics provider like Prometheus. This chart complements the [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server) chart that provides resource only metrics.
+
+## Prerequisites
+
+Kubernetes 1.14+
+
+## Get Helm Repositories Info
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Helm Chart
+
+```console
+helm install [RELEASE_NAME] prometheus-community/prometheus-adapter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Helm Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Helm Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 4.0.0
+
+Previously, security context of the container was set directly in the deployment template. This release makes it configurable through the new configuration variable `securityContext` whilst keeping the previously set values as defaults. Furthermore, previous variable `runAsUser` is now set in `securityContext` and is not used any longer. Please, use `securityContext.runAsUser` instead. In the same security context, `seccompProfile` has been enabled and set to type `RuntimeDefault`.
+
+### To 3.0.0
+
+Due to a change in deployment labels, the upgrade requires `helm upgrade --force` in order to re-create the deployment.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/prometheus-adapter
+```
+
+### Prometheus Service Endpoint
+
+To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
+
+### Adapter Rules
+
+Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/docs/config.md) for the proper format).
+
+### Horizontal Pod Autoscaler Metrics
+
+Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
+
+The Prometheus Adapter can serve three different [metrics APIs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-metrics-apis):
+
+### Custom Metrics
+
+Enabling this option will cause custom metrics to be served at `/apis/custom.metrics.k8s.io/v1beta1`. Enabled by default when `rules.default` is true, but can be customized by populating `rules.custom`:
+
+```yaml
+rules:
+  custom:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_custom_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+### External Metrics
+
+Enabling this option will cause external metrics to be served at `/apis/external.metrics.k8s.io/v1beta1`. Can be enabled by populating `rules.external`:
+
+```yaml
+rules:
+  external:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_external_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+### Resource Metrics
+
+Enabling this option will cause resource metrics to be served at `/apis/metrics.k8s.io/v1beta1`. Resource metrics will allow pod CPU and Memory metrics to be used in [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) as well as the `kubectl top` command. Can be enabled by populating `rules.resource`:
+
+```yaml
+rules:
+  resource:
+    cpu:
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          rate(container_cpu_usage_seconds_total{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum  by (<<.GroupBy>>) (
+          rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",<<.LabelMatchers>>}[3m])
+        )
+      resources:
+        overrides:
+          node:
+            resource: node
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      containerLabel: container
+    memory:
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
+          -
+          avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
+        )
+      resources:
+        overrides:
+          node:
+            resource: node
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      containerLabel: container
+    window: 3m
+```
+
+**NOTE:** Setting a value for `rules.resource` will also deploy the resource metrics API service, providing the same functionality as [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server). As such it is not possible to deploy them both in the same cluster.

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/ci/external-rules-values.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/ci/external-rules-values.yaml
@@ -1,0 +1,9 @@
+rules:
+  external:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_custom_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/NOTES.txt
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/NOTES.txt
@@ -1,0 +1,9 @@
+{{ template "k8s-prometheus-adapter.fullname" .  }} has been deployed.
+In a few minutes you should be able to list metrics using the following command(s):
+{{ if .Values.rules.resource }}
+  kubectl get --raw /apis/metrics.k8s.io/v1beta1
+{{- end }}
+  kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1
+{{ if .Values.rules.external }}
+  kubectl get --raw /apis/external.metrics.k8s.io/v1beta1
+{{- end }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/_helpers.tpl
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-prometheus-adapter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-prometheus-adapter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "k8s-prometheus-adapter.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-prometheus-adapter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate basic labels
+*/}}
+{{- define "k8s-prometheus-adapter.labels" }}
+helm.sh/chart: {{ include "k8s-prometheus-adapter.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "k8s-prometheus-adapter.name" . }}
+{{- include "k8s-prometheus-adapter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-prometheus-adapter.selectorLabels" }}
+app.kubernetes.io/name: {{ include "k8s-prometheus-adapter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8s-prometheus-adapter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "k8s-prometheus-adapter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/* Get Policy API Version */}}
+{{- define "k8s-prometheus-adapter.pdb.apiVersion" -}}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "policy/v1" -}}
+{{- else -}}
+    {{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/certmanager.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/certmanager.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.certManager.enabled -}}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-self-signed-issuer
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  secretName: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+  duration: {{ .Values.certManager.caCertDuration }}
+  issuerRef:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}-self-signed-issuer
+  commonName: "ca.webhook.prometheus-adapter"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-issuer
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  ca:
+    secretName: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+---
+# Finally, generate a serving certificate for the apiservices to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-cert
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  secretName: {{ template "k8s-prometheus-adapter.fullname" . }}
+  duration: {{ .Values.certManager.certDuration }}
+  issuerRef:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-issuer
+  dnsNames:
+  - {{ template "k8s-prometheus-adapter.fullname" . }}
+  - {{ template "k8s-prometheus-adapter.fullname" . }}.{{ include "k8s-prometheus-adapter.namespace" . }}
+  - {{ template "k8s-prometheus-adapter.fullname" . }}.{{ include "k8s-prometheus-adapter.namespace" . }}.svc
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-auth-delegator.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-auth-delegator.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-system-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-resource-reader.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-resource-reader.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-resource-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-resource-reader.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-resource-reader.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-resource-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/configmap.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/configmap.yaml
@@ -1,0 +1,97 @@
+{{- if not .Values.rules.existing -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+data:
+  config.yaml: |
+{{- if or .Values.rules.default .Values.rules.custom }}
+    rules:
+{{- if .Values.rules.default }}
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+        by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_seconds_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+        by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)$
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_total$
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_seconds_total
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters: []
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+{{- end -}}
+{{- if .Values.rules.custom }}
+{{ toYaml .Values.rules.custom | indent 4 }}
+{{- end -}}
+{{- end -}}
+{{- if .Values.rules.external }}
+    externalRules:
+{{ toYaml .Values.rules.external | indent 4 }}
+{{- end -}}
+{{- if .Values.rules.resource }}
+    resourceRules:
+{{ toYaml .Values.rules.resource | indent 6 }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
@@ -1,0 +1,34 @@
+{{- if or .Values.rules.default .Values.rules.custom }}
+{{- if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1" }}
+apiVersion: apiregistration.k8s.io/v1
+{{- else }}
+apiVersion: apiregistration.k8s.io/v1beta1
+{{- end }}
+kind: APIService
+metadata:
+{{- if or .Values.certManager.enabled .Values.customAnnotations }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+{{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+  {{- if .Values.tls.enable }}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  {{- if not (or .Values.tls.enable .Values.certManager.enabled) }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role-binding-hpa.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role-binding-hpa.yaml
@@ -1,0 +1,24 @@
+{{- /*
+This if must be aligned with custom-metrics-cluster-role.yaml
+as otherwise this binding will point to not existing role.
+*/ -}}
+{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-hpa-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-server-resources
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/deployment.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- if or .Values.customAnnotations .Values.deploymentAnnotations }}
+  annotations:
+    {{- with .Values.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deploymentAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy: {{ toYaml .Values.strategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "k8s-prometheus-adapter.selectorLabels" . | indent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-prometheus-adapter.labels" . | indent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      name: {{ template "k8s-prometheus-adapter.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.customAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+      {{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end}}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        args:
+        - /adapter
+        - --secure-port={{ .Values.listenPort }}
+        {{- if or .Values.tls.enable .Values.certManager.enabled }}
+        - --tls-cert-file=/var/run/serving-cert/tls.crt
+        - --tls-private-key-file=/var/run/serving-cert/tls.key
+        {{- end }}
+        - --cert-dir=/tmp/cert
+        - --logtostderr=true
+        - --prometheus-url={{ tpl .Values.prometheus.url . }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}{{ .Values.prometheus.path }}
+        - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
+        - --v={{ .Values.logLevel }}
+        - --config=/etc/adapter/config.yaml
+        {{- if .Values.extraArguments }}
+        {{- toYaml .Values.extraArguments | trim | nindent 8 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.listenPort }}
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+        {{- with .Values.dnsConfig }}
+        dnsConfig:
+        {{ toYaml . | indent 8 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}
+        {{ end }}
+        - mountPath: /etc/adapter/
+          name: config
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        {{- if or .Values.tls.enable .Values.certManager.enabled }}
+        - mountPath: /var/run/serving-cert
+          name: volume-serving-cert
+          readOnly: true
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      volumes:
+      {{- if .Values.extraVolumes  }}
+      {{ toYaml .Values.extraVolumes | trim | nindent 6 }}
+      {{ end }}
+      - name: config
+        configMap:
+          name: {{ .Values.rules.existing | default (include "k8s-prometheus-adapter.fullname" . ) }}
+      - name: tmp
+        emptyDir: {}
+      {{- if or .Values.tls.enable .Values.certManager.enabled }}
+      - name: volume-serving-cert
+        secret:
+          secretName: {{ template "k8s-prometheus-adapter.fullname" . }}
+      {{- end }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rules.external }}
+{{- if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1" }}
+apiVersion: apiregistration.k8s.io/v1
+{{- else }}
+apiVersion: apiregistration.k8s.io/v1beta1
+{{- end }}
+kind: APIService
+metadata:
+{{- if or .Values.certManager.enabled .Values.customAnnotations }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+{{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+  {{- if .Values.tls.enable }}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: external.metrics.k8s.io
+  version: v1beta1
+  {{- if not (or .Values.tls.enable .Values.certManager.enabled) }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role-binding-hpa.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role-binding-hpa.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.rules.external -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-external-metrics
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.rbac.create .Values.rules.external -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-external-metrics
+rules:
+- apiGroups:
+  - "external.metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/pdb.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: {{ include "k8s-prometheus-adapter.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "k8s-prometheus-adapter.selectorLabels" . | indent 6 }}
+{{- end }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/psp.yaml
@@ -1,0 +1,66 @@
+{{- if and .Values.psp.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+spec:
+  {{- if .Values.hostNetwork.enabled }}
+  hostNetwork: true
+  hostPorts:
+    - min: {{ .Values.listenPort }}
+      max: {{ .Values.listenPort }}
+  {{- end }}
+  fsGroup:
+    rule: RunAsAny
+  runAsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: MustRunAs
+    ranges:
+    - min: 1024
+      max: 65535
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - emptyDir
+  - configMap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+rules:
+- apiGroups: 
+  - 'policy'
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "k8s-prometheus-adapter.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rules.resource}}
+{{- if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1" }}
+apiVersion: apiregistration.k8s.io/v1
+{{- else }}
+apiVersion: apiregistration.k8s.io/v1beta1
+{{- end }}
+kind: APIService
+metadata:
+{{- if or .Values.certManager.enabled .Values.customAnnotations }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" (include "k8s-prometheus-adapter.namespace" .) (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+{{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+  {{- if .Values.tls.enable }}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: metrics.k8s.io
+  version: v1beta1
+  {{- if not (or .Values.tls.enable .Values.certManager.enabled) }}
+  insecureSkipTLSVerify: true
+  {{- end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.rules.resource -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-hpa-controller-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-metrics
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.rules.resource -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/role-binding-auth-reader.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/role-binding-auth-reader.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/secret.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.tls.enable -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- if .Values.customAnnotations }}
+  annotations:
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ b64enc .Values.tls.certificate }}
+  tls.key: {{ b64enc .Values.tls.key }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/service.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if or .Values.service.annotations .Values.customAnnotations }}
+  annotations:
+  {{- if .Values.service.annotations }}
+  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+  {{- if .Values.customAnnotations }}
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+spec:
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: https
+  selector:
+    {{- include "k8s-prometheus-adapter.selectorLabels" . | indent 4 }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/serviceaccount.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
+{{- if or .Values.serviceAccount.annotations .Values.customAnnotations }}
+  annotations:
+  {{- if .Values.serviceAccount.annotations }}
+  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.customAnnotations }}
+  {{- toYaml .Values.customAnnotations | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/values.yaml
@@ -1,0 +1,251 @@
+affinity: {}
+
+topologySpreadConstraints: []
+
+image:
+  repository: registry.k8s.io/prometheus-adapter/prometheus-adapter
+  tag: v0.10.0
+  pullPolicy: IfNotPresent
+
+logLevel: 4
+
+metricsRelistInterval: 1m
+
+listenPort: 6443
+
+nodeSelector: {}
+
+priorityClassName: ""
+
+## Override the release namespace (for multi-namespace deployments in combined charts)
+namespaceOverride: ""
+
+## Additional annotations to add to all resources
+customAnnotations: {}
+  # role: custom-metrics
+
+## Additional labels to add to all resources
+customLabels: {}
+  # monitoring: prometheus-adapter
+
+# Url to access prometheus
+prometheus:
+  # Value is templated
+  url: http://prometheus.default.svc
+  port: 9090
+  path: ""
+
+replicas: 1
+
+# k8s 1.21 needs fsGroup to be set for non root deployments
+# ref: https://github.com/kubernetes/kubernetes/issues/70679
+podSecurityContext:
+  fsGroup: 10001
+
+# SecurityContext of the container
+# ref. https://kubernetes.io/docs/tasks/configure-pod-container/security-context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["all"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+psp:
+  # Specifies whether PSP resources should be created
+  create: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # ServiceAccount annotations.
+  # Use case: AWS EKS IAM roles for service accounts
+  # ref: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
+  annotations: {}
+
+# Custom DNS configuration to be added to prometheus-adapter pods
+dnsConfig: {}
+  # nameservers:
+  #   - 1.2.3.4
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  # options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+rules:
+  default: true
+
+  custom: []
+    # - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    #   resources:
+    #     template: <<.Resource>>
+    #   name:
+    #     matches: ""
+    #     as: "my_custom_metric"
+    #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+
+  # Mounts a configMap with pre-generated rules for use. Overrides the
+  # default, custom, external and resource entries
+  existing:
+
+  external: []
+    # - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    #   resources:
+    #     template: <<.Resource>>
+    #   name:
+    #     matches: ""
+    #     as: "my_external_metric"
+    #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+
+  # resource:
+  #   cpu:
+  #     containerQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         rate(container_cpu_usage_seconds_total{container!="",<<.LabelMatchers>>}[3m])
+  #       )
+  #     nodeQuery: |
+  #       sum  by (<<.GroupBy>>) (
+  #         rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",<<.LabelMatchers>>}[3m])
+  #       )
+  #     resources:
+  #       overrides:
+  #         node:
+  #           resource: node
+  #         namespace:
+  #           resource: namespace
+  #         pod:
+  #           resource: pod
+  #     containerLabel: container
+  #   memory:
+  #     containerQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
+  #       )
+  #     nodeQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
+  #         -
+  #         avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
+  #       )
+  #     resources:
+  #       overrides:
+  #         node:
+  #           resource: node
+  #         namespace:
+  #           resource: namespace
+  #         pod:
+  #           resource: pod
+  #     containerLabel: container
+  #   window: 3m
+
+service:
+  annotations: {}
+  port: 443
+  type: ClusterIP
+  # clusterIP: 1.2.3.4
+
+tls:
+  enable: false
+  ca: |-
+    # Public CA file that signed the APIService
+  key: |-
+    # Private key of the APIService
+  certificate: |-
+    # Public key of the APIService
+
+# Set environment variables from secrets, configmaps or by setting them as name/value
+env: []
+  # - name: TMP_DIR
+  #   value: /tmp
+  # - name: PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret
+  #       key: password
+  #       optional: false
+
+# Any extra arguments
+extraArguments: []
+  # - --tls-private-key-file=/etc/tls/tls.key
+  # - --tls-cert-file=/etc/tls/tls.crt
+
+# Any extra volumes
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
+  #     type: File
+
+# Any extra volume mounts
+extraVolumeMounts: []
+  #   - name: example-name
+  #     mountPath: /path/in/container
+  #   - name: ssl-certs
+  #     mountPath: /etc/ssl/certs/ca-certificates.crt
+  #     readOnly: true
+
+tolerations: []
+
+# Labels added to the pod
+podLabels: {}
+
+# Annotations added to the pod
+podAnnotations: {}
+
+# Annotations added to the deployment
+deploymentAnnotations: {}
+
+hostNetwork:
+  # Specifies if prometheus-adapter should be started in hostNetwork mode.
+  #
+  # You would require this enabled if you use alternate overlay networking for pods and
+  # API server unable to communicate with metrics-server. As an example, this is required
+  # if you use Weave network on EKS. See also dnsPolicy
+  enabled: false
+
+# When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
+# dnsPolicy: ClusterFirstWithHostNet
+
+# Deployment strategy type
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 25%
+    maxSurge: 25%
+
+podDisruptionBudget:
+  # Specifies if PodDisruptionBudget should be enabled
+  # When enabled, minAvailable or maxUnavailable should also be defined.
+  enabled: false
+  minAvailable:
+  maxUnavailable: 1
+
+certManager:
+  enabled: false
+  caCertDuration: 43800h
+  certDuration: 8760h

--- a/charts/prometheus-adapter/prometheus-adapter/values.schema.json
+++ b/charts/prometheus-adapter/prometheus-adapter/values.schema.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "prometheus-adapter": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/prometheus-adapter/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/values.yaml
@@ -1,0 +1,12 @@
+prometheus-adapter:
+  image:
+    registry: k8s-gcr.m.daocloud.io
+    repository: prometheus-adapter/prometheus-adapter
+    tag: v0.10.0
+  resources:
+    limits:
+      cpu: 250m
+      memory: 250Mi
+    requests:
+      cpu: 50m
+      memory: 25Mi

--- a/charts/prometheus-adapter/skip-check.yaml
+++ b/charts/prometheus-adapter/skip-check.yaml
@@ -1,0 +1,2 @@
+prometheus-adapter:
+  - "image/registry"

--- a/test/prometheus-adapter/install.sh
+++ b/test/prometheus-adapter/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
+
+KIND_KUBECONFIG=$1
+
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+
+helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+#==================== notice , prometheus CRD has been deployed , so you no need to =============
+
+set -x
+
+# deploy the prometheus-adapter
+helm install prometheus-adapter chart-museum/prometheus-adapter  ${HELM_MUST_OPTION}  --namespace kube-system
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+  exit 0
+else
+  echo "error, faild to deploy $CHART_DIR"
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #