### PR TITLE
Update schema.json for neuvector

### DIFF
--- a/charts/neuvector/neuvector/values.schema.json
+++ b/charts/neuvector/neuvector/values.schema.json
@@ -45,10 +45,12 @@
                 "storageClass": {
                   "type": "string",
                   "title": "pvc storageClass",
+                  "default": "",
                   "description": "it requires storageClass to support ReadWriteMany(RWX) accessMode"
                 },
                 "capacity": {
                   "type": "string",
+                  "default": "",
                   "title": "pvc capacity"
                 }
               }

--- a/charts/neuvector/parent/values.schema.json
+++ b/charts/neuvector/parent/values.schema.json
@@ -45,10 +45,12 @@
                 "storageClass": {
                   "type": "string",
                   "title": "pvc storageClass",
+                  "default": "",
                   "description": "it requires storageClass to support ReadWriteMany(RWX) accessMode"
                 },
                 "capacity": {
                   "type": "string",
+                  "default": "",
                   "title": "pvc capacity"
                 }
               }


### PR DESCRIPTION
Fixes： 
pvc enabled 关闭时，会安装失败，pvc的 storageClass和capacity 被传入了值 "null"
此时应该给予 storageClass和capacity  一个空的默认值，像是这样：""。