### PR TITLE
Fix VPA Release Name

### DIFF
--- a/charts/vpa/custom.sh
+++ b/charts/vpa/custom.sh
@@ -90,7 +90,7 @@ yq -i '
 
 yq -i '
    .annotations["addon.kpanda.io/namespace"]="kube-system" |
-   .annotations["addon.kpanda.io/name"]="vpa"
+   .annotations["addon.kpanda.io/release-name"]="vpa"
 ' Chart.yaml
 
 if ! grep "keywords:" Chart.yaml &>/dev/null ; then

--- a/charts/vpa/vpa/Chart.yaml
+++ b/charts/vpa/vpa/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://charts.fairwinds.com/stable"
 annotations:
   addon.kpanda.io/namespace: kube-system
-  addon.kpanda.io/name: vpa
+  addon.kpanda.io/release-name: vpa
 keywords:
   - vpa
   - autoscale


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

We want to fix vpa release name to vpa by the right addon annotation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #