### PR TITLE
metrics-server add required install annotation

### DIFF
--- a/charts/metrics-server/custom.sh
+++ b/charts/metrics-server/custom.sh
@@ -28,3 +28,17 @@ REPLACE_BY_DEFINE(){
 }
 
 REPLACE_BY_DEFINE  "metrics-server.image"   '{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}'  '{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}'
+
+
+# add required annotation
+yq -i '
+   .annotations["addon.kpanda.io/required"]="true"
+' Chart.yaml
+# use daocloud registry && set resources limit
+yq -i '
+  .metrics-server.image.registry = "k8s-gcr.m.daocloud.io" |
+  .metrics-server.resources.limits.cpu="500m" |
+  .metrics-server.resources.limits.memory="512Mi" |
+  .metrics-server.resources.requests.cpu="20m" |
+  .metrics-server.resources.requests.memory="150Mi"
+' values.yaml

--- a/charts/metrics-server/metrics-server/Chart.yaml
+++ b/charts/metrics-server/metrics-server/Chart.yaml
@@ -14,26 +14,26 @@ annotations:
       description: "Added support for common labels."
     - kind: changed
       description: "Updated Metrics Server image to v0.6.2."
+  addon.kpanda.io/required: "true"
 apiVersion: v2
 appVersion: 0.6.2
-description: Metrics Server is a scalable, efficient source of container resource
-  metrics for Kubernetes built-in autoscaling pipelines.
+description: Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
 home: https://github.com/kubernetes-sigs/metrics-server
 icon: https://avatars.githubusercontent.com/u/36015203?s=400&v=4
 keywords:
-- kubernetes
-- metrics-server
-- metrics
+  - kubernetes
+  - metrics-server
+  - metrics
 maintainers:
-- name: stevehipwell
-  url: https://github.com/stevehipwell
-- name: krmichel
-  url: https://github.com/krmichel
-- name: endrec
-  url: https://github.com/endrec
+  - name: stevehipwell
+    url: https://github.com/stevehipwell
+  - name: krmichel
+    url: https://github.com/krmichel
+  - name: endrec
+    url: https://github.com/endrec
 name: metrics-server
 sources:
-- https://github.com/kubernetes-sigs/metrics-server
+  - https://github.com/kubernetes-sigs/metrics-server
 type: application
 version: 3.8.3
 dependencies:

--- a/charts/metrics-server/metrics-server/values.yaml
+++ b/charts/metrics-server/metrics-server/values.yaml
@@ -3,20 +3,17 @@ metrics-server:
   # Default values for metrics-server.
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
-
   image:
-    registry: k8s.gcr.io
+    registry: k8s-gcr.m.daocloud.io
     repository: metrics-server/metrics-server
     # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
     tag: "v0.6.2"
     pullPolicy: IfNotPresent
-
   imagePullSecrets: []
   # - name: registrySecretName
 
   nameOverride: ""
   fullnameOverride: ""
-
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -28,12 +25,10 @@ metrics-server:
     # The list of secrets mountable by this service account.
     # See https://kubernetes.io/docs/reference/labels-annotations-taints/#enforce-mountable-secrets
     secrets: []
-
   rbac:
     # Specifies whether RBAC resources should be created
     create: true
     pspEnabled: false
-
   apiService:
     # Specifies if the v1beta1.metrics.k8s.io API service should be created.
     #
@@ -47,23 +42,17 @@ metrics-server:
     insecureSkipTLSVerify: true
     # The PEM encoded CA bundle for TLS verification
     caBundle: ""
-
   commonLabels: {}
   podLabels: {}
   podAnnotations: {}
-
   podSecurityContext: {}
-
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
-
   priorityClassName: system-cluster-critical
-
   containerPort: 4443
-
   hostNetwork:
     # Specifies if metrics-server should be started in hostNetwork mode.
     #
@@ -71,9 +60,7 @@ metrics-server:
     # API server unable to communicate with metrics-server. As an example, this is required
     # if you use Weave network on EKS
     enabled: false
-
   replicas: 1
-
   updateStrategy: {}
   #   type: RollingUpdate
   #   rollingUpdate:
@@ -85,16 +72,13 @@ metrics-server:
     enabled: false
     minAvailable:
     maxUnavailable:
-
   defaultArgs:
     - --cert-dir=/tmp
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
     - --kubelet-use-node-status-port
     - --metric-resolution=15s
     - --kubelet-insecure-tls
-
   args: []
-
   livenessProbe:
     httpGet:
       path: /livez
@@ -103,7 +87,6 @@ metrics-server:
     initialDelaySeconds: 0
     periodSeconds: 10
     failureThreshold: 3
-
   readinessProbe:
     httpGet:
       path: /readyz
@@ -112,7 +95,6 @@ metrics-server:
     initialDelaySeconds: 20
     periodSeconds: 10
     failureThreshold: 3
-
   service:
     type: ClusterIP
     port: 443
@@ -121,10 +103,8 @@ metrics-server:
     #  Add these labels to have metrics-server show up in `kubectl cluster-info`
     #  kubernetes.io/cluster-service: "true"
     #  kubernetes.io/name: "Metrics-server"
-
   metrics:
     enabled: false
-
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -132,23 +112,20 @@ metrics-server:
     scrapeTimeout: 10s
     metricRelabelings: []
     relabelings: []
-
   # See https://github.com/kubernetes-sigs/metrics-server#scaling
-  resources: {}
-
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 20m
+      memory: 150Mi
   extraVolumeMounts: []
-
   extraVolumes: []
-
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
-
   topologySpreadConstraints: []
-
   # Annotations to add to the deployment
   deploymentAnnotations: {}
-
   schedulerName: ""


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
创建集群
metrics-server添加创建集群必装的annotation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #