### PR TITLE
update vgpu servicemonitor

### DIFF
--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/templates/vgpu-servicemonitor.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/vgpu/templates/vgpu-servicemonitor.yaml
@@ -16,8 +16,31 @@ spec:
       sourceLabels:
       - podname
       targetLabel: exported_pod
+    - action: replace
+      sourceLabels:
+      - podnamespace
+      targetLabel: exported_namespace
     path: /metrics
     port: monitor
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_endpoint_node_name
+      targetLabel: node
+  - bearerTokenSecret:
+      key: ""
+    interval: 15s
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - podname
+      targetLabel: exported_pod
+    - action: replace
+      sourceLabels:
+      - podnamespace
+      targetLabel: exported_namespace
+    path: /metrics
+    port: monitorport
     relabelings:
     - action: replace
       sourceLabels:

--- a/charts/nvidia-vgpu/parent/charts/vgpu/templates/vgpu-servicemonitor.yaml
+++ b/charts/nvidia-vgpu/parent/charts/vgpu/templates/vgpu-servicemonitor.yaml
@@ -16,8 +16,31 @@ spec:
       sourceLabels:
       - podname
       targetLabel: exported_pod
+    - action: replace
+      sourceLabels:
+      - podnamespace
+      targetLabel: exported_namespace
     path: /metrics
     port: monitor
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_endpoint_node_name
+      targetLabel: node
+  - bearerTokenSecret:
+      key: ""
+    interval: 15s
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - podname
+      targetLabel: exported_pod
+    - action: replace
+      sourceLabels:
+      - podnamespace
+      targetLabel: exported_namespace
+    path: /metrics
+    port: monitorport
     relabelings:
     - action: replace
       sourceLabels:


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
之前vgpu servicemonitor少采集了一个port，这里新增了采集端口
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #