### PR TITLE
fix: argocd image error

### DIFF
--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/dex/deployment.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: {{ template "argo-cd.dexServiceAccountName" . }}
       containers:
       - name: {{ .Values.dex.name }}
-        image: {{ include "global.images.image" (dict "imageRoot" .Values.dex.image "global" .Values.global ) }}
+        image: {{ .Values.dex.image.registry }}/{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.image.imagePullPolicy }}
         command:
         - /shared/argocd-dex

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: {{ include "argo-cd.redisServiceAccountName" . }}
       containers:
       - name: {{ .Values.redis.name }}
-        image: {{ include "global.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global ) }}
+        image: {{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.redis.image.imagePullPolicy }}
         args:
         - --save

--- a/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
@@ -838,6 +838,7 @@ dex:
     # -- Dex imagePullPolicy
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""
+    registry: ghcr.m.daocloud.io
   # -- Secrets with credentials to pull images from a private registry
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []
@@ -1038,6 +1039,7 @@ redis:
     # -- Redis image pull policy
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""
+    registry: docker.m.daocloud.io
   ## Prometheus redis-exporter sidecar
   exporter:
     # -- Enable Prometheus redis-exporter sidecar

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -93,7 +93,9 @@ yq -i 'del(.redis-ha.exporter.image)' charts/argo-cd/values.yaml
 yq -i "
   .redis-ha.exporter.image.registry = \"docker.m.daocloud.io\" |
   .redis-ha.exporter.image.repository = \"oliver006/redis_exporter\" |
-  .redis-ha.exporter.image.tag = \"${exporterImageTag}\"
+  .redis-ha.exporter.image.tag = \"${exporterImageTag}\"  |
+  .redis.image.registry = \"docker.m.daocloud.io\" |
+  .dex.image.registry = \"ghcr.m.daocloud.io\"
 " charts/argo-cd/values.yaml
 
 yq -i "
@@ -201,8 +203,8 @@ if [ $os == "Darwin" ];then
   sed -i "" 's?{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.repoServer.image "global" .Values.global ) }}?g' charts/argo-cd/templates/argocd-repo-server/deployment.yaml
   sed -i "" 's?{{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.server.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.server.image "global" .Values.global ) }}?g' charts/argo-cd/templates/argocd-server/deployment.yaml
   sed -i "" 's?{{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.dex.initImage.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.dex.initImage "global" .Values.global ) }}?g' charts/argo-cd/templates/dex/deployment.yaml
-  sed -i "" 's?{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.dex.image "global" .Values.global ) }}?g' charts/argo-cd/templates/dex/deployment.yaml
-  sed -i "" 's?{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
+  sed -i "" 's?{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?{{ .Values.dex.image.registry }}/{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?g' charts/argo-cd/templates/dex/deployment.yaml
+  sed -i "" 's?{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i "" 's?{{ .Values.redis.exporter.image.repository }}:{{ .Values.redis.exporter.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.exporter.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i "" 's?{{ .Values.redis.metrics.image.repository }}:{{ .Values.redis.metrics.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.metrics.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i "" 's?{{ .Values.image.repository }}:{{ .Values.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.image "global" .Values.global ) }}?g' charts/argo-cd/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -219,8 +221,8 @@ elif [ $os == "Linux" ];then
   sed -i 's?{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.repoServer.image "global" .Values.global ) }}?g' charts/argo-cd/templates/argocd-repo-server/deployment.yaml
   sed -i 's?{{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.server.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.server.image "global" .Values.global ) }}?g' charts/argo-cd/templates/argocd-server/deployment.yaml
   sed -i 's?{{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.dex.initImage.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.dex.initImage "global" .Values.global ) }}?g' charts/argo-cd/templates/dex/deployment.yaml
-  sed -i 's?{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.dex.image "global" .Values.global ) }}?g' charts/argo-cd/templates/dex/deployment.yaml
-  sed -i 's?{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
+  sed -i 's?{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?{{ .Values.dex.image.registry }}/{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}?g' charts/argo-cd/templates/dex/deployment.yaml
+  sed -i 's?{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i 's?{{ .Values.redis.exporter.image.repository }}:{{ .Values.redis.exporter.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.exporter.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i 's?{{ .Values.redis.metrics.image.repository }}:{{ .Values.redis.metrics.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.redis.metrics.image "global" .Values.global ) }}?g' charts/argo-cd/templates/redis/deployment.yaml
   sed -i 's?{{ .Values.image.repository }}:{{ .Values.image.tag }}?{{ include "global.images.image" (dict "imageRoot" .Values.image "global" .Values.global ) }}?g' charts/argo-cd/charts/redis-ha/templates/redis-ha-statefulset.yaml


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

修复argocd中redis和dex 镜像的registry地址不正确，redis和dex的镜像与argocd的镜像不一致，无法使用global.imageRegiestry直接替换

<img width="1377" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/34639446/710dc721-b309-4025-bc43-148a1a82cd4f">
 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #