### PR TITLE
Velero解决非aws环境报错问题解决 & 去除dce没有用的kubectl配置

### DIFF
--- a/charts/velero/custom.sh
+++ b/charts/velero/custom.sh
@@ -26,7 +26,7 @@ if [ "$(uname)" == "Darwin" ];then
 
   sed  -i '' 's?{{ .Values.image.repository }}:{{ .Values.image.tag?{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag?' charts/velero/templates/node-agent-daemonset.yaml
 
-  sed  -i '' '228,235c \ \ \ \ \ \ initContainers:\n        - name: velero-plugin-for-csi\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginCSIRepository }}:{{ .Values.image.pluginCSITag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins\n        - name: velero-plugin-for-aws\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginAWSRepository }}:{{ .Values.image.pluginAWSTag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins' charts/velero/templates/deployment.yaml
+  sed  -i '' '228,235c \ \ \ \ \ \ initContainers:\n        - name: velero-plugin-for-aws\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginAWSRepository }}:{{ .Values.image.pluginAWSTag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins' charts/velero/templates/deployment.yaml
 
   sed  -i '' '18a apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: velero-fs-restore-action-config\n  namespace: {{ $.Release.Namespace }}\n  labels:\n    app.kubernetes.io/name: {{ include "velero.name" $ }}\n    app.kubernetes.io/instance: {{ $.Release.Name }}\n    app.kubernetes.io/managed-by: {{ $.Release.Service }}\n    helm.sh/chart: {{ include "velero.chart" $ }}\n    velero.io/plugin-config: ""\n    velero.io/pod-volume-restore: RestoreItemAction\ndata:\n  image: {{ .Values.image.registry }}/{{ .Values.image.restoreHelperRepository }}:{{ .Values.image.restoreHelperTag }}' charts/velero/templates/configmaps.yaml
 else
@@ -39,15 +39,16 @@ else
 
   sed  -i 's?{{ .Values.image.repository }}:{{ .Values.image.tag?{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag?' charts/velero/templates/node-agent-daemonset.yaml
 
-  sed  -i '228,235c \ \ \ \ \ \ initContainers:\n        - name: velero-plugin-for-csi\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginCSIRepository }}:{{ .Values.image.pluginCSITag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins\n        - name: velero-plugin-for-aws\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginAWSRepository }}:{{ .Values.image.pluginAWSTag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins' charts/velero/templates/deployment.yaml
+  sed  -i '228,235c \ \ \ \ \ \ initContainers:\n        - name: velero-plugin-for-aws\n          image: {{ .Values.image.registry }}/{{ .Values.image.pluginAWSRepository }}:{{ .Values.image.pluginAWSTag }}\n          imagePullPolicy: IfNotPresent\n          volumeMounts:\n            - mountPath: /target\n              name: plugins' charts/velero/templates/deployment.yaml
   sed  -i '18a apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: velero-fs-restore-action-config\n  namespace: {{ $.Release.Namespace }}\n  labels:\n    app.kubernetes.io/name: {{ include "velero.name" $ }}\n    app.kubernetes.io/instance: {{ $.Release.Name }}\n    app.kubernetes.io/managed-by: {{ $.Release.Service }}\n    helm.sh/chart: {{ include "velero.chart" $ }}\n    velero.io/plugin-config: ""\n    velero.io/pod-volume-restore: RestoreItemAction\ndata:\n  image: {{ .Values.image.registry }}/{{ .Values.image.restoreHelperRepository }}:{{ .Values.image.restoreHelperTag }}' charts/velero/templates/configmaps.yaml
 
 fi
 
-yq  -i '."velero"."image"+={"registry":"docker.io","repository":"velero/velero","pluginCSIRepository":"velero/velero-plugin-for-csi","pluginCSITag":"v0.4.0","pluginAWSRepository":"velero/velero-plugin-for-aws","pluginAWSTag":"v1.6.0","restoreHelperRepository":"velero/velero-restore-helper","restoreHelperTag":"v1.10.0"}' values.yaml
+yq  -i '."velero"."image"+={"registry":"docker.io","repository":"velero/velero","pluginAWSRepository":"velero/velero-plugin-for-aws","pluginAWSTag":"v1.6.0","restoreHelperRepository":"velero/velero-restore-helper","restoreHelperTag":"v1.10.0"}' values.yaml
 yq  -i '."velero"."kubectl"."image"+={"registry":"docker.io","repository":"bitnami/kubectl","tag":"1.21.0"}' values.yaml
 yq  -i '."velero"."deployNodeAgent"=true' values.yaml
 yq  -i '."velero"."upgradeCRDs"=false' values.yaml
+yq  -i '."velero"."snapshotsEnabled"=false' values.yaml
 yq  -i '."velero"."cleanUpCRDs"=false' values.yaml
 yq  -i '."velero"."configuration"."provider"="aws"' values.yaml
 
@@ -62,6 +63,7 @@ yq -i '
                                               aws_access_key_id = <modifiy>
                                               aws_secret_access_key = <modifiy>"
 ' values.yaml
+yq  -i 'del(."velero"."kubectl")' values.yaml
 
 yq -i '
    .annotations["addon.kpanda.io/namespace"]="velero"

--- a/charts/velero/parent/.relok8s-images.yaml
+++ b/charts/velero/parent/.relok8s-images.yaml
@@ -1,5 +1,3 @@
 - "{{ .velero.image.registry }}/{{ .velero.image.repository }}:{{ .velero.image.tag }}"
-- "{{ .velero.image.registry }}/{{ .velero.image.pluginCSIRepository }}:{{ .velero.image.pluginCSITag }}"
 - "{{ .velero.image.registry }}/{{ .velero.image.pluginAWSRepository }}:{{ .velero.image.pluginAWSTag }}"
 - "{{ .velero.image.registry }}/{{ .velero.image.restoreHelperRepository }}:{{ .velero.image.restoreHelperTag }}"
-- "{{ .velero.kubectl.image.registry }}/{{ .velero.kubectl.image.repository }}:{{ .velero.kubectl.image.tag }}"

--- a/charts/velero/velero/.relok8s-images.yaml
+++ b/charts/velero/velero/.relok8s-images.yaml
@@ -1,5 +1,3 @@
 - "{{ .velero.image.registry }}/{{ .velero.image.repository }}:{{ .velero.image.tag }}"
-- "{{ .velero.image.registry }}/{{ .velero.image.pluginCSIRepository }}:{{ .velero.image.pluginCSITag }}"
 - "{{ .velero.image.registry }}/{{ .velero.image.pluginAWSRepository }}:{{ .velero.image.pluginAWSTag }}"
 - "{{ .velero.image.registry }}/{{ .velero.image.restoreHelperRepository }}:{{ .velero.image.restoreHelperTag }}"
-- "{{ .velero.kubectl.image.registry }}/{{ .velero.kubectl.image.repository }}:{{ .velero.kubectl.image.tag }}"

--- a/charts/velero/velero/charts/velero/templates/deployment.yaml
+++ b/charts/velero/velero/charts/velero/templates/deployment.yaml
@@ -226,12 +226,6 @@ spec:
           {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       initContainers:
-        - name: velero-plugin-for-csi
-          image: {{ .Values.image.registry }}/{{ .Values.image.pluginCSIRepository }}:{{ .Values.image.pluginCSITag }}
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - mountPath: /target
-              name: plugins
         - name: velero-plugin-for-aws
           image: {{ .Values.image.registry }}/{{ .Values.image.pluginAWSRepository }}:{{ .Values.image.pluginAWSTag }}
           imagePullPolicy: IfNotPresent

--- a/charts/velero/velero/values.yaml
+++ b/charts/velero/velero/values.yaml
@@ -18,8 +18,6 @@ velero:
     # - registrySecretName
 
     registry: docker.m.daocloud.io
-    pluginCSIRepository: velero/velero-plugin-for-csi
-    pluginCSITag: v0.4.0
     pluginAWSRepository: velero/velero-plugin-for-aws
     pluginAWSTag: v1.6.0
     restoreHelperRepository: velero/velero-restore-helper
@@ -176,26 +174,6 @@ velero:
       #   for: 15m
       #   labels:
       #     severity: warning
-  kubectl:
-    image:
-      repository: bitnami/kubectl
-      # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
-      # If used, it will take precedence over the kubectl.image.tag.
-      # digest:
-      # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-      # tag: 1.16.15
-
-      registry: docker.m.daocloud.io
-      tag: 1.21.0
-    # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
-    # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    containerSecurityContext: {}
-    # Resource requests/limits to specify for the upgrade/cleanup job. Optional
-    resources: {}
-    # Annotations to set for the upgrade/cleanup job. Optional.
-    annotations: {}
-    # Labels to set for the upgrade/cleanup job. Optional.
-    labels: {}
   # This job upgrades the CRDs.
   upgradeCRDs: false
   # This job is meant primarily for cleaning up CRDs on CI systems.
@@ -238,18 +216,18 @@ velero:
         region: ""
         s3ForcePathStyle: true
         s3Url: ""
-      #  region:
-      #  s3ForcePathStyle:
-      #  s3Url:
-      #  kmsKeyId:
-      #  resourceGroup:
-      #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
-      #  subscriptionId:
-      #  storageAccount:
-      #  publicUrl:
-      #  Name of the GCP service account to use for this backup storage location. Specify the
-      #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
-      #  serviceAccount:
+        #  region:
+        #  s3ForcePathStyle:
+        #  s3Url:
+        #  kmsKeyId:
+        #  resourceGroup:
+        #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
+        #  subscriptionId:
+        #  storageAccount:
+        #  publicUrl:
+        #  Name of the GCP service account to use for this backup storage location. Specify the
+        #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+        #  serviceAccount:
     # Parameters for the `default` VolumeSnapshotLocation. See
     # https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
     volumeSnapshotLocation:
@@ -386,7 +364,7 @@ velero:
   # Whether to create backupstoragelocation crd, if false => do not create a default backup location
   backupsEnabled: true
   # Whether to create volumesnapshotlocation crd, if false => disable snapshot feature
-  snapshotsEnabled: true
+  snapshotsEnabled: false
   # Whether to deploy the node-agent daemonset.
   deployNodeAgent: true
   nodeAgent:


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

1. 非aws环境报错问题解决
2. 去除dce没有用的kubectl配置

以下是测试结果，已经可可以从MinIO拉取backup
<img width="595" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/81207605/ad2f80e2-1257-4dde-8091-d9a12ce8eeb7">

