### PR TITLE
metallb: disable frr by default

### DIFF
--- a/charts/metallb/custom.sh
+++ b/charts/metallb/custom.sh
@@ -57,6 +57,7 @@ yq -i '
    .metallb.speaker.resources.requests.memory="80Mi" |
    .metallb.speaker.resources.limits.cpu="200m" |
    .metallb.speaker.resources.limits.memory="300Mi" |
+   .metallb.speaker.frr.enabled=false |
    .metallb.speaker.frr.image.registry="quay.m.daocloud.io" |
    .metallb.speaker.frr.image.repository="frrouting/frr"
 ' values.yaml

--- a/charts/metallb/metallb/README.md
+++ b/charts/metallb/metallb/README.md
@@ -121,7 +121,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | metallb.speaker.affinity | object | `{}` |  |
 | metallb.speaker.enabled | bool | `true` |  |
 | metallb.speaker.excludeInterfaces.enabled | bool | `true` |  |
-| metallb.speaker.frr.enabled | bool | `true` |  |
+| metallb.speaker.frr.enabled | bool | `false` |  |
 | metallb.speaker.frr.image.pullPolicy | string | `nil` |  |
 | metallb.speaker.frr.image.registry | string | `"quay.m.daocloud.io"` |  |
 | metallb.speaker.frr.image.repository | string | `"frrouting/frr"` |  |

--- a/charts/metallb/metallb/values.schema.json
+++ b/charts/metallb/metallb/values.schema.json
@@ -48,6 +48,32 @@
                                     "default": "metallb/speaker"
                                 }
                             }
+                        },
+                        "frr": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable FRR",
+                                    "description": "MetalLB provides a deployment mode that uses FRR as a backend for the BGP layer, which provide IPv6 Support for BGP and BFD",
+                                    "default": false
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string",
+                                            "title": "Registry",
+                                            "default": "quay.m.daocloud.io"
+                                        },
+                                        "repository": {
+                                            "type": "string",
+                                            "title": "Repository",
+                                            "default": "frrouting/frr"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },

--- a/charts/metallb/metallb/values.yaml
+++ b/charts/metallb/metallb/values.yaml
@@ -305,7 +305,7 @@ metallb:
     # frr contains configuration specific to the MetalLB FRR container,
     # for speaker running alongside FRR.
     frr:
-      enabled: true
+      enabled: false
       image:
         repository: frrouting/frr
         tag: 8.5.2

--- a/charts/metallb/parent/values.schema.json
+++ b/charts/metallb/parent/values.schema.json
@@ -48,6 +48,32 @@
                                     "default": "metallb/speaker"
                                 }
                             }
+                        },
+                        "frr": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable FRR",
+                                    "description": "MetalLB provides a deployment mode that uses FRR as a backend for the BGP layer, which provide IPv6 Support for BGP and BFD",
+                                    "default": false
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string",
+                                            "title": "Registry",
+                                            "default": "quay.m.daocloud.io"
+                                        },
+                                        "repository": {
+                                            "type": "string",
+                                            "title": "Repository",
+                                            "default": "frrouting/frr"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

metallb: disable frr by default

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #