### PR TITLE
f5 images

### DIFF
--- a/charts/f5networks/config
+++ b/charts/f5networks/config
@@ -14,3 +14,4 @@ export TEST_ASSIGNER=ty-dc
 
 export DAOCLOUD_REPO_PROJECT=addon
 
+export NO_TRIVY=true

--- a/charts/f5networks/f5networks/values.schema.json
+++ b/charts/f5networks/f5networks/values.schema.json
@@ -18,7 +18,7 @@
               "default": "",
               "title": "Registry",
               "examples": [
-                "docker.m.daocloud.io/f5networks"
+                "docker.m.daocloud.io"
               ]
             },
             "repo": {
@@ -26,7 +26,7 @@
               "default": "",
               "title": "repository",
               "examples": [
-                "k8s-bigip-ctlr"
+                "f5networks/k8s-bigip-ctlr"
               ]
             }
           }
@@ -153,13 +153,16 @@
               "default": "",
               "title": "Registry",
               "examples": [
-                "docker.m.daocloud.io/f5networks"
+                "docker.m.daocloud.io"
               ]
             },
             "repo": {
               "type": "string",
               "default": "",
-              "title": "repository"
+              "title": "repository",
+              "examples": [
+                "f5networks/f5-ipam-controller"
+              ]
             },
             "version": {
               "type": "string",

--- a/charts/f5networks/f5networks/values.yaml
+++ b/charts/f5networks/f5networks/values.yaml
@@ -32,8 +32,8 @@ f5-bigip-ctlr:
     node_label_selector: "node-role=f5nodeport"
 
   image:
-    user: docker.m.daocloud.io/f5networks
-    repo: k8s-bigip-ctlr
+    user: docker.m.daocloud.io
+    repo: f5networks/k8s-bigip-ctlr
     pullPolicy: IfNotPresent
 
   # k8s-bigip-ctlr version
@@ -57,8 +57,8 @@ f5-ipam-controller:
 
   image:
     # Use the tag to target a specific version of the Controller
-    user: 'docker.m.daocloud.io/f5networks'
-    repo: f5-ipam-controller
+    user: 'docker.m.daocloud.io'
+    repo: f5networks/f5-ipam-controller
     pullPolicy: IfNotPresent
     version: 0.1.8
 

--- a/charts/f5networks/parent/values.schema.json
+++ b/charts/f5networks/parent/values.schema.json
@@ -18,7 +18,7 @@
               "default": "",
               "title": "Registry",
               "examples": [
-                "docker.m.daocloud.io/f5networks"
+                "docker.m.daocloud.io"
               ]
             },
             "repo": {
@@ -26,7 +26,7 @@
               "default": "",
               "title": "repository",
               "examples": [
-                "k8s-bigip-ctlr"
+                "f5networks/k8s-bigip-ctlr"
               ]
             }
           }
@@ -153,13 +153,16 @@
               "default": "",
               "title": "Registry",
               "examples": [
-                "docker.m.daocloud.io/f5networks"
+                "docker.m.daocloud.io"
               ]
             },
             "repo": {
               "type": "string",
               "default": "",
-              "title": "repository"
+              "title": "repository",
+              "examples": [
+                "f5networks/f5-ipam-controller"
+              ]
             },
             "version": {
               "type": "string",

--- a/charts/f5networks/parent/values.yaml
+++ b/charts/f5networks/parent/values.yaml
@@ -32,8 +32,8 @@ f5-bigip-ctlr:
     node_label_selector: "node-role=f5nodeport"
 
   image:
-    user: docker.m.daocloud.io/f5networks
-    repo: k8s-bigip-ctlr
+    user: docker.m.daocloud.io
+    repo: f5networks/k8s-bigip-ctlr
     pullPolicy: IfNotPresent
 
   # k8s-bigip-ctlr version
@@ -57,8 +57,8 @@ f5-ipam-controller:
 
   image:
     # Use the tag to target a specific version of the Controller
-    user: 'docker.m.daocloud.io/f5networks'
-    repo: f5-ipam-controller
+    user: 'docker.m.daocloud.io'
+    repo: f5networks/f5-ipam-controller
     pullPolicy: IfNotPresent
     version: 0.1.8
 

--- a/charts/f5networks/update.sh
+++ b/charts/f5networks/update.sh
@@ -5,12 +5,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+IPAM_VERSION=0.0.4
+CTLR_VERISON=0.0.23
 
 CURRENT_DIR_PATH=$(cd $(dirname $0); pwd)
 
 cd $CURRENT_DIR_PATH
 
-rm -rf f5networks
+rm -rf f5networks || true
 mkdir -p f5networks/charts
 cp -rf parent/.  f5networks/
 
@@ -21,17 +23,18 @@ set -o nounset
 #================== set sub-charts
 
 cd f5networks/charts
-rm * -rf
+rm * -rf || true
 
 helm repo remove f5-ipam-stable || true
 helm repo add f5-ipam-stable https://f5networks.github.io/f5-ipam-controller/helm-charts/stable
-helm pull f5-ipam-stable/f5-ipam-controller --untar
+helm pull f5-ipam-stable/f5-ipam-controller --untar --version ${IPAM_VERSION}
 
 helm repo remove f5-stable || true
 helm repo add f5-stable https://f5networks.github.io/charts/stable
-helm pull f5-stable/f5-bigip-ctlr --untar
+helm pull f5-stable/f5-bigip-ctlr --untar --version ${CTLR_VERISON}
 
 # update
+pwd
 
 FILE="./f5-ipam-controller/templates/f5-ipam-controller-deploy.yaml"
 

--- a/scripts/generateChart.sh
+++ b/scripts/generateChart.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 if ! which helm &>/dev/null ; then
     echo "error, please install 'helm'"
     exit 1


### PR DESCRIPTION
修复每晚 CI  
<https://github.com/DaoCloud/dce-charts-repackage/actions/runs/5072952618>

![企业微信截图_155b5905-a4b2-4ce5-8c3c-10419ddaf26b](https://github.com/DaoCloud/dce-charts-repackage/assets/45163302/58705eb3-f4d8-4470-8a5a-64a53039a721)

F5 报错 

![企业微信截图_e71c7f31-4523-4617-9ea9-8c9206cf9dfa](https://github.com/DaoCloud/dce-charts-repackage/assets/45163302/7131821e-5191-49fd-8a48-04335b5401e2)

而看一个正常的 image 应该是 
![企业微信截图_51e021ef-0cef-4ad8-90ee-ce97d09dea64](https://github.com/DaoCloud/dce-charts-repackage/assets/45163302/cfda7b3d-8963-4010-ac45-e264552aa574)

所以，应该是 yaml 中的 repository 和 repo 的 格式问题 

<img width="825" alt="企业微信截图_a350aebb-d768-4c2a-9f00-1943bca01510" src="https://github.com/DaoCloud/dce-charts-repackage/assets/45163302/ece42940-03ab-45de-871d-3ff4326a9fd6">
<img width="455" alt="企业微信截图_7ab8eb5c-819f-43a8-b5bc-257b4f57488e" src="https://github.com/DaoCloud/dce-charts-repackage/assets/45163302/90c1d0aa-028b-42c6-8db0-2195e9d673b7">




