### PR TITLE
Update harbor operator registry

### DIFF
--- a/charts/harbor-operator/harbor-operator/values.yaml
+++ b/charts/harbor-operator/harbor-operator/values.yaml
@@ -1,5 +1,5 @@
 image:
-  registry: m.daocloud.io/docker.io
+  registry: release.daocloud.io
   # image.repository -- The image repository whose default is the chart appVersion.
   repository: goharbor/harbor-operator
   # image.pullPolicy -- The image pull policy for the controller.

--- a/charts/harbor-operator/update.sh
+++ b/charts/harbor-operator/update.sh
@@ -19,7 +19,7 @@ ls -lh
 cp .relok8s-images.yaml ./harbor-operator/
 
 # add image.registry field
-imageRegistry=`sed -n -e 'registry: docker.io' harbor-operator/values.yaml`
+imageRegistry=`sed -n -e 'registry: release.daocloud.io' harbor-operator/values.yaml`
 os=$(uname)
 echo $os
 
@@ -28,14 +28,14 @@ if [ $os == "Darwin" ];then
         line=`sed -n -e '/# image.repository/=' harbor-operator/values.yaml`
         echo "line is:" $line
         sed -i "" "$line i\\
-  registry: m.daocloud.io\\/docker.io
+  registry: release.daocloud.io
         " harbor-operator/values.yaml
     fi
 elif [ $os == "Linux" ];then
     if [ ! $imageRegistry ];then
             line=`sed -n -e '/# image.repository/=' harbor-operator/values.yaml`
             echo "line is:" $line
-            sed -i "$line i \  registry: m.daocloud.io\\/docker.io" harbor-operator/values.yaml
+            sed -i "$line i \  registry: release.daocloud.io" harbor-operator/values.yaml
     fi
 fi
 


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

修改harbor-operator chart registry 为relases仓库

我们需要支持harbor-operator arm化，但官方暂时未支持arm，我们构建了arm的harbor & harbor-operator 在relases上
后期官方支持再切换回来

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #