### PR TITLE
add nodeSelector to nvidia-vgpu

### DIFF
--- a/charts/nvidia-vgpu/custom.sh
+++ b/charts/nvidia-vgpu/custom.sh
@@ -270,12 +270,12 @@ elif [ $os == "Linux" ];then
 fi
 # update nvidianodeSelector values
 yq -i '
-    .hami.devicePlugin.nvidianodeSelector={"nvidia.com/gpu.deploy.driver":"true", "nvidia.com/vgpu.deploy.device-plugin": "true"} |
-    .hami.scheduler.nodeSelector={"nvidia.com/gpu.deploy.driver":"true"}
+    .hami.devicePlugin.nvidianodeSelector={"nvidia.com/gpu.deploy.container-toolkit":"true", "nvidia.com/vgpu.deploy.device-plugin": "true"} |
+    .hami.scheduler.nodeSelector={"nvidia.com/gpu.deploy.container-toolkit":"true"}
 ' values.yaml
 yq -i '
-    .devicePlugin.nvidianodeSelector={"nvidia.com/gpu.deploy.driver":"true", "nvidia.com/vgpu.deploy.device-plugin": "true"} |
-    .scheduler.nodeSelector={"nvidia.com/gpu.deploy.driver":"true"}
+    .devicePlugin.nvidianodeSelector={"nvidia.com/gpu.deploy.container-toolkit":"true", "nvidia.com/vgpu.deploy.device-plugin": "true"} |
+    .scheduler.nodeSelector={"nvidia.com/gpu.deploy.container-toolkit":"true"}
 ' charts/hami/values.yaml
 
 # add hygonImageRepository and hygonImageTag

--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/hami/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/hami/values.yaml
@@ -84,7 +84,7 @@ scheduler:
     labels: {}
     annotations: {}
   nodeSelector:
-    nvidia.com/gpu.deploy.driver: "true"
+    nvidia.com/gpu.deploy.container-toolkit: "true"
   serviceMonitor:
     enable: false
 devicePlugin:
@@ -110,7 +110,7 @@ devicePlugin:
   libPath: /usr/local/vgpu
   podAnnotations: {}
   nvidianodeSelector:
-    nvidia.com/gpu.deploy.driver: "true"
+    nvidia.com/gpu.deploy.container-toolkit: "true"
     nvidia.com/vgpu.deploy.device-plugin: "true"
   mlunodeSelector:
     mlu: "on"

--- a/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
@@ -85,7 +85,7 @@ hami:
       labels: {}
       annotations: {}
     nodeSelector:
-      nvidia.com/gpu.deploy.driver: "true"
+      nvidia.com/gpu.deploy.container-toolkit: "true"
     serviceMonitor:
       enable: false
   devicePlugin:
@@ -110,7 +110,7 @@ hami:
     libPath: /usr/local/vgpu
     podAnnotations: {}
     nvidianodeSelector:
-      nvidia.com/gpu.deploy.driver: "true"
+      nvidia.com/gpu.deploy.container-toolkit: "true"
       nvidia.com/vgpu.deploy.device-plugin: "true"
     mlunodeSelector:
       mlu: "on"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

`"nvidia.com/gpu.deploy.driver":"true"` 是表示 driver 是用 gpu-operator安装的。

 如果主机预安装了 driver.

导致 出现这种情况 `"nvidia.com/gpu.deploy.driver":"pre-installed"` 

因此修改为 `"nvidia.com/gpu.deploy.container-toolkit":"true"` 目前没有看到类似的逻辑


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #