### PR TITLE
fix:  对齐从子chart中拷出来的values.schema.json和values.yaml

### DIFF
--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.schema.json
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/values.schema.json
@@ -1,151 +1,159 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
+  "$schema": "http://json-schema.org/schema#",
+  "required": [
+    "opentelemetry-demo-lite"
+  ],
+  "type": "object",
+  "properties": {
+    "opentelemetry-demo-lite": {
+      "type": "object",
+      "properties": {
         "opentelemetry-demo-lite": {
-            "type": "object",
-            "title": "Opentelemetry demo lite",
-            "description": "The Opentelemetry demo lite is a microservice-based distributed system. This demo aims to help users quickly and easily trial the features of DaoCloud Enterprise.",
-            "properties": {
-                "global": {
-                    "type": "object",
-                    "title": " ",
-                    "properties": {
-                        "observability": {
-                            "type": "object",
-                            "title": "Observability",
-                            "properties": {
-                                "adServiceJVMEnable": {
-                                    "type": "boolean",
-                                    "title": "Enable JVM monitor",
-                                    "description": "Enable JVM monitoring for adservice service only.",
-                                    "default": true
-                                }
-                            }
-                        },
-                        "opentelemetryDemo": {
-                            "type": "object",
-                            "title": "Service Mesh",
-                            "properties": {
-                                "istioSidecar": {
-                                    "type": "object",
-                                    "title": " ",
-                                    "properties": {
-                                        "enabled": {
-                                            "type": "boolean",
-                                            "title": "Enable Service Mesh",
-                                            "description": "Please ensure that the cluster has enabled the Istio plugin. The sidecar will be injected for all services by default.",
-                                            "default": false
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "microservices": {
-                            "type": "object",
-                            "title": "Microservices",
-                            "description": "Please ensure there are available registry instances. In case the parameters are incorrectly filled in, the services would fail to run properly. By default, only adservice and dataservice would be integrated into the Registry and Sentinel governance would be enabled.",
-                            "properties": {
-                                "nacos": {
-                                    "type": "object",
-                                    "title": "nacos settings",
-                                    "required": [
-                                        "registryName",
-                                        "registryEndpoint",
-                                        "registryServiceGroup",
-                                        "registryInstanceGroup"
-                                    ],
-                                    "properties": {
-                                        "enabled": {
-                                            "type": "boolean",
-                                            "title": "Enable Nacos",
-                                            "description": "If enabled, The Chart will deploy two extra services: dataservice and mysql. The adservice will call dataservice which uses mysql to store Ad data to get Ad data.",
-                                            "default": false
-                                        },
-                                        "registryName": {
-                                            "type": "string",
-                                            "title": "Registry name",
-                                            "default": "nacos"
-                                        },
-                                        "registryEndpoint": {
-                                            "type": "string",
-                                            "title": "Registry endpoint",
-                                            "default": "nacos:8848"
-                                        },
-                                        "registryNamespace": {
-                                            "type": "string",
-                                            "title": "Registry namespace",
-                                            "default": ""
-                                        },
-                                        "registryServiceGroup": {
-                                            "type": "string",
-                                            "title": "Registry service group",
-                                            "default": "DEFAULT_GROUP"
-                                        },
-                                        "registryInstanceGroup": {
-                                            "type": "string",
-                                            "title": "Registry instance group",
-                                            "default": "DEFAULT"
-                                        },
-                                        "username": {
-                                            "type": "string",
-                                            "title": "Username",
-                                            "default": ""
-                                        },
-                                        "password": {
-                                            "type": "string",
-                                            "title": "Password",
-                                            "default": ""
-                                        }
-                                    }
-                                },
-                                "sentinel": {
-                                    "type": "object",
-                                    "title": "Sentinel settings",
-                                    "required": [
-                                        "endpoint"
-                                    ],
-                                    "properties": {
-                                        "enabled": {
-                                            "type": "boolean",
-                                            "title": "Enable sentinel",
-                                            "description": "please ensure Nacos is enabled and that the parameters above are filled in correctly for the Registry. Meanwhile, Please ensure that Sentinel governance has been enabled in the same Registry.",
-                                            "default": false
-                                        },
-                                        "endpoint": {
-                                            "type": "string",
-                                            "title": "Endpoint",
-                                            "default": "sentinel:8080"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "middleware": {
-                            "type": "object",
-                            "title": "Middleware",
-                            "properties": {
-                                "redis": {
-                                    "type": "object",
-                                    "title": "redis settings",
-                                    "properties": {
-                                        "deployBy": {
-                                            "type": "string",
-                                            "title": "redis deploy way",
-                                            "description": "Use built-in redis by default. If you want to use a redis create by redis operater, Please chooise redisCR and make sure redis operator is ready.",
-                                            "default": "builtin",
-                                            "enum": [
-                                                "builtin",
-                                                "redisCR"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
+          "type": "object",
+          "title": "Opentelemetry demo lite",
+          "description": "The Opentelemetry demo lite is a microservice-based distributed system. This demo aims to help users quickly and easily trial the features of DaoCloud Enterprise.",
+          "properties": {
+            "global": {
+              "type": "object",
+              "title": " ",
+              "properties": {
+                "observability": {
+                  "type": "object",
+                  "title": "Observability",
+                  "properties": {
+                    "adServiceJVMEnable": {
+                      "type": "boolean",
+                      "title": "Enable JVM monitor",
+                      "description": "Enable JVM monitoring for adservice service only.",
+                      "default": true
                     }
+                  }
+                },
+                "opentelemetryDemo": {
+                  "type": "object",
+                  "title": "Service Mesh",
+                  "properties": {
+                    "istioSidecar": {
+                      "type": "object",
+                      "title": " ",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "title": "Enable Service Mesh",
+                          "description": "Please ensure that the cluster has enabled the Istio plugin. The sidecar will be injected for all services by default.",
+                          "default": false
+                        }
+                      }
+                    }
+                  }
+                },
+                "microservices": {
+                  "type": "object",
+                  "title": "Microservices",
+                  "description": "Please ensure there are available registry instances. In case the parameters are incorrectly filled in, the services would fail to run properly. By default, only adservice and dataservice would be integrated into the Registry and Sentinel governance would be enabled.",
+                  "properties": {
+                    "nacos": {
+                      "type": "object",
+                      "title": "nacos settings",
+                      "required": [
+                        "registryName",
+                        "registryEndpoint",
+                        "registryServiceGroup",
+                        "registryInstanceGroup"
+                      ],
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "title": "Enable Nacos",
+                          "description": "If enabled, The Chart will deploy two extra services: dataservice and mysql. The adservice will call dataservice which uses mysql to store Ad data to get Ad data.",
+                          "default": false
+                        },
+                        "registryName": {
+                          "type": "string",
+                          "title": "Registry name",
+                          "default": "nacos"
+                        },
+                        "registryEndpoint": {
+                          "type": "string",
+                          "title": "Registry endpoint",
+                          "default": "nacos:8848"
+                        },
+                        "registryNamespace": {
+                          "type": "string",
+                          "title": "Registry namespace",
+                          "default": ""
+                        },
+                        "registryServiceGroup": {
+                          "type": "string",
+                          "title": "Registry service group",
+                          "default": "DEFAULT_GROUP"
+                        },
+                        "registryInstanceGroup": {
+                          "type": "string",
+                          "title": "Registry instance group",
+                          "default": "DEFAULT"
+                        },
+                        "username": {
+                          "type": "string",
+                          "title": "Username",
+                          "default": ""
+                        },
+                        "password": {
+                          "type": "string",
+                          "title": "Password",
+                          "default": ""
+                        }
+                      }
+                    },
+                    "sentinel": {
+                      "type": "object",
+                      "title": "Sentinel settings",
+                      "required": [
+                        "endpoint"
+                      ],
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "title": "Enable sentinel",
+                          "description": "please ensure Nacos is enabled and that the parameters above are filled in correctly for the Registry. Meanwhile, Please ensure that Sentinel governance has been enabled in the same Registry.",
+                          "default": false
+                        },
+                        "endpoint": {
+                          "type": "string",
+                          "title": "Endpoint",
+                          "default": "sentinel:8080"
+                        }
+                      }
+                    }
+                  }
+                },
+                "middleware": {
+                  "type": "object",
+                  "title": "Middleware",
+                  "properties": {
+                    "redis": {
+                      "type": "object",
+                      "title": "redis settings",
+                      "properties": {
+                        "deployBy": {
+                          "type": "string",
+                          "title": "redis deploy way",
+                          "description": "Use built-in redis by default. If you want to use a redis create by redis operater, Please chooise redisCR and make sure redis operator is ready.",
+                          "default": "builtin",
+                          "enum": [
+                            "builtin",
+                            "redisCR"
+                          ]
+                        }
+                      }
+                    }
+                  }
                 }
+              }
             }
+          }
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

repackage 支持拷贝chart的values.schema.json到repackage后的chart中，但是因为所有被repackage的chart都是作为子chart，原始的values.schema.json 并不能生效。

为了避免需要同时在上游和repackage中更新schema的变化，在打包逻辑里增加了自动缩进

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1716 