### PR TITLE
upgrade argo-rollouts to v2.32.0

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/.relok8s-images.yaml
+++ b/charts/argo-rollouts/argo-rollouts/.relok8s-images.yaml
@@ -1,2 +1,3 @@
+- "{{ .argo-rollouts.global.imageRegistry }}/{{ .argo-rollouts.global.repository }}:{{ .argo-rollouts.global.tag }}"
 - "{{ .argo-rollouts.controller.image.registry }}/{{ .argo-rollouts.controller.image.repository }}:{{ .argo-rollouts.controller.image.tag }}"
 - "{{ .argo-rollouts.dashboard.image.registry }}/{{ .argo-rollouts.dashboard.image.repository }}:{{ .argo-rollouts.dashboard.image.tag }}"

--- a/charts/argo-rollouts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/Chart.yaml
@@ -1,11 +1,12 @@
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts to v.1.4.1
-    - kind: added
-      description: Put Changelog URL on README.md
+      description: Upgrade Argo Rollouts to v1.6.0
+  artifacthub.io/signKey: |
+    fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
+    url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.4.1
+appVersion: v1.6.0
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -18,8 +19,8 @@ maintainers:
 name: argo-rollouts
 sources:
   - https://github.com/argoproj/argo-rollouts
-version: 2.22.3
+version: 2.32.0
 dependencies:
   - name: argo-rollouts
-    version: "2.22.3"
+    version: "2.32.0"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-rollouts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/README.md
@@ -49,6 +49,7 @@ For full list of changes please check ArtifactHub [changelog].
 | createClusterAggregateRoles | bool | `true` | flag to enable creation of cluster aggregate roles (requires cluster RBAC) |
 | extraObjects | list | `[]` | Additional manifests to deploy within the chart. A list of objects. |
 | fullnameOverride | string | `nil` | String to fully override "argo-rollouts.fullname" template |
+| global.deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | installCRDs | bool | `true` | Install and upgrade CRDs |
 | keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
@@ -75,7 +76,10 @@ For full list of changes please check ArtifactHub [changelog].
 | containerSecurityContext | object | `{}` | Security Context to set on container level |
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
+| controller.containerPorts.healthz | int | `8080` | Healthz container port |
+| controller.containerPorts.metrics | int | `8090` | Metrics container port |
 | controller.createClusterRole | bool | `true` | flag to enable creation of cluster controller role (requires cluster RBAC) |
+| controller.deploymentAnnotations | object | `{}` | Annotations to be added to the controller deployment |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-controller.  A list of flags. |
 | controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |
 | controller.extraEnv | list | `[]` | Additional environment variables for rollouts-controller. A list of name/value maps. |
@@ -85,23 +89,34 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | controller.initContainers | list | `[]` | Init containers to add to the rollouts controller pod |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
+| controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
+| controller.metrics.service.annotations | object | `{}` | Service annotations |
+| controller.metrics.service.port | int | `8090` | Metrics service port |
+| controller.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | controller.metrics.serviceMonitor.additionalAnnotations | object | `{}` | Annotations to be added to the ServiceMonitor |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Labels to be added to the ServiceMonitor |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
+| controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
+| controller.metrics.serviceMonitor.namespace | string | `""` | Namespace to be used for the ServiceMonitor |
+| controller.metrics.serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
 | controller.nodeSelector | object | `{}` | [Node selector] |
 | controller.pdb.annotations | object | `{}` | Annotations to be added to controller [Pod Disruption Budget] |
 | controller.pdb.enabled | bool | `false` | Deploy a [Pod Disruption Budget] for the controller |
 | controller.pdb.labels | object | `{}` | Labels to be added to controller [Pod Disruption Budget] |
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the controller |
-| podAnnotations | object | `{}` | Annotations to be added to the Rollout pods |
+| controller.trafficRouterPlugins | object | `{}` | Configures 3rd party traffic router plugins for controller |
+| controller.volumeMounts | list | `[]` | Additional volumeMounts to add to the controller container |
+| controller.volumes | list | `[]` | Additional volumes to add to the controller pod |
+| podAnnotations | object | `{}` | Annotations for the all deployed pods |
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
@@ -117,6 +132,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.component | string | `"rollouts-dashboard"` | Value of label `app.kubernetes.io/component` |
 | dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
+| dashboard.deploymentAnnotations | object | `{}` | Annotations to be added to the dashboard deployment |
 | dashboard.enabled | bool | `false` | Deploy dashboard server |
 | dashboard.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-dashboard. A list of flags. |
 | dashboard.extraEnv | list | `[]` | Additional environment variables for rollouts-dashboard. A list of name/value maps. |
@@ -139,6 +155,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.labels | object | `{}` | Labels to be added to dashboard [Pod Disruption Budget] |
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |
@@ -159,6 +176,8 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | dashboard.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | dashboard.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the dashboard server |
+| dashboard.volumeMounts | list | `[]` | Additional volumeMounts to add to the dashboard container |
+| dashboard.volumes | list | `[]` | Additional volumes to add to the dashboard pod |
 
 ## Upgrading
 

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
@@ -1,11 +1,12 @@
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts to v.1.4.1
-    - kind: added
-      description: Put Changelog URL on README.md
+      description: Upgrade Argo Rollouts to v1.6.0
+  artifacthub.io/signKey: |
+    fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
+    url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.4.1
+appVersion: v1.6.0
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -18,4 +19,4 @@ maintainers:
 name: argo-rollouts
 sources:
 - https://github.com/argoproj/argo-rollouts
-version: 2.22.3
+version: 2.32.0

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
@@ -49,6 +49,7 @@ For full list of changes please check ArtifactHub [changelog].
 | createClusterAggregateRoles | bool | `true` | flag to enable creation of cluster aggregate roles (requires cluster RBAC) |
 | extraObjects | list | `[]` | Additional manifests to deploy within the chart. A list of objects. |
 | fullnameOverride | string | `nil` | String to fully override "argo-rollouts.fullname" template |
+| global.deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | installCRDs | bool | `true` | Install and upgrade CRDs |
 | keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
@@ -75,7 +76,10 @@ For full list of changes please check ArtifactHub [changelog].
 | containerSecurityContext | object | `{}` | Security Context to set on container level |
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
+| controller.containerPorts.healthz | int | `8080` | Healthz container port |
+| controller.containerPorts.metrics | int | `8090` | Metrics container port |
 | controller.createClusterRole | bool | `true` | flag to enable creation of cluster controller role (requires cluster RBAC) |
+| controller.deploymentAnnotations | object | `{}` | Annotations to be added to the controller deployment |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-controller.  A list of flags. |
 | controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |
 | controller.extraEnv | list | `[]` | Additional environment variables for rollouts-controller. A list of name/value maps. |
@@ -85,23 +89,34 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | controller.initContainers | list | `[]` | Init containers to add to the rollouts controller pod |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
+| controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
+| controller.metrics.service.annotations | object | `{}` | Service annotations |
+| controller.metrics.service.port | int | `8090` | Metrics service port |
+| controller.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | controller.metrics.serviceMonitor.additionalAnnotations | object | `{}` | Annotations to be added to the ServiceMonitor |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Labels to be added to the ServiceMonitor |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
+| controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
+| controller.metrics.serviceMonitor.namespace | string | `""` | Namespace to be used for the ServiceMonitor |
+| controller.metrics.serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
 | controller.nodeSelector | object | `{}` | [Node selector] |
 | controller.pdb.annotations | object | `{}` | Annotations to be added to controller [Pod Disruption Budget] |
 | controller.pdb.enabled | bool | `false` | Deploy a [Pod Disruption Budget] for the controller |
 | controller.pdb.labels | object | `{}` | Labels to be added to controller [Pod Disruption Budget] |
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the controller |
-| podAnnotations | object | `{}` | Annotations to be added to the Rollout pods |
+| controller.trafficRouterPlugins | object | `{}` | Configures 3rd party traffic router plugins for controller |
+| controller.volumeMounts | list | `[]` | Additional volumeMounts to add to the controller container |
+| controller.volumes | list | `[]` | Additional volumes to add to the controller pod |
+| podAnnotations | object | `{}` | Annotations for the all deployed pods |
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
@@ -117,6 +132,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.component | string | `"rollouts-dashboard"` | Value of label `app.kubernetes.io/component` |
 | dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
+| dashboard.deploymentAnnotations | object | `{}` | Annotations to be added to the dashboard deployment |
 | dashboard.enabled | bool | `false` | Deploy dashboard server |
 | dashboard.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-dashboard. A list of flags. |
 | dashboard.extraEnv | list | `[]` | Additional environment variables for rollouts-dashboard. A list of name/value maps. |
@@ -139,6 +155,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.labels | object | `{}` | Labels to be added to dashboard [Pod Disruption Budget] |
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |
@@ -159,6 +176,8 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | dashboard.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | dashboard.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the dashboard server |
+| dashboard.volumeMounts | list | `[]` | Additional volumeMounts to add to the dashboard container |
+| dashboard.volumes | list | `[]` | Additional volumes to add to the dashboard pod |
 
 ## Upgrading
 

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/_helpers.tpl
@@ -109,3 +109,31 @@ Return the appropriate apiVersion for pod disruption budget
 {{- print "policy/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "global.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+    {{- if and .global.repository (eq $repositoryName "") }}
+     {{- $repositoryName = .global.repository -}}
+    {{- end -}}
+    {{- if and .global.tag (eq $tag "")}}
+     {{- $tag = .global.tag -}}
+    {{- end -}}
+{{- end -}}
+{{- if .tag }}
+    {{- if .tag.imageTag }}
+     {{- $tag = .tag.imageTag -}}
+    {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
@@ -135,6 +135,7 @@ rules:
   - get
   - list
   - watch
+  - update
   - patch
 # job access needed for analysis template job metrics
 - apiGroups:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrolebinding.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "argo-rollouts.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/configmap.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/configmap.yaml
@@ -1,15 +1,15 @@
-{{ if .Values.notifications.secret.create }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: argo-rollouts-notification-secret
+  name: argo-rollouts-config
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  {{- with .Values.notifications.secret.items }}
+data:
+  {{- with .Values.controller.metricProviderPlugins }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
-{{- end }}
+  {{- with .Values.controller.trafficRouterPlugins }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -1,7 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.controller.deploymentAnnotations) }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   name: {{ include "argo-rollouts.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
@@ -15,9 +22,11 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.controller.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
@@ -32,8 +41,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}
       containers:
-      - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
+      - image: {{ include "global.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global ) }}
         args:
+        - --healthzPort={{ .Values.controller.containerPorts.healthz }}
+        - --metricsport={{ .Values.controller.containerPorts.metrics }}
         {{- if not .Values.clusterInstall }}
         - --namespaced
         {{- end }}
@@ -50,9 +61,9 @@ spec:
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         name: argo-rollouts
         ports:
-        - containerPort: 8090
+        - containerPort: {{ .Values.controller.containerPorts.metrics }}
           name: metrics
-        - containerPort: 8080
+        - containerPort: {{ .Values.controller.containerPorts.healthz }}
           name: healthz
         livenessProbe:
           {{- toYaml .Values.controller.livenessProbe | nindent 10 }}
@@ -62,6 +73,10 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
+        {{- with .Values.controller.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.controller.extraContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -97,4 +112,8 @@ spec:
       {{- end }}
       {{- with .Values.controller.priorityClassName }}
       priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.volumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/metrics-service.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/metrics-service.yaml
@@ -3,19 +3,23 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "argo-rollouts.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
-  {{- with .Values.serviceAnnotations }}
   annotations:
+  {{- with .Values.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.metrics.service.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ports:
-  - name: metrics
+  - name: {{ .Values.controller.metrics.service.portName }}
     protocol: TCP
-    port: 8090
-    targetPort: 8090
+    port: {{ .Values.controller.metrics.service.port }}
+    targetPort: metrics
   selector:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.selectorLabels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argo-rollouts-notification-configmap
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/poddisruptionbudget.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "argo-rollouts.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-rollouts.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-rollouts.labels" . | nindent 4 }}
   {{- with .Values.controller.pdb.labels }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/role.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "argo-rollouts.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
@@ -135,6 +136,7 @@ rules:
   - get
   - list
   - watch
+  - update
   - patch
 # job access needed for analysis template job metrics
 - apiGroups:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/rolebinding.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "argo-rollouts.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
@@ -13,4 +14,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "argo-rollouts.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/serviceaccount.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "argo-rollouts.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/servicemonitor.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argo-rollouts.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.controller.metrics.serviceMonitor.namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
@@ -15,7 +16,15 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: metrics
+  - port: {{ .Values.controller.metrics.service.portName }}
+    {{- with .Values.controller.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.controller.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.1
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -188,6 +188,8 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            apiVersion:
+                              type: string
                             interval:
                               type: string
                             query:
@@ -240,6 +242,51 @@ spec:
                                 parallelism:
                                   format: int32
                                   type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        - onPodConditions
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -263,6 +310,7 @@ spec:
                                         type: string
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 suspend:
                                   type: boolean
                                 template:
@@ -325,6 +373,7 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       weight:
                                                         format: int32
                                                         type: integer
@@ -371,10 +420,12 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       type: array
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             podAffinity:
                                               properties:
@@ -406,6 +457,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -429,6 +481,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -472,6 +525,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -495,6 +549,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -536,6 +591,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -559,6 +615,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -602,6 +659,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -625,6 +683,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -670,6 +729,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -679,6 +739,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -694,6 +755,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -705,6 +767,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -720,6 +783,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -729,6 +793,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1269,6 +1334,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1278,6 +1344,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1293,6 +1360,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1304,6 +1372,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1319,6 +1388,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1328,6 +1398,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1832,6 +1903,8 @@ spec:
                                           type: boolean
                                         hostPID:
                                           type: boolean
+                                        hostUsers:
+                                          type: boolean
                                         hostname:
                                           type: string
                                         imagePullSecrets:
@@ -1840,6 +1913,7 @@ spec:
                                               name:
                                                 type: string
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                         initContainers:
                                           items:
@@ -1872,6 +1946,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1881,6 +1956,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1896,6 +1972,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1907,6 +1984,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1922,6 +2000,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1931,6 +2010,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -2579,12 +2659,22 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               maxSkew:
                                                 format: int32
                                                 type: integer
                                               minDomains:
                                                 format: int32
                                                 type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
                                               topologyKey:
                                                 type: string
                                               whenUnsatisfiable:
@@ -2710,9 +2800,50 @@ spec:
                           required:
                           - query
                           type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         prometheus:
                           properties:
                             address:
+                              type: string
+                            authentication:
+                              properties:
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
                               type: string
                             query:
                               type: string

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.1
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -184,6 +184,8 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            apiVersion:
+                              type: string
                             interval:
                               type: string
                             query:
@@ -236,6 +238,51 @@ spec:
                                 parallelism:
                                   format: int32
                                   type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        - onPodConditions
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -259,6 +306,7 @@ spec:
                                         type: string
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 suspend:
                                   type: boolean
                                 template:
@@ -321,6 +369,7 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       weight:
                                                         format: int32
                                                         type: integer
@@ -367,10 +416,12 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       type: array
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             podAffinity:
                                               properties:
@@ -402,6 +453,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -425,6 +477,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -468,6 +521,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -491,6 +545,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -532,6 +587,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -555,6 +611,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -598,6 +655,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -621,6 +679,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -666,6 +725,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -675,6 +735,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -690,6 +751,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -701,6 +763,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -716,6 +779,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -725,6 +789,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1265,6 +1330,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1274,6 +1340,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1289,6 +1356,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1300,6 +1368,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1315,6 +1384,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1324,6 +1394,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1828,6 +1899,8 @@ spec:
                                           type: boolean
                                         hostPID:
                                           type: boolean
+                                        hostUsers:
+                                          type: boolean
                                         hostname:
                                           type: string
                                         imagePullSecrets:
@@ -1836,6 +1909,7 @@ spec:
                                               name:
                                                 type: string
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                         initContainers:
                                           items:
@@ -1868,6 +1942,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1877,6 +1952,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1892,6 +1968,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1903,6 +1980,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1918,6 +1996,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1927,6 +2006,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -2575,12 +2655,22 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               maxSkew:
                                                 format: int32
                                                 type: integer
                                               minDomains:
                                                 format: int32
                                                 type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
                                               topologyKey:
                                                 type: string
                                               whenUnsatisfiable:
@@ -2706,9 +2796,50 @@ spec:
                           required:
                           - query
                           type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         prometheus:
                           properties:
                             address:
+                              type: string
+                            authentication:
+                              properties:
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
                               type: string
                             query:
                               type: string

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.1
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -184,6 +184,8 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            apiVersion:
+                              type: string
                             interval:
                               type: string
                             query:
@@ -236,6 +238,51 @@ spec:
                                 parallelism:
                                   format: int32
                                   type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        - onPodConditions
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -259,6 +306,7 @@ spec:
                                         type: string
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 suspend:
                                   type: boolean
                                 template:
@@ -321,6 +369,7 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       weight:
                                                         format: int32
                                                         type: integer
@@ -367,10 +416,12 @@ spec:
                                                               type: object
                                                             type: array
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       type: array
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             podAffinity:
                                               properties:
@@ -402,6 +453,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -425,6 +477,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -468,6 +521,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -491,6 +545,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -532,6 +587,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -555,6 +611,7 @@ spec:
                                                                   type: string
                                                                 type: object
                                                             type: object
+                                                            x-kubernetes-map-type: atomic
                                                           namespaces:
                                                             items:
                                                               type: string
@@ -598,6 +655,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -621,6 +679,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -666,6 +725,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -675,6 +735,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -690,6 +751,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -701,6 +763,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -716,6 +779,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -725,6 +789,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1265,6 +1330,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1274,6 +1340,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1289,6 +1356,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1300,6 +1368,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1315,6 +1384,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1324,6 +1394,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -1828,6 +1899,8 @@ spec:
                                           type: boolean
                                         hostPID:
                                           type: boolean
+                                        hostUsers:
+                                          type: boolean
                                         hostname:
                                           type: string
                                         imagePullSecrets:
@@ -1836,6 +1909,7 @@ spec:
                                               name:
                                                 type: string
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                         initContainers:
                                           items:
@@ -1868,6 +1942,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         fieldRef:
                                                           properties:
                                                             apiVersion:
@@ -1877,6 +1952,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
                                                           properties:
                                                             containerName:
@@ -1892,6 +1968,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         secretKeyRef:
                                                           properties:
                                                             key:
@@ -1903,6 +1980,7 @@ spec:
                                                           required:
                                                           - key
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       type: object
                                                   required:
                                                   - name
@@ -1918,6 +1996,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     prefix:
                                                       type: string
                                                     secretRef:
@@ -1927,6 +2006,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
                                               image:
@@ -2575,12 +2655,22 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               maxSkew:
                                                 format: int32
                                                 type: integer
                                               minDomains:
                                                 format: int32
                                                 type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
                                               topologyKey:
                                                 type: string
                                               whenUnsatisfiable:
@@ -2706,9 +2796,50 @@ spec:
                           required:
                           - query
                           type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         prometheus:
                           properties:
                             address:
+                              type: string
+                            authentication:
+                              properties:
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
                               type: string
                             query:
                               type: string

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.1
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -158,7 +158,11 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     service:
+                      properties:
+                        name:
+                          type: string
                       type: object
                     template:
                       properties:
@@ -220,6 +224,7 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           weight:
                                             format: int32
                                             type: integer
@@ -266,10 +271,12 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   properties:
@@ -301,6 +308,7 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 properties:
                                                   matchExpressions:
@@ -324,6 +332,7 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 items:
                                                   type: string
@@ -367,6 +376,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -390,6 +400,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -431,6 +442,7 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 properties:
                                                   matchExpressions:
@@ -454,6 +466,7 @@ spec:
                                                       type: string
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 items:
                                                   type: string
@@ -497,6 +510,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -520,6 +534,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             items:
                                               type: string
@@ -565,6 +580,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               properties:
                                                 apiVersion:
@@ -574,6 +590,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -589,6 +606,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               properties:
                                                 key:
@@ -600,6 +618,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -615,6 +634,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           type: string
                                         secretRef:
@@ -624,6 +644,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -1164,6 +1185,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               properties:
                                                 apiVersion:
@@ -1173,6 +1195,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -1188,6 +1211,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               properties:
                                                 key:
@@ -1199,6 +1223,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -1214,6 +1239,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           type: string
                                         secretRef:
@@ -1223,6 +1249,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -1727,6 +1754,8 @@ spec:
                               type: boolean
                             hostPID:
                               type: boolean
+                            hostUsers:
+                              type: boolean
                             hostname:
                               type: string
                             imagePullSecrets:
@@ -1735,6 +1764,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
                               items:
@@ -1767,6 +1797,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               properties:
                                                 apiVersion:
@@ -1776,6 +1807,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -1791,6 +1823,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               properties:
                                                 key:
@@ -1802,6 +1835,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -1817,6 +1851,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           type: string
                                         secretRef:
@@ -1826,6 +1861,7 @@ spec:
                                             optional:
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -2474,12 +2510,22 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   maxSkew:
                                     format: int32
                                     type: integer
                                   minDomains:
                                     format: int32
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.1
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -118,6 +118,7 @@ spec:
                       type: string
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               strategy:
                 properties:
                   blueGreen:
@@ -163,6 +164,17 @@ spec:
                         x-kubernetes-int-or-string: true
                       postPromotionAnalysis:
                         properties:
+                          analysisRunMetadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
                           args:
                             items:
                               properties:
@@ -220,6 +232,17 @@ spec:
                         type: object
                       prePromotionAnalysis:
                         properties:
+                          analysisRunMetadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
                           args:
                             items:
                               properties:
@@ -307,6 +330,17 @@ spec:
                         type: integer
                       analysis:
                         properties:
+                          analysisRunMetadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
                           args:
                             items:
                               properties:
@@ -440,6 +474,17 @@ spec:
                           properties:
                             analysis:
                               properties:
+                                analysisRunMetadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
                                 args:
                                   items:
                                     properties:
@@ -580,6 +625,12 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
+                                      service:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
                                       specRef:
                                         type: string
                                       weight:
@@ -693,6 +744,10 @@ spec:
                                 type: string
                               ingress:
                                 type: string
+                              ingresses:
+                                items:
+                                  type: string
+                                type: array
                               rootService:
                                 type: string
                               servicePort:
@@ -710,7 +765,6 @@ spec:
                                 - enabled
                                 type: object
                             required:
-                            - ingress
                             - servicePort
                             type: object
                           ambassador:
@@ -869,9 +923,14 @@ spec:
                                 type: string
                               stableIngress:
                                 type: string
-                            required:
-                            - stableIngress
+                              stableIngresses:
+                                items:
+                                  type: string
+                                type: array
                             type: object
+                          plugins:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           smi:
                             properties:
                               rootService:
@@ -949,6 +1008,7 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       format: int32
                                       type: integer
@@ -995,10 +1055,12 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     type: array
                                 required:
                                 - nodeSelectorTerms
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
                             properties:
@@ -1030,6 +1092,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -1053,6 +1116,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -1096,6 +1160,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -1119,6 +1184,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -1160,6 +1226,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -1183,6 +1250,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -1226,6 +1294,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -1249,6 +1318,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -1294,6 +1364,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -1303,6 +1374,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1318,6 +1390,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -1329,6 +1402,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -1344,6 +1418,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -1353,6 +1428,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -1893,6 +1969,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -1902,6 +1979,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1917,6 +1995,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -1928,6 +2007,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -1943,6 +2023,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -1952,6 +2033,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -2456,6 +2538,8 @@ spec:
                         type: boolean
                       hostPID:
                         type: boolean
+                      hostUsers:
+                        type: boolean
                       hostname:
                         type: string
                       imagePullSecrets:
@@ -2464,6 +2548,7 @@ spec:
                             name:
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
                         items:
@@ -2496,6 +2581,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -2505,6 +2591,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -2520,6 +2607,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -2531,6 +2619,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -2546,6 +2635,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -2555,6 +2645,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -3203,12 +3294,22 @@ spec:
                                     type: string
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             maxSkew:
                               format: int32
                               type: integer
                             minDomains:
                               format: int32
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:
@@ -3257,15 +3358,21 @@ spec:
                     properties:
                       arn:
                         type: string
+                      fullName:
+                        type: string
                       name:
                         type: string
                     required:
                     - arn
                     - name
                     type: object
+                  ingress:
+                    type: string
                   loadBalancer:
                     properties:
                       arn:
+                        type: string
+                      fullName:
                         type: string
                       name:
                         type: string
@@ -3277,6 +3384,8 @@ spec:
                     properties:
                       arn:
                         type: string
+                      fullName:
+                        type: string
                       name:
                         type: string
                     required:
@@ -3284,6 +3393,49 @@ spec:
                     - name
                     type: object
                 type: object
+              albs:
+                items:
+                  properties:
+                    canaryTargetGroup:
+                      properties:
+                        arn:
+                          type: string
+                        fullName:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - arn
+                      - name
+                      type: object
+                    ingress:
+                      type: string
+                    loadBalancer:
+                      properties:
+                        arn:
+                          type: string
+                        fullName:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - arn
+                      - name
+                      type: object
+                    stableTargetGroup:
+                      properties:
+                        arn:
+                          type: string
+                        fullName:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - arn
+                      - name
+                      type: object
+                  type: object
+                type: array
               availableReplicas:
                 format: int32
                 type: integer

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/clusterrole.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/clusterrole.yaml
@@ -71,4 +71,18 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/clusterrolebinding.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/clusterrolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -2,7 +2,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.dashboard.deploymentAnnotations) }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   name: {{ include "argo-rollouts.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.dashboard.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
@@ -16,9 +23,11 @@ spec:
   replicas: {{ .Values.dashboard.replicas }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.dashboard.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
@@ -33,7 +42,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
       containers:
-      - image: "{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ default .Chart.AppVersion .Values.dashboard.image.tag }}"
+      - image: {{ include "global.images.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global ) }}
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
         args:
         {{- with .Values.dashboard.extraArgs }}
@@ -51,6 +60,10 @@ spec:
           {{- toYaml .Values.dashboard.containerSecurityContext | nindent 10 }}
         resources:
           {{- toYaml .Values.dashboard.resources | nindent 10 }}
+        {{- with .Values.dashboard.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.dashboard.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.dashboard.nodeSelector | nindent 8 }}
@@ -79,5 +92,9 @@ spec:
       {{- end }}
       {{- with .Values.dashboard.priorityClassName }}
       priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.dashboard.volumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/ingress.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
 {{- end }}
   name: {{ template "argo-rollouts.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-rollouts.labels" . | nindent 4 }}
     {{- if .Values.dashboard.ingress.labels }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/poddisruptionbudget.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "argo-rollouts.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-rollouts.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-rollouts.labels" . | nindent 4 }}
   {{- with .Values.dashboard.pdb.labels }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/service.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "argo-rollouts.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.dashboard.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/serviceaccount.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: {{ .Values.dashboard.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/extra-manifests.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/extra-manifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
@@ -38,9 +38,17 @@ extraObjects: []
   #     api-key: <datadog-api-key>
   #     app-key: <datadog-app-key>
 
+global:
+  # -- Annotations for all deployed Deployments
+  deploymentAnnotations: {}
+
 controller:
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-controller
+  # -- Annotations to be added to the controller deployment
+  deploymentAnnotations: {}
+  # -- Annotations to be added to application controller pods
+  podAnnotations: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
@@ -104,16 +112,36 @@ controller:
   # -- flag to enable creation of cluster controller role (requires cluster RBAC)
   createClusterRole: true
 
+  # Controller container ports
+  containerPorts:
+    # -- Metrics container port
+    metrics: 8090
+    # -- Healthz container port
+    healthz: 8080
+
   metrics:
     # -- Deploy metrics service
     enabled: false
+    service:
+      # -- Metrics service port name
+      portName: metrics
+      # -- Metrics service port
+      port: 8090
+      # -- Service annotations
+      annotations: {}
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Namespace to be used for the ServiceMonitor
+      namespace: ""
       # -- Labels to be added to the ServiceMonitor
       additionalLabels: {}
       # -- Annotations to be added to the ServiceMonitor
       additionalAnnotations: {}
+      # -- RelabelConfigs to apply to samples before scraping
+      relabelings: []
+      # -- MetricRelabelConfigs to apply to samples before ingestion
+      metricRelabelings: []
 
   # -- Configure liveness [probe] for the controller
   # @default -- See [values.yaml]
@@ -152,6 +180,31 @@ controller:
     # -- Maximum number / percentage of pods that may be made unavailable
     maxUnavailable: # 0
 
+  # -- Additional volumes to add to the controller pod
+  volumes: []
+    # - configMap:
+    #     name: my-certs-cm
+    #   name: my-certs
+
+  # -- Additional volumeMounts to add to the controller container
+  volumeMounts: []
+    # - mountPath: /etc/ssl/certs
+    #   name: my-certs
+
+  # -- Configures 3rd party metric providers for controller
+  ## Ref: https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
+  metricProviderPlugins: {}
+    # metricProviderPlugins: |-
+    #   - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
+    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+
+  # -- Configures 3rd party traffic router plugins for controller
+  ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
+  trafficRouterPlugins: {}
+    # trafficRouterPlugins: |-
+    #   - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
+    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -164,7 +217,7 @@ serviceAccount:
 # -- Annotations to be added to all CRDs
 crdAnnotations: {}
 
-# -- Annotations to be added to the Rollout pods
+# -- Annotations for the all deployed pods
 podAnnotations: {}
 
 # -- Security Context to set on pod level
@@ -217,6 +270,10 @@ dashboard:
   readonly: false
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-dashboard
+  # -- Annotations to be added to the dashboard deployment
+  deploymentAnnotations: {}
+  # -- Annotations to be added to application dashboard pods
+  podAnnotations: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
@@ -350,6 +407,12 @@ dashboard:
       # - secretName: argorollouts-example-tls
       #   hosts:
       #     - argorollouts.example.com
+
+  # -- Additional volumes to add to the dashboard pod
+  volumes: []
+
+  # -- Additional volumeMounts to add to the dashboard container
+  volumeMounts: []
 
 notifications:
   secret:

--- a/charts/argo-rollouts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/values.yaml
@@ -33,9 +33,19 @@ argo-rollouts:
   #     api-key: <datadog-api-key>
   #     app-key: <datadog-app-key>
 
+  global:
+    # -- Annotations for all deployed Deployments
+    deploymentAnnotations: {}
+    imageRegistry: quay.m.daocloud.io
+    repository: argoproj/argo-rollouts
+    tag: v1.6.0
   controller:
     # -- Value of label `app.kubernetes.io/component`
     component: rollouts-controller
+    # -- Annotations to be added to the controller deployment
+    deploymentAnnotations: {}
+    # -- Annotations to be added to application controller pods
+    podAnnotations: {}
     # -- [Node selector]
     nodeSelector: {}
     # -- [Tolerations] for use with node taints
@@ -60,7 +70,7 @@ argo-rollouts:
       # -- Repository to use
       repository: argoproj/argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "master"
+      tag: "v1.6.0"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-controller.  A list of flags.
@@ -94,16 +104,35 @@ argo-rollouts:
 
     # -- flag to enable creation of cluster controller role (requires cluster RBAC)
     createClusterRole: true
+    # Controller container ports
+    containerPorts:
+      # -- Metrics container port
+      metrics: 8090
+      # -- Healthz container port
+      healthz: 8080
     metrics:
       # -- Deploy metrics service
       enabled: false
+      service:
+        # -- Metrics service port name
+        portName: metrics
+        # -- Metrics service port
+        port: 8090
+        # -- Service annotations
+        annotations: {}
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
         enabled: false
+        # -- Namespace to be used for the ServiceMonitor
+        namespace: ""
         # -- Labels to be added to the ServiceMonitor
         additionalLabels: {}
         # -- Annotations to be added to the ServiceMonitor
         additionalAnnotations: {}
+        # -- RelabelConfigs to apply to samples before scraping
+        relabelings: []
+        # -- MetricRelabelConfigs to apply to samples before ingestion
+        metricRelabelings: []
     # -- Configure liveness [probe] for the controller
     # @default -- See [values.yaml]
     livenessProbe:
@@ -138,6 +167,30 @@ argo-rollouts:
       minAvailable: # 1
       # -- Maximum number / percentage of pods that may be made unavailable
       maxUnavailable: # 0
+    # -- Additional volumes to add to the controller pod
+    volumes: []
+    # - configMap:
+    #     name: my-certs-cm
+    #   name: my-certs
+
+    # -- Additional volumeMounts to add to the controller container
+    volumeMounts: []
+    # - mountPath: /etc/ssl/certs
+    #   name: my-certs
+
+    # -- Configures 3rd party metric providers for controller
+    ## Ref: https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
+    metricProviderPlugins: {}
+    # metricProviderPlugins: |-
+    #   - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
+    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+
+    # -- Configures 3rd party traffic router plugins for controller
+    ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
+    trafficRouterPlugins: {}
+    # trafficRouterPlugins: |-
+    #   - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
+    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
   serviceAccount:
     # -- Specifies whether a service account should be created
     create: true
@@ -148,7 +201,7 @@ argo-rollouts:
     name: ""
   # -- Annotations to be added to all CRDs
   crdAnnotations: {}
-  # -- Annotations to be added to the Rollout pods
+  # -- Annotations for the all deployed pods
   podAnnotations: {}
   # -- Security Context to set on pod level
   podSecurityContext:
@@ -196,6 +249,10 @@ argo-rollouts:
     readonly: false
     # -- Value of label `app.kubernetes.io/component`
     component: rollouts-dashboard
+    # -- Annotations to be added to the dashboard deployment
+    deploymentAnnotations: {}
+    # -- Annotations to be added to application dashboard pods
+    podAnnotations: {}
     # -- [Node selector]
     nodeSelector: {}
     # -- [Tolerations] for use with node taints
@@ -222,7 +279,7 @@ argo-rollouts:
       # --  Repository to use
       repository: argoproj/kubectl-argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "master"
+      tag: "v1.6.0"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-dashboard. A list of flags.
@@ -323,6 +380,10 @@ argo-rollouts:
       # - secretName: argorollouts-example-tls
       #   hosts:
       #     - argorollouts.example.com
+    # -- Additional volumes to add to the dashboard pod
+    volumes: []
+    # -- Additional volumeMounts to add to the dashboard container
+    volumeMounts: []
   notifications:
     secret:
       # -- Whether to create notifications secret

--- a/charts/argo-rollouts/config
+++ b/charts/argo-rollouts/config
@@ -4,11 +4,11 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-rollouts
 export CHART_NAME=argo-rollouts
-export VERSION=2.22.3
+export VERSION=2.32.0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr
-export UPGRADE_REVIWER=usernameisnull
+export UPGRADE_REVIWER=yyzxw
 export TEST_ASSIGNER=liyuerich
 
 # push to daocloud repo

--- a/charts/argo-rollouts/custom.sh
+++ b/charts/argo-rollouts/custom.sh
@@ -27,12 +27,57 @@ if ! which yq &>/dev/null ; then
      mv /tmp/${YQ_BINARY} /usr/bin/yq
 fi
 
-yq -i '
-  .argo-rollouts.controller.image.registry = "quay.m.daocloud.io" |
-  .argo-rollouts.dashboard.image.registry = "quay.m.daocloud.io"
-' values.yaml
+# re-write global config.
+
+defaultVersion=$(yq .appVersion Chart.yaml)
+yq -i "
+  .argo-rollouts.controller.image.registry = \"quay.m.daocloud.io\" |
+  .argo-rollouts.controller.image.tag = \"${defaultVersion}\" |
+  .argo-rollouts.dashboard.image.registry = \"quay.m.daocloud.io\" |
+  .argo-rollouts.dashboard.image.tag = \"${defaultVersion}\" |
+  .argo-rollouts.global.imageRegistry=\"quay.m.daocloud.io\" |
+  .argo-rollouts.global.repository=\"argoproj/argo-rollouts\" |
+  .argo-rollouts.global.tag = \"${defaultVersion}\"
+" values.yaml
 
 #==============================
-echo "fulfill tag"
-sed -i 's@tag: ""@tag: "master"@g' values.yaml
+os=$(uname)
+
+
+echo '
+{{- define "global.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+    {{- if and .global.repository (eq $repositoryName "") }}
+     {{- $repositoryName = .global.repository -}}
+    {{- end -}}
+    {{- if and .global.tag (eq $tag "")}}
+     {{- $tag = .global.tag -}}
+    {{- end -}}
+{{- end -}}
+{{- if .tag }}
+    {{- if .tag.imageTag }}
+     {{- $tag = .tag.imageTag -}}
+    {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+'>>charts/argo-rollouts/templates/_helpers.tpl
+
+if [ $os == "Darwin" ];then
+  sed -i "" 's?"{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"?{{ include "global.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global ) }}?g' charts/argo-rollouts/templates/controller/deployment.yaml
+  sed -i "" 's?"{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ default .Chart.AppVersion .Values.dashboard.image.tag }}"?{{ include "global.images.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global ) }}?g' charts/argo-rollouts/templates/dashboard/deployment.yaml
+elif [ $os == "Linux" ];then
+  sed -i 's?"{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"?{{ include "global.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global ) }}?g' charts/argo-rollouts/templates/controller/deployment.yaml
+  sed -i 's?"{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ default .Chart.AppVersion .Values.dashboard.image.tag }}"?{{ include "global.images.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global ) }}?g' charts/argo-rollouts/templates/dashboard/deployment.yaml
+fi
 exit $?

--- a/charts/argo-rollouts/parent/.relok8s-images.yaml
+++ b/charts/argo-rollouts/parent/.relok8s-images.yaml
@@ -1,2 +1,3 @@
+- "{{ .argo-rollouts.global.imageRegistry }}/{{ .argo-rollouts.global.repository }}:{{ .argo-rollouts.global.tag }}"
 - "{{ .argo-rollouts.controller.image.registry }}/{{ .argo-rollouts.controller.image.repository }}:{{ .argo-rollouts.controller.image.tag }}"
 - "{{ .argo-rollouts.dashboard.image.registry }}/{{ .argo-rollouts.dashboard.image.repository }}:{{ .argo-rollouts.dashboard.image.tag }}"

--- a/charts/argo-rollouts/skip-check.yaml
+++ b/charts/argo-rollouts/skip-check.yaml
@@ -1,0 +1,4 @@
+argo-rollouts:
+  - "global/repository"
+  - "global/imageRegistry"
+  - "global/tag"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

upgrade argo-rollouts to v2.32.0

<img width="1493" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/34639446/438912e5-3754-4695-92f7-ecd8e98e4857">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #