### PR TITLE
fix: argocd image error

### DIFF
--- a/charts/argo-cd/argo-cd/.relok8s-images.yaml
+++ b/charts/argo-cd/argo-cd/.relok8s-images.yaml
@@ -1,4 +1,4 @@
-- "{{ .argo-cd.global.imageRegistry }}/{{ .argo-cd.global.repository}}:{{ .argo-cd.global.tag }}"
+- "{{ .argo-cd.global.image.registry }}/{{ .argo-cd.global.image.repository}}:{{ .argo-cd.global.image.tag }}"
 - "{{ .argo-cd.dex.image.registry }}/{{ .argo-cd.dex.image.repository }}:{{ .argo-cd.dex.image.tag }}"
 - "{{ .argo-cd.redis.image.registry }}/{{ .argo-cd.redis.image.repository }}:{{ .argo-cd.redis.image.tag }}"
 - "{{ .argo-cd.redis.exporter.image.registry }}/{{ .argo-cd.redis.exporter.image.repository }}:{{ .argo-cd.redis.exporter.image.tag }}"

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/_helpers.tpl
@@ -220,13 +220,27 @@ Merge Argo Params Configuration with Preset Configuration
 {{- $tag := .imageRoot.tag | toString -}}
 {{- if .global }}
     {{- if .global.imageRegistry }}
-     {{- $registryName = .global.imageRegistry -}}
+        {{- $registryName = .global.imageRegistry -}}
+    {{ else if .imageRoot.registry }}
+        {{- $registryName = .imageRoot.registry -}}
+    {{ else if .global.image.registry }}
+        {{- $registryName = .global.image.registry -}}
     {{- end -}}
-    {{- if and .global.repository (eq $repositoryName "") }}
-     {{- $repositoryName = .global.repository -}}
+
+    {{- if and .global.repository }}
+        {{- $repositoryName = .global.repository -}}
+    {{- else if .imageRoot.repository }}
+        {{- $repositoryName = .imageRoot.repository -}}
+    {{- else if .global.image.repository }}
+        {{- $repositoryName = .global.image.repository -}}
     {{- end -}}
-    {{- if and .global.tag (eq $tag "")}}
-     {{- $tag = .global.tag -}}
+
+    {{- if and .global.tag }}
+        {{- $tag = .global.tag -}}
+    {{- else if .imageRoot.tag }}
+        {{- $tag = .imageRoot.tag -}}
+    {{- else if .global.image.tag }}
+        {{- $tag = .global.image.tag -}}
     {{- end -}}
 {{- end -}}
 {{- if .tag }}

--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -129,9 +129,9 @@ argo-cd:
     #   maxSurge: 25%
     #   maxUnavailable: 25%
 
-    imageRegistry: quay.m.daocloud.io
-    repository: argoproj/argocd
-    tag: v2.7.3
+    imageRegistry: ""
+    repository: ""
+    tag: ""
   ## Argo Configs
   configs:
     # General Argo CD configuration

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -159,9 +159,9 @@ originGlobalRepository=$(yq ".argo-cd.global.image.repository" values.yaml)
 originGlobalTag=$(yq ".argo-cd.global.image.tag" values.yaml)
 
 yq -i "
-  .argo-cd.global.imageRegistry=\"${originGlobalRegistry}\" |
-  .argo-cd.global.repository=\"${originGlobalRepository}\" |
-  .argo-cd.global.tag=\"${originGlobalTag}\"
+  .argo-cd.global.imageRegistry=\"\" |
+  .argo-cd.global.repository=\"\" |
+  .argo-cd.global.tag=\"\"
 " values.yaml
 
 
@@ -172,13 +172,27 @@ echo '
 {{- $tag := .imageRoot.tag | toString -}}
 {{- if .global }}
     {{- if .global.imageRegistry }}
-     {{- $registryName = .global.imageRegistry -}}
+        {{- $registryName = .global.imageRegistry -}}
+    {{ else if .imageRoot.registry }}
+        {{- $registryName = .imageRoot.registry -}}
+    {{ else if .global.image.registry }}
+        {{- $registryName = .global.image.registry -}}
     {{- end -}}
-    {{- if and .global.repository (eq $repositoryName "") }}
-     {{- $repositoryName = .global.repository -}}
+
+    {{- if and .global.repository }}
+        {{- $repositoryName = .global.repository -}}
+    {{- else if .imageRoot.repository }}
+        {{- $repositoryName = .imageRoot.repository -}}
+    {{- else if .global.image.repository }}
+        {{- $repositoryName = .global.image.repository -}}
     {{- end -}}
-    {{- if and .global.tag (eq $tag "")}}
-     {{- $tag = .global.tag -}}
+
+    {{- if and .global.tag }}
+        {{- $tag = .global.tag -}}
+    {{- else if .imageRoot.tag }}
+        {{- $tag = .imageRoot.tag -}}
+    {{- else if .global.image.tag }}
+        {{- $tag = .global.image.tag -}}
     {{- end -}}
 {{- end -}}
 {{- if .tag }}

--- a/charts/argo-cd/parent/.relok8s-images.yaml
+++ b/charts/argo-cd/parent/.relok8s-images.yaml
@@ -1,4 +1,4 @@
-- "{{ .argo-cd.global.imageRegistry }}/{{ .argo-cd.global.repository}}:{{ .argo-cd.global.tag }}"
+- "{{ .argo-cd.global.image.registry }}/{{ .argo-cd.global.image.repository}}:{{ .argo-cd.global.image.tag }}"
 - "{{ .argo-cd.dex.image.registry }}/{{ .argo-cd.dex.image.repository }}:{{ .argo-cd.dex.image.tag }}"
 - "{{ .argo-cd.redis.image.registry }}/{{ .argo-cd.redis.image.repository }}:{{ .argo-cd.redis.image.tag }}"
 - "{{ .argo-cd.redis.exporter.image.registry }}/{{ .argo-cd.redis.exporter.image.repository }}:{{ .argo-cd.redis.exporter.image.tag }}"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

修复 argocd 的镜像渲染错误。

<img width="1426" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/34639446/52d188a7-68e1-4ef5-afcb-7538c989fda1">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #