### PR TITLE
add servicemonitor with nvidia-vgpu

### DIFF
--- a/charts/nvidia-vgpu/custom.sh
+++ b/charts/nvidia-vgpu/custom.sh
@@ -305,3 +305,7 @@ yq -i '
 
 # rm daemonsethygon.yaml file
 rm -rf charts/vgpu/templates/device-plugin/daemonsethygon.yaml
+
+yq -i '.scheduler.serviceMonitor.enable=false' charts/vgpu/values.yaml
+
+yq -i '.vgpu.scheduler.serviceMonitor.enable=false' values.yaml

--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/templates/vgpu-servicemonitor.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/templates/vgpu-servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.scheduler.serviceMonitor.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    operator.insight.io/managed-by: insight
+  name: vgpu-exporter
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 15s
+    path: /metrics
+    port: monitor
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_endpoint_node_name
+      targetLabel: node
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: 4pd-scheduler
+{{- end }}

--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/values.yaml
@@ -76,6 +76,8 @@ scheduler:
     monitorPort: 31993
     labels: {}
     annotations: {}
+  serviceMonitor:
+    enable: false
 devicePlugin:
   registry: docker.m.daocloud.io
   repository: 4pdosc/k8s-vdevice

--- a/charts/nvidia-vgpu/nvidia-vgpu/values.schema.json
+++ b/charts/nvidia-vgpu/nvidia-vgpu/values.schema.json
@@ -42,6 +42,19 @@
                             }
                         }
                     }
+                },
+                "scheduler": {
+                    "type": "object",
+                    "properties": {
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
@@ -77,6 +77,8 @@ vgpu:
       monitorPort: 31993
       labels: {}
       annotations: {}
+    serviceMonitor:
+      enable: false
   devicePlugin:
     registry: docker.m.daocloud.io
     repository: 4pdosc/k8s-vdevice

--- a/charts/nvidia-vgpu/parent/charts/vgpu/templates/vgpu-servicemonitor.yaml
+++ b/charts/nvidia-vgpu/parent/charts/vgpu/templates/vgpu-servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.scheduler.serviceMonitor.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    operator.insight.io/managed-by: insight
+  name: vgpu-exporter
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 15s
+    path: /metrics
+    port: monitor
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_endpoint_node_name
+      targetLabel: node
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: 4pd-scheduler
+{{- end }}

--- a/charts/nvidia-vgpu/parent/values.schema.json
+++ b/charts/nvidia-vgpu/parent/values.schema.json
@@ -42,6 +42,19 @@
                             }
                         }
                     }
+                },
+                "scheduler": {
+                    "type": "object",
+                    "properties": {
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
* vgpu添加servicemonitor，用作指标采集
* 新增servicemonitor 开关

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #