### PR TITLE
Update schema to origin of contour

### DIFF
--- a/charts/contour/contour/values.schema.json
+++ b/charts/contour/contour/values.schema.json
@@ -9,7 +9,8 @@
         "imageRegistry": {
           "type": "string",
           "title": "Global Image Registry",
-          "default": "release.daocloud.io"
+          "default": "",
+          "description": "Replace the default image repository"
         }
       }
     },

--- a/charts/contour/parent/values.schema.json
+++ b/charts/contour/parent/values.schema.json
@@ -9,7 +9,8 @@
         "imageRegistry": {
           "type": "string",
           "title": "Global Image Registry",
-          "default": "release.daocloud.io"
+          "default": "",
+          "description": "Replace the default image repository"
         }
       }
     },


### PR DESCRIPTION
* schema 的镜像仓库值留空比较好，有在线使用和离线使用，以及去除厂商标志的情况
* 离线安装情况，需要 schema 的默认值不会覆盖 values.yaml 的值，dce chart sync 会替换为内网镜像