### PR TITLE
fix nvidia-vgpu set kubeScheduler.imageTag

### DIFF
--- a/charts/nvidia-vgpu/custom-sub.sh
+++ b/charts/nvidia-vgpu/custom-sub.sh
@@ -47,6 +47,13 @@ elif [ $os == "Linux" ];then
            " charts/vgpu/values.yaml
 fi
 
+# set scheduler imageTag v1.20.0 to "v1.24.0"
+if [ $os == "Darwin" ];then
+        sed -i "" "s/imageTag: \"v1.20.0\"/imageTag: \"v1.24.0\"/g" charts/vgpu/values.yaml
+elif [ $os == "Linux" ];then
+        sed -i "s/imageTag: \"v1.20.0\"/imageTag: \"v1.24.0\"/g" charts/vgpu/values.yaml
+fi
+
 # sed scheduler.extender.image
 line=$(sed -n -e '/ image: "4pdosc\/k8s-vdevice"/=' charts/vgpu/values.yaml  | head -n 1)
 if [ $os == "Darwin" ];then

--- a/charts/nvidia-vgpu/custom.sh
+++ b/charts/nvidia-vgpu/custom.sh
@@ -53,6 +53,13 @@ elif [ $os == "Linux" ];then
     sed -i "s/image: {{ .Values.scheduler.kubeScheduler.image }}:{{ .Values.scheduler.kubeScheduler.imageTag }}/image: \"{{ .Values.scheduler.kubeScheduler.registry }}\/{{ .Values.scheduler.kubeScheduler.repository }}:{{ .Values.scheduler.kubeScheduler.imageTag }}\"/" charts/vgpu/templates/scheduler/deployment.yaml
 fi
 
+# set scheduler imageTag v1.20.0 to "v1.24.0"
+if [ $os == "Darwin" ];then
+        sed -i "" "s/imageTag: \"v1.20.0\"/imageTag: \"v1.24.0\"/g" values.yaml
+elif [ $os == "Linux" ];then
+        sed -i "s/imageTag: \"v1.20.0\"/imageTag: \"v1.24.0\"/g" values.yaml
+fi
+
 # sed scheduler.extender.image
 line=$(sed -n -e '/ image: "4pdosc\/k8s-vdevice"/=' values.yaml  | head -n 1)
 if [ $os == "Darwin" ];then

--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/values.yaml
@@ -28,7 +28,7 @@ scheduler:
   defaultMem: 0
   defaultCores: 0
   kubeScheduler:
-    imageTag: "v1.20.0"
+    imageTag: "v1.24.0"
     registry: k8s-gcr.m.daocloud.io
     repository: kube-scheduler
     imagePullPolicy: IfNotPresent

--- a/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
@@ -30,7 +30,7 @@ vgpu:
     defaultMem: 0
     defaultCores: 0
     kubeScheduler:
-      imageTag: "v1.20.0"
+      imageTag: "v1.24.0"
       registry: k8s-gcr.m.daocloud.io
       repository: kubernetes/kube-scheduler
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

fix nvidia-vgpu set kubeScheduler.imageTag. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #