### PR TITLE
Robot Upgrade: node-problem-detector chart upgrade from 2.3.1 to 2.3.5

### DIFF
--- a/charts/node-problem-detector/config
+++ b/charts/node-problem-detector/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://charts.deliveryhero.io
 export REPO_NAME=node-problem-detector
 export CHART_NAME=node-problem-detector
-export VERSION=2.3.1
+export VERSION=2.3.5
 # pr, issue, none
 export UPGRADE_METHOD=pr
 

--- a/charts/node-problem-detector/node-problem-detector/Chart.yaml
+++ b/charts/node-problem-detector/node-problem-detector/Chart.yaml
@@ -1,25 +1,22 @@
 apiVersion: v1
-appVersion: v0.8.12
-description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector)
-  daemonset. This tool aims to make various node problems visible to the upstream
-  layers in cluster management stack. It is a daemon which runs on each node, detects
-  node problems and reports them to apiserver. '
+appVersion: v0.8.13
+description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver. '
 home: https://github.com/kubernetes/node-problem-detector
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 keywords:
-- node
-- problem
-- detector
-- monitoring
+  - node
+  - problem
+  - detector
+  - monitoring
 maintainers:
-- email: no-reply@deliveryhero.com
-  name: max-rocket-internet
+  - email: no-reply@deliveryhero.com
+    name: max-rocket-internet
 name: node-problem-detector
 sources:
-- https://github.com/kubernetes/node-problem-detector
-- https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-version: 2.3.1
+  - https://github.com/kubernetes/node-problem-detector
+  - https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+version: 2.3.5
 dependencies:
   - name: node-problem-detector
-    version: "2.3.1"
+    version: "2.3.5"
     repository: "https://charts.deliveryhero.io"

--- a/charts/node-problem-detector/node-problem-detector/README.md
+++ b/charts/node-problem-detector/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.3.5](https://img.shields.io/badge/Version-2.3.5-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -56,9 +56,10 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
 | hostPID | bool | `false` |  |
+| image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.12"` |  |
+| image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.13"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/Chart.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.8.12
+appVersion: v0.8.13
 description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector)
   daemonset. This tool aims to make various node problems visible to the upstream
   layers in cluster management stack. It is a daemon which runs on each node, detects
@@ -18,4 +18,4 @@ name: node-problem-detector
 sources:
 - https://github.com/kubernetes/node-problem-detector
 - https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-version: 2.3.1
+version: 2.3.5

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/README.md
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.3.5](https://img.shields.io/badge/Version-2.3.5-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -56,9 +56,10 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
 | hostPID | bool | `false` |  |
+| image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.12"` |  |
+| image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.13"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/daemonset.yaml
@@ -50,7 +50,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.image.digest }}
+          image:  "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image:  "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" | quote }}
           command:
             - "/bin/sh"
@@ -112,6 +116,7 @@ spec:
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}
+            defaultMode: 493
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/values.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/values.yaml
@@ -55,8 +55,10 @@ logDir:
   pod: ""
 
 image:
-  repository: k8s.gcr.io/node-problem-detector/node-problem-detector
-  tag: v0.8.12
+  repository: registry.k8s.io/node-problem-detector/node-problem-detector
+  tag: v0.8.13
+  # image.digest -- the image digest. If given it takes precedence over a given tag.
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
I am robot, upgrade: project node-problem-detector chart upgrade from 2.3.1 to 2.3.5