### PR TITLE
sriov-network-operator: update ib-sriov-cni image version

### DIFF
--- a/charts/sriov-network-operator/custom.sh
+++ b/charts/sriov-network-operator/custom.sh
@@ -56,7 +56,7 @@ yq -i '
    .images.sriovCni.repository="k8snetworkplumbingwg/sriov-cni" |
    .images.sriovCni.tag="v2.7.0" |
    .images.ibSriovCni.repository="k8snetworkplumbingwg/ib-sriov-cni" |
-   .images.ibSriovCni.tag="v1.0.3" |
+   .images.ibSriovCni.tag="v1.0.2" |
    .images.sriovDevicePlugin.repository="k8snetworkplumbingwg/sriov-network-device-plugin" |
    .images.sriovDevicePlugin.tag="v3.5.1" |
    .images.resourcesInjector.repository="k8snetworkplumbingwg/network-resources-injector" |

--- a/charts/sriov-network-operator/sriov-network-operator/values.yaml
+++ b/charts/sriov-network-operator/sriov-network-operator/values.yaml
@@ -42,7 +42,7 @@ images:
     tag: v2.7.0
   ibSriovCni:
     repository: k8snetworkplumbingwg/ib-sriov-cni
-    tag: v1.0.3
+    tag: v1.0.2
   sriovDevicePlugin:
     repository: k8snetworkplumbingwg/sriov-network-device-plugin
     tag: v3.5.1


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

ib-sriov-cni:v1.0.3 don't have arm64 image. update it to v1.0.2

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #