### PR TITLE
otel demo version bump up to 1.1.1

### DIFF
--- a/charts/opentelemetry-demo-lite/config
+++ b/charts/opentelemetry-demo-lite/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://openinsight-proj.github.io/openinsight-helm-charts
 export REPO_NAME=open-insight
 export CHART_NAME=opentelemetry-demo-lite
-export VERSION=1.1.0
+export VERSION=1.1.1
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/Chart.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/Chart.yaml
@@ -12,8 +12,8 @@ name: opentelemetry-demo-lite
 sources:
   - https://github.com/openinsight-proj/openinsight-helm-charts
 type: application
-version: 1.1.0
+version: 1.1.1
 dependencies:
   - name: opentelemetry-demo-lite
-    version: "1.1.0"
+    version: "1.1.1"
     repository: "https://openinsight-proj.github.io/openinsight-helm-charts"

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/Chart.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/Chart.yaml
@@ -18,4 +18,4 @@ name: opentelemetry-demo-lite
 sources:
 - https://github.com/openinsight-proj/openinsight-helm-charts
 type: application
-version: 1.1.0
+version: 1.1.1

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/templates/adservice.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/templates/adservice.yaml
@@ -43,12 +43,18 @@ spec:
             {{- with .Values.extensions.adservice.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+            - name: NACOS_NAMESPACE_ID
+              value: {{ .Values.global.microservices.nacos.registryNamespace }}
+            - name: NACOS_GROUP_NAME
+              value: {{ .Values.global.microservices.nacos.registryServiceGroup }}
+            - name: SKOALA_REGISTRY
+              value: {{ .Values.global.microservices.nacos.registryName }}
             - name: JAVA_OPTS
               value: '{{ include "java.adservice.opt" . }}'
             - name: DATA_SERVICE_ADDR
               value: '{{ include "otel-demo.name" . }}-dataservice:8080'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: k8s.namespace.name=$(K8S_NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.pod.uid=$(OTEL_RESOURCE_ATTRIBUTES_POD_UID),skoala.registry={{ .Values.global.microservices.nacos.registryName }},nacos.namespaceid={{ .Values.global.microservices.nacos.registryNamespace }},nacos.groupname={{ .Values.global.microservices.nacos.registryServiceGroup }}
+              value: k8s.namespace.name=$(K8S_NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.pod.uid=$(OTEL_RESOURCE_ATTRIBUTES_POD_UID){{- if .Values.global.microservices.nacos.enabled }},skoala.registry=$(SKOALA_REGISTRY),nacos.namespaceid=$(NACOS_NAMESPACE_ID),nacos.groupname=$(NACOS_GROUP_NAME){{ end }}
           resources:
             requests:
               cpu: "0.2"

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.schema.json
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.schema.json
@@ -67,16 +67,16 @@
                                         "registryName": {
                                             "type": "string",
                                             "title": "Registry name",
-                                            "default": ""
+                                            "default": "nacos"
                                         },
                                         "registryAddr": {
                                             "type": "string",
-                                            "title": "Registry address",
-                                            "default": ""
+                                            "title": "Registry endpoint",
+                                            "default": "nacos:8848"
                                         },
                                         "registryNamespace": {
                                             "type": "string",
-                                            "title": "Registry mamespace",
+                                            "title": "Registry namespace",
                                             "default": "public"
                                         },
                                         "registryServiceGroup": {

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.yaml
@@ -14,11 +14,11 @@ global:
   microservices:
     nacos:
       enabled: false
-      registryName: $(SKOALA_REGISTRY)
-      registryAddr: ""
-      registryNamespace: $(NACOS_NAMESPACE_ID)
-      registryServiceGroup: $(NACOS_GROUP_NAME)
-      registryInstanceGroup: DEFAULT
+      registryName: "nacos"
+      registryAddr: "nacos:8848"
+      registryNamespace: "public"
+      registryServiceGroup: "DEFAULT_GROUP"
+      registryInstanceGroup: "DEFAULT"
       kubeMetadataClusterName: ""
       username: ""
       password: ""
@@ -178,12 +178,6 @@ extensions:
             fieldPath: metadata.uid
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://insight-agent-opentelemetry-collector.insight-system.svc.cluster.local:4317'
-      - name: NACOS_NAMESPACE_ID
-        value: public
-      - name: NACOS_GROUP_NAME
-        value: DEFAULT_GROUP
-      - name: SKOALA_REGISTRY
-        value: nacos-test
       - name: AD_SERVICE_PORT
         value: "8080"
     podAnnotations:

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.schema.json
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.schema.json
@@ -67,12 +67,12 @@
                                         "registryName": {
                                             "type": "string",
                                             "title": "Registry name",
-                                            "default": ""
+                                            "default": "nacos"
                                         },
                                         "registryAddr": {
                                             "type": "string",
-                                            "title": "Registry address",
-                                            "default": ""
+                                            "title": "Registry endpoint",
+                                            "default": "nacos:8848"
                                         },
                                         "registryNamespace": {
                                             "type": "string",

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.yaml
@@ -16,11 +16,11 @@ opentelemetry-demo-lite:
     microservices:
       nacos:
         enabled: false
-        registryName: $(SKOALA_REGISTRY)
-        registryAddr: ""
-        registryNamespace: $(NACOS_NAMESPACE_ID)
-        registryServiceGroup: $(NACOS_GROUP_NAME)
-        registryInstanceGroup: DEFAULT
+        registryName: "nacos"
+        registryAddr: "nacos:8848"
+        registryNamespace: "public"
+        registryServiceGroup: "DEFAULT_GROUP"
+        registryInstanceGroup: "DEFAULT"
         kubeMetadataClusterName: ""
         username: ""
         password: ""
@@ -180,12 +180,6 @@ opentelemetry-demo-lite:
               fieldPath: metadata.uid
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: 'http://insight-agent-opentelemetry-collector.insight-system.svc.cluster.local:4317'
-        - name: NACOS_NAMESPACE_ID
-          value: public
-        - name: NACOS_GROUP_NAME
-          value: DEFAULT_GROUP
-        - name: SKOALA_REGISTRY
-          value: nacos-test
         - name: AD_SERVICE_PORT
           value: "8080"
       podAnnotations:

--- a/charts/opentelemetry-demo-lite/parent/values.schema.json
+++ b/charts/opentelemetry-demo-lite/parent/values.schema.json
@@ -67,12 +67,12 @@
                                         "registryName": {
                                             "type": "string",
                                             "title": "Registry name",
-                                            "default": ""
+                                            "default": "nacos"
                                         },
                                         "registryAddr": {
                                             "type": "string",
-                                            "title": "Registry address",
-                                            "default": ""
+                                            "title": "Registry endpoint",
+                                            "default": "nacos:8848"
                                         },
                                         "registryNamespace": {
                                             "type": "string",

--- a/charts/opentelemetry-demo-lite/parent/values.yaml
+++ b/charts/opentelemetry-demo-lite/parent/values.yaml
@@ -16,11 +16,11 @@ opentelemetry-demo-lite:
     microservices:
       nacos:
         enabled: false
-        registryName: $(SKOALA_REGISTRY)
-        registryAddr: ""
-        registryNamespace: $(NACOS_NAMESPACE_ID)
-        registryServiceGroup: $(NACOS_GROUP_NAME)
-        registryInstanceGroup: DEFAULT
+        registryName: "nacos"
+        registryAddr: "nacos:8848"
+        registryNamespace: "public"
+        registryServiceGroup: "DEFAULT_GROUP"
+        registryInstanceGroup: "DEFAULT"
         kubeMetadataClusterName: ""
         username: ""
         password: ""
@@ -180,12 +180,6 @@ opentelemetry-demo-lite:
               fieldPath: metadata.uid
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: 'http://insight-agent-opentelemetry-collector.insight-system.svc.cluster.local:4317'
-        - name: NACOS_NAMESPACE_ID
-          value: public
-        - name: NACOS_GROUP_NAME
-          value: DEFAULT_GROUP
-        - name: SKOALA_REGISTRY
-          value: nacos-test
         - name: AD_SERVICE_PORT
           value: "8080"
       podAnnotations:


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #