### PR TITLE
multus-underlay: add default additional_hijack_subnet for nodelocaldns

### DIFF
--- a/charts/multus-underlay/multus-underlay/README.md
+++ b/charts/multus-underlay/multus-underlay/README.md
@@ -27,7 +27,7 @@ Multi-underlay enables attaching multiple network interfaces to pods in Kubernet
 | cluster_subnet.service_subnet.ipv6 | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
-| macvlan.custom_route | list | `[]` |  |
+| macvlan.custom_route[0] | string | `"169.254.25.10/32"` |  |
 | macvlan.enable | bool | `true` |  |
 | macvlan.master | string | `"ens192"` |  |
 | macvlan.migrate_route | int | `-1` |  |
@@ -102,7 +102,7 @@ Multi-underlay enables attaching multiple network interfaces to pods in Kubernet
 | sriov.pod.resources.sriov_cni.requests.cpu | string | `"100m"` |  |
 | sriov.pod.resources.sriov_cni.requests.memory | string | `"50Mi"` |  |
 | sriov.serviceAccount.name | string | `"sriov-device-plugin-test"` |  |
-| sriov.sriov_crd.custom_route | list | `[]` |  |
+| sriov.sriov_crd.custom_route[0] | string | `"169.254.25.10/32"` |  |
 | sriov.sriov_crd.migrate_route | int | `-1` |  |
 | sriov.sriov_crd.name | string | `"sriov-overlay-vlan0"` |  |
 | sriov.sriov_crd.overlayInterface | string | `"eth0"` |  |

--- a/charts/multus-underlay/multus-underlay/values.schema.json
+++ b/charts/multus-underlay/multus-underlay/values.schema.json
@@ -107,6 +107,17 @@
                     "default": "ens192",
                     "description": "Notice: The master interface must exist on the host"
                 },
+                "custom_route": {
+                    "type": "array",
+                    "title": "additional_hijack_routes",
+                    "description": "special subnet routing table that need to be hijacked to node forwarding, such as nodelocaldns",
+                    "items": {
+                        "type": "string",
+                        "default": [
+                            "169.254.25.10/32"
+                        ]
+                    }
+                },
                 "vlanID": {
                     "type": "integer",
                     "title": "Vlan ID",
@@ -188,6 +199,17 @@
                         "name": {
                             "type": "string",
                             "title": "SRIOV CR Name"
+                        },
+                        "custom_route": {
+                            "type": "array",
+                            "title": "additional_hijack_routes",
+                            "description": "special subnet routing table that need to be hijacked to node forwarding, such as nodelocaldns",
+                            "items": {
+                                "type": "string",
+                                "default": [
+                                    "169.254.25.10/32"
+                                ]
+                            }
                         },
                         "vlanId": {
                             "type": "integer",

--- a/charts/multus-underlay/multus-underlay/values.yaml
+++ b/charts/multus-underlay/multus-underlay/values.yaml
@@ -71,7 +71,7 @@ macvlan:
   vlanID: 0
   migrate_route: -1
   overlayInterface: eth0
-  custom_route: []
+  custom_route: ["169.254.25.10/32"]
   skip_call: false
 sriov:
   images:
@@ -125,7 +125,7 @@ sriov:
     name: sriov-overlay-vlan0
     vlanId: 0
     overlayInterface: eth0
-    custom_route: []
+    custom_route: ["169.254.25.10/32"]
     skip_call: false
     migrate_route: -1
   manifests:

--- a/charts/multus-underlay/parent/values.schema.json
+++ b/charts/multus-underlay/parent/values.schema.json
@@ -107,6 +107,17 @@
                     "default": "ens192",
                     "description": "Notice: The master interface must exist on the host"
                 },
+                "custom_route": {
+                    "type": "array",
+                    "title": "additional_hijack_routes",
+                    "description": "special subnet routing table that need to be hijacked to node forwarding, such as nodelocaldns",
+                    "items": {
+                        "type": "string",
+                        "default": [
+                            "169.254.25.10/32"
+                        ]
+                    }
+                },
                 "vlanID": {
                     "type": "integer",
                     "title": "Vlan ID",
@@ -188,6 +199,17 @@
                         "name": {
                             "type": "string",
                             "title": "SRIOV CR Name"
+                        },
+                        "custom_route": {
+                            "type": "array",
+                            "title": "additional_hijack_routes",
+                            "description": "special subnet routing table that need to be hijacked to node forwarding, such as nodelocaldns",
+                            "items": {
+                                "type": "string",
+                                "default": [
+                                    "169.254.25.10/32"
+                                ]
+                            }
                         },
                         "vlanId": {
                             "type": "integer",

--- a/charts/multus-underlay/parent/values.yaml
+++ b/charts/multus-underlay/parent/values.yaml
@@ -77,7 +77,7 @@ macvlan:
   vlanID: 0
   migrate_route: -1
   overlayInterface: eth0
-  custom_route: []
+  custom_route: ["169.254.25.10/32"]
   skip_call: false
 
 sriov:
@@ -137,7 +137,7 @@ sriov:
     name: sriov-overlay-vlan0
     vlanId: 0
     overlayInterface: eth0
-    custom_route: []
+    custom_route: ["169.254.25.10/32"]
     skip_call: false
     migrate_route: -1
 


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

multus-underlay: add default additional_hijack_subnet for nodelocaldns

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #