### PR TITLE
Robot Upgrade: argo-rollouts chart upgrade from 2.32.0 to 2.32.1

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+    - kind: fixed
+      description: Use integer instead of float for controller replicas
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
@@ -19,8 +19,8 @@ maintainers:
 name: argo-rollouts
 sources:
   - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.32.1
 dependencies:
   - name: argo-rollouts
-    version: "2.32.0"
+    version: "2.32.1"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+    - kind: fixed
+      description: Use integer instead of float for controller replicas
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
@@ -19,4 +19,4 @@ maintainers:
 name: argo-rollouts
 sources:
 - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.32.1

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- if not .Values.clusterInstall }}
         - --namespaced
         {{- end }}
-        {{- if gt .Values.controller.replicas 1.0 }}
+        {{- if gt (int .Values.controller.replicas) 1 }}
         - --leader-elect
         {{- end }}
         {{- with .Values.controller.extraArgs }}

--- a/charts/argo-rollouts/config
+++ b/charts/argo-rollouts/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-rollouts
 export CHART_NAME=argo-rollouts
-export VERSION=2.32.0
+export VERSION=2.32.1
 
 # pr, issue, none
 export UPGRADE_METHOD=pr


### PR DESCRIPTION
I am robot, upgrade: project argo-rollouts chart upgrade from 2.32.0 to 2.32.1