### PR TITLE
Robot Upgrade: argo-rollouts chart upgrade from 2.32.0 to 2.32.7

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+      description: Bump argo-rollouts to v1.6.3
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.0
+appVersion: v1.6.3
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,8 +19,8 @@ maintainers:
 name: argo-rollouts
 sources:
   - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.32.7
 dependencies:
   - name: argo-rollouts
-    version: "2.32.0"
+    version: "2.32.7"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-rollouts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/README.md
@@ -65,6 +65,7 @@ For full list of changes please check ArtifactHub [changelog].
 | providerRBAC.providers.apisix | bool | `true` | Adds RBAC rules for the Apisix provider |
 | providerRBAC.providers.awsAppMesh | bool | `true` | Adds RBAC rules for the AWS App Mesh provider |
 | providerRBAC.providers.awsLoadBalancerController | bool | `true` | Adds RBAC rules for the AWS Load Balancer Controller provider |
+| providerRBAC.providers.contour | bool | `true` | Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md` |
 | providerRBAC.providers.istio | bool | `true` | Adds RBAC rules for the Istio provider |
 | providerRBAC.providers.smi | bool | `true` | Adds RBAC rules for the SMI provider |
 | providerRBAC.providers.traefik | bool | `true` | Adds RBAC rules for the Traefik provider |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+      description: Bump argo-rollouts to v1.6.3
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.0
+appVersion: v1.6.3
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,4 +19,4 @@ maintainers:
 name: argo-rollouts
 sources:
 - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.32.7

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
@@ -65,6 +65,7 @@ For full list of changes please check ArtifactHub [changelog].
 | providerRBAC.providers.apisix | bool | `true` | Adds RBAC rules for the Apisix provider |
 | providerRBAC.providers.awsAppMesh | bool | `true` | Adds RBAC rules for the AWS App Mesh provider |
 | providerRBAC.providers.awsLoadBalancerController | bool | `true` | Adds RBAC rules for the AWS Load Balancer Controller provider |
+| providerRBAC.providers.contour | bool | `true` | Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md` |
 | providerRBAC.providers.istio | bool | `true` | Adds RBAC rules for the Istio provider |
 | providerRBAC.providers.smi | bool | `true` | Adds RBAC rules for the SMI provider |
 | providerRBAC.providers.traefik | bool | `true` | Adds RBAC rules for the Traefik provider |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
@@ -255,5 +255,17 @@ rules:
   - get
   - update
 {{- end }}
+{{- if .Values.providerRBAC.providers.contour }}
+  # Access needed when using the Contour provider
+- apiGroups:
+    - projectcontour.io
+  resources:
+    - httpproxies
+  verbs:
+    - get
+    - list
+    - watch
+    - update
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- if not .Values.clusterInstall }}
         - --namespaced
         {{- end }}
-        {{- if gt .Values.controller.replicas 1.0 }}
+        {{- if gt (int .Values.controller.replicas) 1 }}
         - --leader-elect
         {{- end }}
         {{- with .Values.controller.extraArgs }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -189,13 +189,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2809,6 +2818,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2857,6 +2879,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
@@ -262,6 +262,8 @@ providerRBAC:
     traefik: true
     # -- Adds RBAC rules for the Apisix provider
     apisix: true
+    # -- Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md`
+    contour: true
 
 dashboard:
   # -- Deploy dashboard server

--- a/charts/argo-rollouts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/values.yaml
@@ -38,7 +38,7 @@ argo-rollouts:
     deploymentAnnotations: {}
     imageRegistry: quay.m.daocloud.io
     repository: argoproj/argo-rollouts
-    tag: v1.6.0
+    tag: v1.6.3
   controller:
     # -- Value of label `app.kubernetes.io/component`
     component: rollouts-controller
@@ -70,7 +70,7 @@ argo-rollouts:
       # -- Repository to use
       repository: argoproj/argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.0"
+      tag: "v1.6.3"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-controller.  A list of flags.
@@ -242,6 +242,8 @@ argo-rollouts:
       traefik: true
       # -- Adds RBAC rules for the Apisix provider
       apisix: true
+      # -- Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md`
+      contour: true
   dashboard:
     # -- Deploy dashboard server
     enabled: false
@@ -279,7 +281,7 @@ argo-rollouts:
       # --  Repository to use
       repository: argoproj/kubectl-argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.0"
+      tag: "v1.6.3"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-dashboard. A list of flags.

--- a/charts/argo-rollouts/config
+++ b/charts/argo-rollouts/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-rollouts
 export CHART_NAME=argo-rollouts
-export VERSION=2.32.0
+export VERSION=2.32.7
 
 # pr, issue, none
 export UPGRADE_METHOD=pr


### PR DESCRIPTION
I am robot, upgrade: project argo-rollouts chart upgrade from 2.32.0 to 2.32.7