### PR TITLE
fix github ci: image templete

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          
+
       - name: check change
         id: check_change
         run: |
@@ -163,9 +163,10 @@ jobs:
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do
               source ${BASE}/charts/${PROJECT}/config && [ "${NO_IMAGE}" == "true" ] && continue
               CHART_PATH=${BASE}/charts/${PROJECT}/${PROJECT}
-              if helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3 | grep -v "daocloud" &>/dev/null ; then
+              # istio template compatibility, need `grep -v " image: {{"`, related issue: https://github.com/DaoCloud/dce-charts-repackage/pull/1094
+              if helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3 | grep -v " image: {{ " | grep -v "daocloud" &>/dev/null ; then
                   echo "error, ${PROJECT} image is not in daocloud repo"
-                  helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3 | grep -v "daocloud"
+                  helm template test ${CHART_PATH} | grep ' image: ' | cut -d ":" -f2,3 | grep -v " image: {{ " | grep -v "daocloud"
                   exit 1
               fi
           done
@@ -210,7 +211,7 @@ jobs:
               (( $? == 0 )) || { echo "error, failed to check chart trivy" && exit 1 ; }
               echo "chart trivy check: pass charts/${PROJECT}/${PROJECT} "
           done
-          
+
       - name: check upgrade
         run: |
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
修复 CI 扫描镜像无法兼容  Istio 存在 image template 格式
<img width="1031" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/44200120/f6b313ba-0a4c-4c79-911d-5919aab2d380">

https://github.com/DaoCloud/dce-charts-repackage/actions/runs/5089017256/jobs/9146138306?pr=1087

应该忽略  helm template 后包含的 `image: {{ XX }}`  