### PR TITLE
Robot Upgrade: node-problem-detector chart upgrade from 2.3.1 to 2.3.11

### DIFF
--- a/charts/node-problem-detector/config
+++ b/charts/node-problem-detector/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://charts.deliveryhero.io
 export REPO_NAME=node-problem-detector
 export CHART_NAME=node-problem-detector
-export VERSION=2.3.1
+export VERSION=2.3.11
 # pr, issue, none
 export UPGRADE_METHOD=pr
 

--- a/charts/node-problem-detector/node-problem-detector/Chart.yaml
+++ b/charts/node-problem-detector/node-problem-detector/Chart.yaml
@@ -1,25 +1,22 @@
 apiVersion: v1
-appVersion: v0.8.12
-description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector)
-  daemonset. This tool aims to make various node problems visible to the upstream
-  layers in cluster management stack. It is a daemon which runs on each node, detects
-  node problems and reports them to apiserver. '
+appVersion: v0.8.14
+description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver. '
 home: https://github.com/kubernetes/node-problem-detector
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 keywords:
-- node
-- problem
-- detector
-- monitoring
+  - node
+  - problem
+  - detector
+  - monitoring
 maintainers:
-- email: no-reply@deliveryhero.com
-  name: max-rocket-internet
+  - email: no-reply@deliveryhero.com
+    name: max-rocket-internet
 name: node-problem-detector
 sources:
-- https://github.com/kubernetes/node-problem-detector
-- https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-version: 2.3.1
+  - https://github.com/kubernetes/node-problem-detector
+  - https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+version: 2.3.11
 dependencies:
   - name: node-problem-detector
-    version: "2.3.1"
+    version: "2.3.11"
     repository: "https://charts.deliveryhero.io"

--- a/charts/node-problem-detector/node-problem-detector/README.md
+++ b/charts/node-problem-detector/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.3.11](https://img.shields.io/badge/Version-2.3.11-informational?style=flat-square) ![AppVersion: v0.8.14](https://img.shields.io/badge/AppVersion-v0.8.14-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -56,9 +56,10 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
 | hostPID | bool | `false` |  |
+| image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.12"` |  |
+| image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.14"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
@@ -72,7 +73,9 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |
 | metrics.prometheusRule.enabled | bool | `false` |  |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| metrics.serviceMonitor.additionalRelabelings | list | `[]` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | priorityClassName | string | `"system-node-critical"` |  |
@@ -80,7 +83,9 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | rbac.pspEnabled | bool | `false` |  |
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
+| serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
+| serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `nil` |  |
 | settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |
 | settings.custom_plugin_monitors | list | `[]` |  |
@@ -92,6 +97,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | tolerations[0].effect | string | `"NoSchedule"` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | string | `"RollingUpdate"` | Manage the daemonset update strategy |
+| volume.localtime.type | string | `"FileOrCreate"` |  |
 
 ## Maintainers
 

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/Chart.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.8.12
+appVersion: v0.8.14
 description: 'This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector)
   daemonset. This tool aims to make various node problems visible to the upstream
   layers in cluster management stack. It is a daemon which runs on each node, detects
@@ -18,4 +18,4 @@ name: node-problem-detector
 sources:
 - https://github.com/kubernetes/node-problem-detector
 - https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-version: 2.3.1
+version: 2.3.11

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/README.md
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.3.11](https://img.shields.io/badge/Version-2.3.11-informational?style=flat-square) ![AppVersion: v0.8.14](https://img.shields.io/badge/AppVersion-v0.8.14-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -56,9 +56,10 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
 | hostPID | bool | `false` |  |
+| image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.12"` |  |
+| image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.14"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
@@ -72,7 +73,9 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |
 | metrics.prometheusRule.enabled | bool | `false` |  |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| metrics.serviceMonitor.additionalRelabelings | list | `[]` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | priorityClassName | string | `"system-node-critical"` |  |
@@ -80,7 +83,9 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | rbac.pspEnabled | bool | `false` |  |
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
+| serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
+| serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `nil` |  |
 | settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |
 | settings.custom_plugin_monitors | list | `[]` |  |
@@ -92,6 +97,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | tolerations[0].effect | string | `"NoSchedule"` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | string | `"RollingUpdate"` | Manage the daemonset update strategy |
+| volume.localtime.type | string | `"FileOrCreate"` |  |
 
 ## Maintainers
 

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/daemonset.yaml
@@ -50,7 +50,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.image.digest }}
+          image:  "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image:  "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" | quote }}
           command:
             - "/bin/sh"
@@ -108,10 +112,11 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
-            type: "FileOrCreate"
+            type: {{ default "FileOrCreate" .Values.volume.localtime.type }}
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}
+            defaultMode: 493
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/serviceaccount.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/serviceaccount.yaml
@@ -8,5 +8,12 @@ metadata:
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+   {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/servicemonitor.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/templates/servicemonitor.yaml
@@ -32,4 +32,11 @@ spec:
       targetLabel: host_ip
       sourceLabels:
         - __meta_kubernetes_pod_host_ip
+    {{- if .Values.metrics.serviceMonitor.additionalRelabelings }}
+    {{- toYaml .Values.metrics.serviceMonitor.additionalRelabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/values.yaml
+++ b/charts/node-problem-detector/node-problem-detector/charts/node-problem-detector/values.yaml
@@ -55,8 +55,10 @@ logDir:
   pod: ""
 
 image:
-  repository: k8s.gcr.io/node-problem-detector/node-problem-detector
-  tag: v0.8.12
+  repository: registry.k8s.io/node-problem-detector/node-problem-detector
+  tag: v0.8.14
+  # image.digest -- the image digest. If given it takes precedence over a given tag.
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -73,6 +75,10 @@ rbac:
 # not recommended, but may be useful for certain use cases.
 hostNetwork: false
 hostPID: false
+
+volume:
+  localtime:
+    type: "FileOrCreate"
 
 priorityClassName: system-node-critical
 
@@ -92,6 +98,10 @@ tolerations:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # Labels to add to the service account
+  labels: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
@@ -108,6 +118,8 @@ metrics:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    additionalRelabelings: []
+    metricRelabelings: []
   prometheusRule:
     enabled: false
     defaultRules:


### PR DESCRIPTION
I am robot, upgrade: project node-problem-detector chart upgrade from 2.3.1 to 2.3.11