### PR TITLE
bump multus-underlay to 0.2.4

### DIFF
--- a/charts/multus-underlay/config
+++ b/charts/multus-underlay/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/cni-plugins
 export REPO_NAME=meta-plugins
 export CHART_NAME=meta-plugins
-export VERSION=0.2.3
+export VERSION=0.2.4
 
 # pr, issue, none
 export UPGRADE_METHOD=issue

--- a/charts/multus-underlay/multus-underlay/Chart.yaml
+++ b/charts/multus-underlay/multus-underlay/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
-appVersion: 0.2.3
+appVersion: 0.2.4
 description: Multi-underlay enables attaching multiple network interfaces to pods in Kubernetes.
 name: multus-underlay
 sources:
   - https://github.com/spidernet-io/cni-plugins
 type: application
-version: 0.2.3
+version: 0.2.4
 dependencies:
   - name: meta-plugins
-    version: "0.2.3"
+    version: "0.2.4"
     repository: "https://spidernet-io.github.io/cni-plugins"
   - name: multus
     repository: file://charts/multus

--- a/charts/multus-underlay/multus-underlay/README.md
+++ b/charts/multus-underlay/multus-underlay/README.md
@@ -1,6 +1,6 @@
 # multus-underlay
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.4](https://img.shields.io/badge/AppVersion-0.2.4-informational?style=flat-square)
 
 Multi-underlay enables attaching multiple network interfaces to pods in Kubernetes.
 
@@ -14,7 +14,7 @@ Multi-underlay enables attaching multiple network interfaces to pods in Kubernet
 |------------|------|---------|
 | file://charts/multus | multus | v3.9 |
 | file://charts/sriov | sriov | 0.1.2 |
-| https://spidernet-io.github.io/cni-plugins | meta-plugins | 0.2.3 |
+| https://spidernet-io.github.io/cni-plugins | meta-plugins | 0.2.4 |
 
 ## Values
 
@@ -38,7 +38,7 @@ Multi-underlay enables attaching multiple network interfaces to pods in Kubernet
 | macvlan.vlanID | int | `0` |  |
 | meta-plugins.image.registry | string | `"ghcr.m.daocloud.io"` |  |
 | meta-plugins.image.repository | string | `"spidernet-io/cni-plugins/meta-plugins"` |  |
-| meta-plugins.image.tag | string | `"v0.2.3"` |  |
+| meta-plugins.image.tag | string | `"v0.2.4"` |  |
 | multus.config.cni_conf.binDir | string | `"/opt/cni/bin"` |  |
 | multus.config.cni_conf.capabilities.bandwidth | bool | `true` |  |
 | multus.config.cni_conf.capabilities.portMappings | bool | `true` |  |

--- a/charts/multus-underlay/multus-underlay/charts/meta-plugins/Chart.yaml
+++ b/charts/multus-underlay/multus-underlay/charts/meta-plugins/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.2.3
+appVersion: 0.2.4
 description: meta-plugins works with macvlan cni to solve some communication problems
   when macvlan is used as CNI.
 maintainers:
@@ -8,4 +8,4 @@ name: meta-plugins
 sources:
 - https://github.com/spidernet-io/cni-plugins
 type: application
-version: 0.2.3
+version: 0.2.4

--- a/charts/multus-underlay/multus-underlay/charts/meta-plugins/README.md
+++ b/charts/multus-underlay/multus-underlay/charts/meta-plugins/README.md
@@ -1,6 +1,6 @@
 # meta-plugins
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.4](https://img.shields.io/badge/AppVersion-0.2.4-informational?style=flat-square)
 
 meta-plugins works with macvlan cni to solve some communication problems when macvlan is used as CNI.
 

--- a/charts/multus-underlay/multus-underlay/templates/net-atta-def.yaml
+++ b/charts/multus-underlay/multus-underlay/templates/net-atta-def.yaml
@@ -35,10 +35,10 @@ metadata:
 {{- end }}
   annotations:
     {{- include "multus-underlay.helm-hook-annotations" . | nindent 4 }}
-    v1.multus-underlay-cni.io/instance-type: "macvlan_standalone"
+    v1.multus-underlay-cni.io/instance-type: "macvlan_underlay"
     v1.multus-underlay-cni.io/default-cni: "true"
     v1.multus-underlay-cni.io/underlay-cni: "true"
-    v1.multus-underlay-cni.io/coexist-types: '["macvlan_standalone"]'
+    v1.multus-underlay-cni.io/coexist-types: '["macvlan_underlay"]'
     v1.multus-underlay-cni.io/vlanId: {{ .Values.macvlan.vlanID | quote }}
 spec:
   config: |-
@@ -144,9 +144,9 @@ metadata:
 {{- end }}
   annotations:
     {{- include "multus-underlay.helm-hook-annotations" . | nindent 4 }}
-    v1.multus-underlay-cni.io/instance-type: "sriov_standalone"
+    v1.multus-underlay-cni.io/instance-type: "sriov_underlay"
     v1.multus-underlay-cni.io/default-cni: "true"
-    v1.multus-underlay-cni.io/other-cni: '["sriov_standalone"]'
+    v1.multus-underlay-cni.io/other-cni: '["sriov_underlay"]'
     v1.multus-underlay-cni.io/vlanId: {{ .Values.sriov.sriov_crd.vlanId | quote }}
     k8s.v1.cni.cncf.io/resourceName: "{{ .Values.sriov.config.sriov_device_plugin.resourcePrefix }}/{{ .Values.sriov.config.sriov_device_plugin.name }}"
 spec:

--- a/charts/multus-underlay/multus-underlay/values.yaml
+++ b/charts/multus-underlay/multus-underlay/values.yaml
@@ -138,4 +138,4 @@ meta-plugins:
   image:
     registry: ghcr.m.daocloud.io
     repository: spidernet-io/cni-plugins/meta-plugins
-    tag: v0.2.3
+    tag: v0.2.4

--- a/charts/multus-underlay/parent/templates/net-atta-def.yaml
+++ b/charts/multus-underlay/parent/templates/net-atta-def.yaml
@@ -35,10 +35,10 @@ metadata:
 {{- end }}
   annotations:
     {{- include "multus-underlay.helm-hook-annotations" . | nindent 4 }}
-    v1.multus-underlay-cni.io/instance-type: "macvlan_standalone"
+    v1.multus-underlay-cni.io/instance-type: "macvlan_underlay"
     v1.multus-underlay-cni.io/default-cni: "true"
     v1.multus-underlay-cni.io/underlay-cni: "true"
-    v1.multus-underlay-cni.io/coexist-types: '["macvlan_standalone"]'
+    v1.multus-underlay-cni.io/coexist-types: '["macvlan_underlay"]'
     v1.multus-underlay-cni.io/vlanId: {{ .Values.macvlan.vlanID | quote }}
 spec:
   config: |-
@@ -144,9 +144,9 @@ metadata:
 {{- end }}
   annotations:
     {{- include "multus-underlay.helm-hook-annotations" . | nindent 4 }}
-    v1.multus-underlay-cni.io/instance-type: "sriov_standalone"
+    v1.multus-underlay-cni.io/instance-type: "sriov_underlay"
     v1.multus-underlay-cni.io/default-cni: "true"
-    v1.multus-underlay-cni.io/other-cni: '["sriov_standalone"]'
+    v1.multus-underlay-cni.io/other-cni: '["sriov_underlay"]'
     v1.multus-underlay-cni.io/vlanId: {{ .Values.sriov.sriov_crd.vlanId | quote }}
     k8s.v1.cni.cncf.io/resourceName: "{{ .Values.sriov.config.sriov_device_plugin.resourcePrefix }}/{{ .Values.sriov.config.sriov_device_plugin.name }}"
 spec:


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

bump multus-underlay to 0.2.4

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #