### PR TITLE
upgrade metrics server version to 3.8.4

### DIFF
--- a/charts/metrics-server/config
+++ b/charts/metrics-server/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://kubernetes-sigs.github.io/metrics-server
 export REPO_NAME=metrics-server
 export CHART_NAME=metrics-server
-export VERSION=3.8.3
+export VERSION=3.8.4
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/metrics-server/metrics-server/Chart.yaml
+++ b/charts/metrics-server/metrics-server/Chart.yaml
@@ -1,19 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added support for topologySpreadConstraints."
-    - kind: added
-      description: "Set resource namespaces explicitly."
-    - kind: added
-      description: "Allow configuring TLS on the APIService."
-    - kind: added
-      description: "Enabled service monitor relabelling."
-    - kind: added
-      description: "Added ability to set the scheduler name."
-    - kind: added
-      description: "Added support for common labels."
     - kind: changed
-      description: "Updated Metrics Server image to v0.6.2."
+      description: "Changed the image registry location to registry.k8s.io."
   addon.kpanda.io/required: "true"
 apiVersion: v2
 appVersion: 0.6.2
@@ -35,8 +23,8 @@ name: metrics-server
 sources:
   - https://github.com/kubernetes-sigs/metrics-server
 type: application
-version: 3.8.3
+version: 3.8.4
 dependencies:
   - name: metrics-server
-    version: "3.8.3"
+    version: "3.8.4"
     repository: "https://kubernetes-sigs.github.io/metrics-server"

--- a/charts/metrics-server/metrics-server/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/metrics-server/charts/metrics-server/Chart.yaml
@@ -1,19 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added support for topologySpreadConstraints."
-    - kind: added
-      description: "Set resource namespaces explicitly."
-    - kind: added
-      description: "Allow configuring TLS on the APIService."
-    - kind: added
-      description: "Enabled service monitor relabelling."
-    - kind: added
-      description: "Added ability to set the scheduler name."
-    - kind: added
-      description: "Added support for common labels."
     - kind: changed
-      description: "Updated Metrics Server image to v0.6.2."
+      description: "Changed the image registry location to registry.k8s.io."
 apiVersion: v2
 appVersion: 0.6.2
 description: Metrics Server is a scalable, efficient source of container resource
@@ -35,4 +23,4 @@ name: metrics-server
 sources:
 - https://github.com/kubernetes-sigs/metrics-server
 type: application
-version: 3.8.3
+version: 3.8.4

--- a/charts/metrics-server/metrics-server/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/metrics-server/charts/metrics-server/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: k8s.gcr.io/metrics-server/metrics-server
+  repository: registry.k8s.io/metrics-server/metrics-server
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
创建集群内置metrics-server，原理是在chart中添加required Anntation
但是kpanda默认list addon拉取的是最新的chart包
metrics-server最新为3.8.4，之前打包的是3.8.3所以annotiaton没生效，所以这里将版本升级至最新

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #