### PR TITLE
Make snapshot enable back by default, no idea why NiuLechuan disable it before

### DIFF
--- a/charts/velero/custom.sh
+++ b/charts/velero/custom.sh
@@ -57,7 +57,7 @@ sed -i 's/toYaml .Values.initContainers/tpl (toYaml .Values.initContainers) ./' 
 
 yq  -i '.velero.deployNodeAgent=true' values.yaml
 yq  -i '.velero.upgradeCRDs=false' values.yaml
-yq  -i '.velero.snapshotsEnabled=false' values.yaml
+#yq  -i '.velero.snapshotsEnabled=true' values.yaml # was set false by NiuLechuan in commit e8a28ef99f548b16905cd7051262ee93aa51a716.No idea why, so restore it back
 yq  -i '.velero.cleanUpCRDs=false' values.yaml
 #yq  -i '."velero"."configuration"."provider"="aws"' values.yaml the configuration.provider is deprecated
 yq  -i '.velero.configuration.volumeSnapshotLocation[0].provider="aws"' values.yaml

--- a/charts/velero/velero/values.yaml
+++ b/charts/velero/velero/values.yaml
@@ -383,7 +383,7 @@ velero:
   # Whether to create backupstoragelocation crd, if false => do not create a default backup location
   backupsEnabled: true
   # Whether to create volumesnapshotlocation crd, if false => disable snapshot feature
-  snapshotsEnabled: false
+  snapshotsEnabled: true
   # Whether to deploy the node-agent daemonset.
   deployNodeAgent: true
   nodeAgent:


### PR DESCRIPTION
请review仅关注第一个commit


不清楚为什么牛老师之前关闭了它

从git日志看不到解释

如果默认关闭的话，就不会创建`volumeSnapshotLocation`的CRD，也不会去启动snapshot的能力

