### PR TITLE
fix: remove NodePort in jenkins schema

### DIFF
--- a/charts/jenkins/jenkins/values.schema.json
+++ b/charts/jenkins/jenkins/values.schema.json
@@ -1,244 +1,246 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "required": [
-        "jenkins"
-    ],
-    "properties": {
-        "jenkins": {
-            "type": "object",
-            "required": [
-                "image"
-            ],
-            "properties": {
-                "Agent": {
-                    "type": "object",
-                    "properties": {
-                        "Builder": {
-                            "type": "object",
-                            "properties": {
-                                "ContainerRuntime": {
-                                    "type": "string",
-                                    "default": "podman",
-                                    "enum": [
-                                        "podman",
-                                        "docker"
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "Master": {
-                    "type": "object",
-                    "required": [
-                        "AdminPassword",
-                        "AdminUser",
-                        "resources"
-                    ],
-                    "properties": {
-                        "AdminPassword": {
-                            "type": "string",
-                            "default": "Admin01"
-                        },
-                        "AdminUser": {
-                            "type": "string",
-                            "default": "admin"
-                        },
-                        "Deploy": {
-                            "type": "object",
-                            "required": [
-                                "NotWithApiServer"
-                            ],
-                            "properties": {
-                                "JenkinsHost": {
-                                    "type": "string",
-                                    "default": ""
-                                },
-                                "NotWithApiServer": {
-                                    "type": "boolean",
-                                    "default": false
-                                }
-                            },
-                            "if": {
-                                "properties": {
-                                    "NotWithApiServer": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "JenkinsHost"
-                                ]
-                            }
-                        },
-                        "JavaOpts": {
-                            "type": "string",
-                            "default": "-XX:MaxRAMPercentage=70.0 \n-XX:MinHeapFreeRatio=8\n-XX:MaxHeapFreeRatio=15\n-XX:MinRAMPercentage=20.0\n-XX:-UseAdaptiveSizePolicy\n-XX:-ShrinkHeapInSteps\n-Dhudson.slaves.NodeProvisioner.initialDelay=20\n-Dhudson.slaves.NodeProvisioner.MARGIN=50\n-Dhudson.slaves.NodeProvisioner.MARGIN0=0.85\n-Dhudson.model.LoadStatistics.clock=5000\n-Dhudson.model.LoadStatistics.decay=0.2\n-Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000\n-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true\n-Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000\n-Djenkins.install.runSetupWizard=false\n-XX:+UseG1GC\n-XX:+UseStringDeduplication\n-XX:+ParallelRefProcEnabled\n-XX:+DisableExplicitGC\n-XX:+UnlockDiagnosticVMOptions\n-XX:+UnlockExperimentalVMOptions"
-                        },
-                        "NodePort": {
-                            "type": "integer",
-                            "default": 31767
-                        },
-                        "ServicePort": {
-                            "type": "integer",
-                            "default": 80
-                        },
-                        "ServiceType": {
-                            "type": "string",
-                            "default": "ClusterIP",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer"
-                            ]
-                        },
-                        "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string",
-                                            "default": "2"
-                                        },
-                                        "memory": {
-                                            "type": "string",
-                                            "default": "4096Mi"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string",
-                                            "default": "1"
-                                        },
-                                        "memory": {
-                                            "type": "string",
-                                            "default": "799Mi"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "eventProxy": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "eventProxy": {
-                                    "type": "object",
-                                    "if": {
-                                        "properties": {
-                                            "enabled": {
-                                                "const": true
-                                            }
-                                        }
-                                    },
-                                    "then": {
-                                        "required": [
-                                            "host",
-                                            "proto",
-                                            "token",
-                                            "webhookUrl"
-                                        ]
-                                    },
-                                    "properties": {
-                                        "host": {
-                                            "type": "string",
-                                            "default": "amamba-devops-server.amamba-system:80"
-                                        },
-                                        "proto": {
-                                            "type": "string",
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https"
-                                            ]
-                                        },
-                                        "token": {
-                                            "type": "string"
-                                        },
-                                        "webhookUrl": {
-                                            "type": "string",
-                                            "default": "/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean",
-                            "default": true
-                        },
-                        "image": {
-                            "type": "object",
-                            "required": [
-                                "registry",
-                                "repository",
-                                "tag"
-                            ],
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "default": "release.daocloud.io"
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "default": "amamba/amamba-event-proxy"
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "default": "v0.18.0-alpha.0"
-                                }
-                            }
-                        },
-                        "imagePullPolicy": {
-                            "type": "string",
-                            "default": "IfNotPresent",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ]
-                        },
-                        "resources": {
-                            "type": "object"
-                        }
-                    },
-                    "if": {
-                        "properties": {
-                            "enabled": {
-                                "const": true
-                            }
-                        }
-                    },
-                    "then": {
-                        "required": [
-                            "image"
-                        ]
-                    }
-                },
-                "image": {
-                    "type": "object",
-                    "required": [
-                        "registry"
-                    ],
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "default": "docker.m.daocloud.io"
-                        }
-                    }
+  "$schema": "http://json-schema.org/schema#",
+  "required": [
+    "jenkins"
+  ],
+  "type": "object",
+  "properties": {
+    "jenkins": {
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "Agent": {
+          "type": "object",
+          "properties": {
+            "Builder": {
+              "type": "object",
+              "properties": {
+                "ContainerRuntime": {
+                  "type": "string",
+                  "default": "podman",
+                  "enum": [
+                    "podman",
+                    "docker"
+                  ]
                 }
+              }
             }
+          }
+        },
+        "Master": {
+          "type": "object",
+          "required": [
+            "AdminPassword",
+            "AdminUser",
+            "resources"
+          ],
+          "properties": {
+            "AdminPassword": {
+              "type": "string",
+              "default": "Admin01"
+            },
+            "AdminUser": {
+              "type": "string",
+              "default": "admin"
+            },
+            "Deploy": {
+              "type": "object",
+              "required": [
+                "NotWithApiServer"
+              ],
+              "properties": {
+                "JenkinsHost": {
+                  "type": "string",
+                  "default": ""
+                },
+                "NotWithApiServer": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "if": {
+                "properties": {
+                  "NotWithApiServer": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "JenkinsHost"
+                ]
+              }
+            },
+            "JavaOpts": {
+              "type": "string",
+              "default": "-XX:MaxRAMPercentage=70.0 \n-XX:MinHeapFreeRatio=8\n-XX:MaxHeapFreeRatio=15\n-XX:MinRAMPercentage=20.0\n-XX:-UseAdaptiveSizePolicy\n-XX:-ShrinkHeapInSteps\n-Dhudson.slaves.NodeProvisioner.initialDelay=20\n-Dhudson.slaves.NodeProvisioner.MARGIN=50\n-Dhudson.slaves.NodeProvisioner.MARGIN0=0.85\n-Dhudson.model.LoadStatistics.clock=5000\n-Dhudson.model.LoadStatistics.decay=0.2\n-Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000\n-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true\n-Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000\n-Djenkins.install.runSetupWizard=false\n-XX:+UseG1GC\n-XX:+UseStringDeduplication\n-XX:+ParallelRefProcEnabled\n-XX:+DisableExplicitGC\n-XX:+UnlockDiagnosticVMOptions\n-XX:+UnlockExperimentalVMOptions"
+            },
+            "NodePort": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ServicePort": {
+              "type": "integer",
+              "default": 80
+            },
+            "ServiceType": {
+              "type": "string",
+              "default": "ClusterIP",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "2"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "4096Mi"
+                    }
+                  }
+                },
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "1"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "799Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eventProxy": {
+          "type": "object",
+          "properties": {
+            "configMap": {
+              "type": "object",
+              "properties": {
+                "eventProxy": {
+                  "type": "object",
+                  "if": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "host",
+                      "proto",
+                      "token",
+                      "webhookUrl"
+                    ]
+                  },
+                  "properties": {
+                    "host": {
+                      "type": "string",
+                      "default": "amamba-devops-server.amamba-system:80"
+                    },
+                    "proto": {
+                      "type": "string",
+                      "default": "http",
+                      "enum": [
+                        "http",
+                        "https"
+                      ]
+                    },
+                    "token": {
+                      "type": "string"
+                    },
+                    "webhookUrl": {
+                      "type": "string",
+                      "default": "/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins"
+                    }
+                  }
+                }
+              }
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "image": {
+              "type": "object",
+              "required": [
+                "registry",
+                "repository",
+                "tag"
+              ],
+              "properties": {
+                "registry": {
+                  "type": "string",
+                  "default": "release.daocloud.io"
+                },
+                "repository": {
+                  "type": "string",
+                  "default": "amamba/amamba-event-proxy"
+                },
+                "tag": {
+                  "type": "string",
+                  "default": "v0.18.0-alpha.0"
+                }
+              }
+            },
+            "imagePullPolicy": {
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "resources": {
+              "type": "object"
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "image"
+            ]
+          }
+        },
+        "image": {
+          "type": "object",
+          "required": [
+            "registry"
+          ],
+          "properties": {
+            "registry": {
+              "type": "string",
+              "default": "docker.m.daocloud.io"
+            }
+          }
         }
+      }
     }
+  }
 }

--- a/charts/jenkins/parent/values.schema.json
+++ b/charts/jenkins/parent/values.schema.json
@@ -1,244 +1,246 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "required": [
-        "jenkins"
-    ],
-    "properties": {
-        "jenkins": {
-            "type": "object",
-            "required": [
-                "image"
-            ],
-            "properties": {
-                "Agent": {
-                    "type": "object",
-                    "properties": {
-                        "Builder": {
-                            "type": "object",
-                            "properties": {
-                                "ContainerRuntime": {
-                                    "type": "string",
-                                    "default": "podman",
-                                    "enum": [
-                                        "podman",
-                                        "docker"
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "Master": {
-                    "type": "object",
-                    "required": [
-                        "AdminPassword",
-                        "AdminUser",
-                        "resources"
-                    ],
-                    "properties": {
-                        "AdminPassword": {
-                            "type": "string",
-                            "default": "Admin01"
-                        },
-                        "AdminUser": {
-                            "type": "string",
-                            "default": "admin"
-                        },
-                        "Deploy": {
-                            "type": "object",
-                            "required": [
-                                "NotWithApiServer"
-                            ],
-                            "properties": {
-                                "JenkinsHost": {
-                                    "type": "string",
-                                    "default": ""
-                                },
-                                "NotWithApiServer": {
-                                    "type": "boolean",
-                                    "default": false
-                                }
-                            },
-                            "if": {
-                                "properties": {
-                                    "NotWithApiServer": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "JenkinsHost"
-                                ]
-                            }
-                        },
-                        "JavaOpts": {
-                            "type": "string",
-                            "default": "-XX:MaxRAMPercentage=70.0 \n-XX:MinHeapFreeRatio=8\n-XX:MaxHeapFreeRatio=15\n-XX:MinRAMPercentage=20.0\n-XX:-UseAdaptiveSizePolicy\n-XX:-ShrinkHeapInSteps\n-Dhudson.slaves.NodeProvisioner.initialDelay=20\n-Dhudson.slaves.NodeProvisioner.MARGIN=50\n-Dhudson.slaves.NodeProvisioner.MARGIN0=0.85\n-Dhudson.model.LoadStatistics.clock=5000\n-Dhudson.model.LoadStatistics.decay=0.2\n-Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000\n-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true\n-Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000\n-Djenkins.install.runSetupWizard=false\n-XX:+UseG1GC\n-XX:+UseStringDeduplication\n-XX:+ParallelRefProcEnabled\n-XX:+DisableExplicitGC\n-XX:+UnlockDiagnosticVMOptions\n-XX:+UnlockExperimentalVMOptions"
-                        },
-                        "NodePort": {
-                            "type": "integer",
-                            "default": 31767
-                        },
-                        "ServicePort": {
-                            "type": "integer",
-                            "default": 80
-                        },
-                        "ServiceType": {
-                            "type": "string",
-                            "default": "ClusterIP",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer"
-                            ]
-                        },
-                        "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string",
-                                            "default": "2"
-                                        },
-                                        "memory": {
-                                            "type": "string",
-                                            "default": "4096Mi"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string",
-                                            "default": "1"
-                                        },
-                                        "memory": {
-                                            "type": "string",
-                                            "default": "799Mi"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "eventProxy": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "eventProxy": {
-                                    "type": "object",
-                                    "if": {
-                                        "properties": {
-                                            "enabled": {
-                                                "const": true
-                                            }
-                                        }
-                                    },
-                                    "then": {
-                                        "required": [
-                                            "host",
-                                            "proto",
-                                            "token",
-                                            "webhookUrl"
-                                        ]
-                                    },
-                                    "properties": {
-                                        "host": {
-                                            "type": "string",
-                                            "default": "amamba-devops-server.amamba-system:80"
-                                        },
-                                        "proto": {
-                                            "type": "string",
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https"
-                                            ]
-                                        },
-                                        "token": {
-                                            "type": "string"
-                                        },
-                                        "webhookUrl": {
-                                            "type": "string",
-                                            "default": "/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean",
-                            "default": true
-                        },
-                        "image": {
-                            "type": "object",
-                            "required": [
-                                "registry",
-                                "repository",
-                                "tag"
-                            ],
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "default": "release.daocloud.io"
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "default": "amamba/amamba-event-proxy"
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "default": "v0.18.0-alpha.0"
-                                }
-                            }
-                        },
-                        "imagePullPolicy": {
-                            "type": "string",
-                            "default": "IfNotPresent",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ]
-                        },
-                        "resources": {
-                            "type": "object"
-                        }
-                    },
-                    "if": {
-                        "properties": {
-                            "enabled": {
-                                "const": true
-                            }
-                        }
-                    },
-                    "then": {
-                        "required": [
-                            "image"
-                        ]
-                    }
-                },
-                "image": {
-                    "type": "object",
-                    "required": [
-                        "registry"
-                    ],
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "default": "docker.m.daocloud.io"
-                        }
-                    }
+  "$schema": "http://json-schema.org/schema#",
+  "required": [
+    "jenkins"
+  ],
+  "type": "object",
+  "properties": {
+    "jenkins": {
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "Agent": {
+          "type": "object",
+          "properties": {
+            "Builder": {
+              "type": "object",
+              "properties": {
+                "ContainerRuntime": {
+                  "type": "string",
+                  "default": "podman",
+                  "enum": [
+                    "podman",
+                    "docker"
+                  ]
                 }
+              }
             }
+          }
+        },
+        "Master": {
+          "type": "object",
+          "required": [
+            "AdminPassword",
+            "AdminUser",
+            "resources"
+          ],
+          "properties": {
+            "AdminPassword": {
+              "type": "string",
+              "default": "Admin01"
+            },
+            "AdminUser": {
+              "type": "string",
+              "default": "admin"
+            },
+            "Deploy": {
+              "type": "object",
+              "required": [
+                "NotWithApiServer"
+              ],
+              "properties": {
+                "JenkinsHost": {
+                  "type": "string",
+                  "default": ""
+                },
+                "NotWithApiServer": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "if": {
+                "properties": {
+                  "NotWithApiServer": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "JenkinsHost"
+                ]
+              }
+            },
+            "JavaOpts": {
+              "type": "string",
+              "default": "-XX:MaxRAMPercentage=70.0 \n-XX:MinHeapFreeRatio=8\n-XX:MaxHeapFreeRatio=15\n-XX:MinRAMPercentage=20.0\n-XX:-UseAdaptiveSizePolicy\n-XX:-ShrinkHeapInSteps\n-Dhudson.slaves.NodeProvisioner.initialDelay=20\n-Dhudson.slaves.NodeProvisioner.MARGIN=50\n-Dhudson.slaves.NodeProvisioner.MARGIN0=0.85\n-Dhudson.model.LoadStatistics.clock=5000\n-Dhudson.model.LoadStatistics.decay=0.2\n-Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000\n-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true\n-Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000\n-Djenkins.install.runSetupWizard=false\n-XX:+UseG1GC\n-XX:+UseStringDeduplication\n-XX:+ParallelRefProcEnabled\n-XX:+DisableExplicitGC\n-XX:+UnlockDiagnosticVMOptions\n-XX:+UnlockExperimentalVMOptions"
+            },
+            "NodePort": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ServicePort": {
+              "type": "integer",
+              "default": 80
+            },
+            "ServiceType": {
+              "type": "string",
+              "default": "ClusterIP",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "2"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "4096Mi"
+                    }
+                  }
+                },
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "1"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "799Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eventProxy": {
+          "type": "object",
+          "properties": {
+            "configMap": {
+              "type": "object",
+              "properties": {
+                "eventProxy": {
+                  "type": "object",
+                  "if": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "host",
+                      "proto",
+                      "token",
+                      "webhookUrl"
+                    ]
+                  },
+                  "properties": {
+                    "host": {
+                      "type": "string",
+                      "default": "amamba-devops-server.amamba-system:80"
+                    },
+                    "proto": {
+                      "type": "string",
+                      "default": "http",
+                      "enum": [
+                        "http",
+                        "https"
+                      ]
+                    },
+                    "token": {
+                      "type": "string"
+                    },
+                    "webhookUrl": {
+                      "type": "string",
+                      "default": "/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins"
+                    }
+                  }
+                }
+              }
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "image": {
+              "type": "object",
+              "required": [
+                "registry",
+                "repository",
+                "tag"
+              ],
+              "properties": {
+                "registry": {
+                  "type": "string",
+                  "default": "release.daocloud.io"
+                },
+                "repository": {
+                  "type": "string",
+                  "default": "amamba/amamba-event-proxy"
+                },
+                "tag": {
+                  "type": "string",
+                  "default": "v0.18.0-alpha.0"
+                }
+              }
+            },
+            "imagePullPolicy": {
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "resources": {
+              "type": "object"
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "image"
+            ]
+          }
+        },
+        "image": {
+          "type": "object",
+          "required": [
+            "registry"
+          ],
+          "properties": {
+            "registry": {
+              "type": "string",
+              "default": "docker.m.daocloud.io"
+            }
+          }
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

上游修改了 schema.values.json，没有在repackage中同步更新，导致安装依然报错：

https://github.com/amamba-io/jenkins-agent/pull/67

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

z