### PR TITLE
update spiderpool to 0.9.0

### DIFF
--- a/charts/spiderpool/config
+++ b/charts/spiderpool/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/spiderpool
 export REPO_NAME=spiderpool
 export CHART_NAME=spiderpool
-export VERSION=0.8.3
+export VERSION=0.9.0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/spiderpool/parent/values.schema.json
+++ b/charts/spiderpool/parent/values.schema.json
@@ -1,45 +1,45 @@
 {
-    "$schema":"https://json-schema.org/draft-07/schema",
-    "type":"object",
-    "properties":{
-        "spiderpool":{
-            "title":"The spiderpool Schema",
-            "type":"object",
-            "properties":{
-                "global":{
-                    "title":"Global Setting",
-                    "type":"object",
-                    "required":[
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "spiderpool": {
+            "title": "The spiderpool Schema",
+            "type": "object",
+            "properties": {
+                "global": {
+                    "title": "Global Setting",
+                    "type": "object",
+                    "required": [
                         "imageRegistryOverride"
                     ],
-                    "properties":{
-                        "imageRegistryOverride":{
-                            "title":"global image Registry",
-                            "type":"string",
-                            "default":"ghcr.m.daocloud.io",
-                            "examples":[
+                    "properties": {
+                        "imageRegistryOverride": {
+                            "title": "global image Registry",
+                            "type": "string",
+                            "default": "ghcr.m.daocloud.io",
+                            "examples": [
                                 "ghcr.m.daocloud.io"
                             ]
                         }
                     }
                 },
-                "spiderpoolAgent":{
-                    "title":"Spiderpool Agent Setting",
-                    "description":"spiderpool agent is a daemonset",
-                    "type":"object",
-                    "properties":{
-                        "image":{
-                            "title":"Spiderpool Agent Image",
-                            "type":"object",
-                            "required":[
+                "spiderpoolAgent": {
+                    "title": "Spiderpool Agent Setting",
+                    "description": "spiderpool agent is a daemonset",
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "title": "Spiderpool Agent Image",
+                            "type": "object",
+                            "required": [
                                 "repository"
                             ],
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-agent",
-                                    "examples":[
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-agent",
+                                    "examples": [
                                         "spidernet-io/spiderpool/spiderpool-agent"
                                     ]
                                 }
@@ -47,73 +47,73 @@
                         }
                     }
                 },
-                "spiderpoolController":{
-                    "title":"Spiderpool Controller Setting",
-                    "description":"spiderpool controller is a deployment",
-                    "type":"object",
-                    "required":[
+                "spiderpoolController": {
+                    "title": "Spiderpool Controller Setting",
+                    "description": "spiderpool controller is a deployment",
+                    "type": "object",
+                    "required": [
                         "replicas"
                     ],
-                    "properties":{
-                        "replicas":{
-                            "title":"replicas number",
-                            "type":"integer",
-                            "default":1,
-                            "minimum":1,
-                            "examples":[
+                    "properties": {
+                        "replicas": {
+                            "title": "replicas number",
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1,
+                            "examples": [
                                 1
                             ]
                         },
-                        "image":{
-                            "title":"Spiderpool Controller Image",
-                            "type":"object",
-                            "required":[
+                        "image": {
+                            "title": "Spiderpool Controller Image",
+                            "type": "object",
+                            "required": [
                                 "repository"
                             ],
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-controller"
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-controller"
                                 }
                             }
                         }
                     }
                 },
-                "multus":{
-                    "type":"object",
-                    "title":"Multus Setting",
-                    "properties":{
-                        "multusCNI":{
-                            "type":"object",
-                            "required":[
+                "multus": {
+                    "type": "object",
+                    "title": "Multus Setting",
+                    "properties": {
+                        "multusCNI": {
+                            "type": "object",
+                            "required": [
                                 "install"
                             ],
-                            "properties":{
-                                "install":{
-                                    "type":"boolean",
-                                    "title":"Install Multus CNI",
-                                    "description":"If you already have multus installed, you can set it to false. Default to true",
-                                    "default":true,
-                                    "examples":[
+                            "properties": {
+                                "install": {
+                                    "type": "boolean",
+                                    "title": "Install Multus CNI",
+                                    "description": "If you already have multus installed, you can set it to false. Default to true",
+                                    "default": true,
+                                    "examples": [
                                         {
-                                            "install":true
+                                            "install": true
                                         }
                                     ]
                                 },
-                                "defaultCniCRName":{
-                                    "type":"string",
-                                    "title":"Default CNI Name",
-                                    "description":"The name of cluster default CNI name. Default is \"\", If this value is empty, spiderpool will automatically get default CNI according to the existed CNI conf file in /etc/cni/net.d/"
+                                "defaultCniCRName": {
+                                    "type": "string",
+                                    "title": "Default CNI Name",
+                                    "description": "The name of cluster default CNI name. Default is \"\", If this value is empty, spiderpool will automatically get default CNI according to the existed CNI conf file in /etc/cni/net.d/"
                                 },
-                                "image":{
-                                    "type":"object",
-                                    "title":"Multus Image",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/multus-cni"
+                                "image": {
+                                    "type": "object",
+                                    "title": "Multus Image",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/multus-cni"
                                         }
                                     }
                                 }
@@ -121,104 +121,104 @@
                         }
                     }
                 },
-                "sriov":{
-                    "type":"object",
-                    "title":"SriovCNI",
-                    "properties":{
-                        "install":{
-                            "type":"boolean",
-                            "title":"Install Sriov-CNI",
-                            "description":"Install all SR-IOV components on-demand through the SRIOV operator."
+                "sriov": {
+                    "type": "object",
+                    "title": "SriovCNI",
+                    "properties": {
+                        "install": {
+                            "type": "boolean",
+                            "title": "Install Sriov-CNI",
+                            "description": "Install all SR-IOV components on-demand through the SRIOV operator."
                         },
-                        "image":{
-                            "type":"object",
-                            "properties":{
-                                "operator":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator",
-                                            "examples":[
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "operator": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovCni":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-cni",
-                                            "examples":[
+                                "sriovCni": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-cni",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-cni"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovDevicePlugin":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-device-plugin",
-                                            "examples":[
+                                "sriovDevicePlugin": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-device-plugin",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-device-plugin"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovConfigDaemon":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator-config-daemon",
-                                            "examples":[
+                                "sriovConfigDaemon": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator-config-daemon",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator-config-daemon"
                                             ]
                                         }
                                     }
                                 },
-                                "ibSriovCni":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/ib-sriov-cni",
-                                            "examples":[
+                                "ibSriovCni": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/ib-sriov-cni",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/ib-sriov-cni"
                                             ]
                                         }
                                     }
                                 },
-                                "resourcesInjector":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/network-resources-injector",
-                                            "examples":[
+                                "resourcesInjector": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/network-resources-injector",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/network-resources-injector"
                                             ]
                                         }
                                     }
                                 },
-                                "webhook":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator-webhook",
-                                            "examples":[
+                                "webhook": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator-webhook",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator-webhook"
                                             ]
                                         }
@@ -228,55 +228,55 @@
                         }
                     }
                 },
-                "rdma":{
-                    "type":"object",
-                    "properties":{
-                        "rdmaSharedDevicePlugin":{
-                            "type":"object",
-                            "title":"RdmaSharedDevicePlugin",
-                            "properties":{
-                                "install":{
-                                    "type":"boolean",
-                                    "title":"Install RdmaSharedDevicePlugin",
-                                    "description":"RdmaSharedDevicePlugin can be used with macvlan for RDMA"
+                "rdma": {
+                    "type": "object",
+                    "properties": {
+                        "rdmaSharedDevicePlugin": {
+                            "type": "object",
+                            "title": "RdmaSharedDevicePlugin",
+                            "properties": {
+                                "install": {
+                                    "type": "boolean",
+                                    "title": "Install RdmaSharedDevicePlugin",
+                                    "description": "RdmaSharedDevicePlugin can be used with macvlan for RDMA"
                                 },
-                                "image":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"mellanox/k8s-rdma-shared-dev-plugin",
-                                            "examples":[
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "mellanox/k8s-rdma-shared-dev-plugin",
+                                            "examples": [
                                                 "mellanox/k8s-rdma-shared-dev-plugin"
                                             ]
                                         }
                                     }
                                 },
-                                "deviceConfig":{
-                                    "type":"object",
-                                    "title":"RdmaSharedDevicePlugin Config",
-                                    "properties":{
-                                        "resourceName":{
-                                            "type":"string",
-                                            "default":"hca_shared_devices",
-                                            "description":"Endpoint resource name. Should not contain special characters, must be unique in the scope of the resource prefix.",
-                                            "examples":[
+                                "deviceConfig": {
+                                    "type": "object",
+                                    "title": "RdmaSharedDevicePlugin Config",
+                                    "properties": {
+                                        "resourceName": {
+                                            "type": "string",
+                                            "default": "hca_shared_devices",
+                                            "description": "Endpoint resource name. Should not contain special characters, must be unique in the scope of the resource prefix.",
+                                            "examples": [
                                                 "hca_shared_devices"
                                             ]
                                         },
-                                        "deviceIDs":{
-                                            "type":"string",
-                                            "description":"A list of devices names to be selected. Examples: \"ens6f0np0\".",
-                                            "default":"1017",
-                                            "examples":[
+                                        "vendors": {
+                                            "type": "string",
+                                            "default": "15b3",
+                                            "description": "Target device's vendor Hex code as string, Example: \"15b3\"."
+                                        },
+                                        "deviceIDs": {
+                                            "type": "string",
+                                            "description": "A list of devices IDs to be selected. Examples: \"1017\".",
+                                            "default": "1017",
+                                            "examples": [
                                                 "1017"
                                             ]
-                                        },
-                                        "vendors":{
-                                            "type":"string",
-                                            "default":"15b3",
-                                            "description":"Target device's vendor Hex code as string, Example: \"15b3\"."
                                         }
                                     }
                                 }
@@ -284,156 +284,166 @@
                         }
                     }
                 },
-                "plugins":{
-                    "type":"object",
-                    "title":"CNI-Plugins",
-                    "properties":{
-                        "image":{
-                            "type":"object",
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-plugins",
-                                    "examples":[
+                "plugins": {
+                    "type": "object",
+                    "title": "CNI-Plugins",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-plugins",
+                                    "examples": [
                                         "spidernet-io/spiderpool/spiderpool-plugins"
                                     ]
                                 }
                             }
                         },
-                        "installCNI":{
-                            "type":"boolean",
-                            "title":"install CNI-Plugins",
-                            "description":"install CNI-Plugins binary(macvlan, ipvlan, etc.) to each node. If you haven't installed it, you can set it to true. Default to false",
-                            "default":false,
-                            "examples":[
+                        "installCNI": {
+                            "type": "boolean",
+                            "title": "install CNI-Plugins",
+                            "description": "install CNI-Plugins binary(macvlan, ipvlan, etc.) to each node. If you haven't installed it, you can set it to true. Default to false",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "installRdmaCNI":{
-                            "type":"boolean",
-                            "title":"install RDMA-CNI",
-                            "description":"install RDMA-CNI plugin binary to each node. If you haven't installed it, you can set it to true. Default to false",
-                            "default":false,
-                            "examples":[
+                        "installRdmaCNI": {
+                            "type": "boolean",
+                            "title": "install RDMA-CNI",
+                            "description": "install RDMA-CNI plugin binary to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": true,
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "installibSriovCNI": {
+                            "type": "boolean",
+                            "title": "install ibSriov-CNI",
+                            "description": "install ib-sriov cni to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": false,
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "installIpoibCNI": {
+                            "type": "boolean",
+                            "title": "install Ipoib-CNI",
+                            "description": "install Ipoib cni to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         }
                     }
                 },
-                "ipam":{
-                    "title":"IP Family Setting",
-                    "type":"object",
-                    "default":{
-                        
-                    },
-                    "required":[
+                "ipam": {
+                    "title": "IP Family Setting",
+                    "type": "object",
+                    "default": {},
+                    "required": [
                         "enableIPv4",
                         "enableIPv6"
                     ],
-                    "properties":{
-                        "enableIPv4":{
-                            "title":"enable IPv4",
-                            "description":"enable IPAM IPv4 feature. Notice: required to create IPv4 ippool",
-                            "type":"boolean",
-                            "default":true,
-                            "examples":[
+                    "properties": {
+                        "enableIPv4": {
+                            "title": "enable IPv4",
+                            "description": "enable IPAM IPv4 feature. Notice: required to create IPv4 ippool",
+                            "type": "boolean",
+                            "default": true,
+                            "examples": [
                                 true
                             ]
                         },
-                        "enableIPv6":{
-                            "title":"enable IPv6",
-                            "description":"enable IPAM IPv6 feature. Notice: required to create IPv6 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                        "enableIPv6": {
+                            "title": "enable IPv6",
+                            "description": "enable IPAM IPv6 feature. Notice: required to create IPv6 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 true
                             ]
                         }
                     }
                 },
-                "clusterDefaultPool":{
-                    "title":"Cluster Default Ippool Installation",
-                    "type":"object",
-                    "default":{
-                        
-                    },
-                    "required":[
+                "clusterDefaultPool": {
+                    "title": "Cluster Default Ippool Installation",
+                    "type": "object",
+                    "default": {},
+                    "required": [
                         "installIPv4IPPool",
                         "installIPv6IPPool"
                     ],
-                    "properties":{
-                        "installIPv4IPPool":{
-                            "title":"install IPv4 ippool",
-                            "description":"when 'enable IPv4', required to install IPv4 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                    "properties": {
+                        "installIPv4IPPool": {
+                            "title": "install IPv4 ippool",
+                            "description": "when 'enable IPv4', required to install IPv4 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "installIPv6IPPool":{
-                            "title":"install IPv6 ippool",
-                            "description":"when 'enable IPv6', required to install IPv6 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                        "installIPv6IPPool": {
+                            "title": "install IPv6 ippool",
+                            "description": "when 'enable IPv6', required to install IPv6 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "ipv4Subnet":{
-                            "title":"IPv4 ippool subnet",
-                            "type":"string",
-                            "default":"192.168.1.0/24",
-                            "examples":[
+                        "ipv4Subnet": {
+                            "title": "IPv4 ippool subnet",
+                            "type": "string",
+                            "default": "192.168.1.0/24",
+                            "examples": [
                                 "192.168.1.0/24"
                             ]
                         },
-                        "ipv6Subnet":{
-                            "title":"IPv6 ippool subnet",
-                            "type":"string",
-                            "default":"fd00::/64",
-                            "examples":[
+                        "ipv6Subnet": {
+                            "title": "IPv6 ippool subnet",
+                            "type": "string",
+                            "default": "fd00::/64",
+                            "examples": [
                                 "fd00::/64"
                             ]
                         },
-                        "ipv4Gateway":{
-                            "title":"IPv4 ippool gateway",
-                            "default":"192.168.1.1",
-                            "type":"string"
+                        "ipv4Gateway": {
+                            "title": "IPv4 ippool gateway",
+                            "default": "192.168.1.1",
+                            "type": "string"
                         },
-                        "ipv6Gateway":{
-                            "title":"IPv6 ippool gateway",
-                            "default":"fd00::1",
-                            "type":"string"
+                        "ipv6Gateway": {
+                            "title": "IPv6 ippool gateway",
+                            "default": "fd00::1",
+                            "type": "string"
                         },
-                        "ipv4IPRanges":{
-                            "title":"IP Ranges for default IPv4 ippool",
-                            "type":"array",
-                            "description":"each item could be range format like '192.168.0.10-192.168.0.100', or comma format like '192.168.0.10,192.168.0.11,192.168.0.12'. Notice: all IP address must belong to ipv4Subnet",
-                            "default":[
-                                
-                            ],
-                            "items":{
-                                "type":"string"
+                        "ipv4IPRanges": {
+                            "title": "IP Ranges for default IPv4 ippool",
+                            "type": "array",
+                            "description": "each item could be range format like '192.168.0.10-192.168.0.100', or comma format like '192.168.0.10,192.168.0.11,192.168.0.12'. Notice: all IP address must belong to ipv4Subnet",
+                            "default": [],
+                            "items": {
+                                "type": "string"
                             },
-                            "examples":[
+                            "examples": [
                                 [
                                     "192.168.1.10-192.168.1.200"
                                 ]
                             ]
                         },
-                        "ipv6IPRanges":{
-                            "title":"IP Ranges for default IPv6 ippool",
-                            "type":"array",
-                            "description":"each item could be range format like 'fd00::10-fd00::200', or comma format like 'fd00::10,fd00::20,fd00::30'. Notice: all IP address must belong to ipv6Subnet ",
-                            "default":[
-                                
-                            ],
-                            "items":{
-                                "type":"string"
+                        "ipv6IPRanges": {
+                            "title": "IP Ranges for default IPv6 ippool",
+                            "type": "array",
+                            "description": "each item could be range format like 'fd00::10-fd00::200', or comma format like 'fd00::10,fd00::20,fd00::30'. Notice: all IP address must belong to ipv6Subnet ",
+                            "default": [],
+                            "items": {
+                                "type": "string"
                             },
-                            "examples":[
+                            "examples": [
                                 [
                                     "fd00::10-fd00::200"
                                 ]

--- a/charts/spiderpool/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.8.3
+appVersion: 0.9.0
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,8 +16,8 @@ name: spiderpool
 sources:
   - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.8.3
+version: 0.9.0
 dependencies:
   - name: spiderpool
-    version: "0.8.3"
+    version: "0.9.0"
     repository: "https://spidernet-io.github.io/spiderpool"

--- a/charts/spiderpool/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/README.md
@@ -214,13 +214,15 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | Name                             | Description                                                | Value                                        |
 | -------------------------------- | ---------------------------------------------------------- | -------------------------------------------- |
 | `plugins.installCNI`             | install all cni plugins to each node                       | `false`                                      |
-| `plugins.installRdmaCNI`         | install rdma cni used to isolate rdma device for sriov cni | `false`                                      |
-| `plugins.installOvsCNI`          | install ovs cni to each node                               | `false`                                      |
+| `plugins.installRdmaCNI`         | install rdma cni used to isolate rdma device for sriov cni | `true`                                       |
+| `plugins.installOvsCNI`          | install ovs cni to each node                               | `true`                                       |
+| `plugins.installibSriovCNI`      | install ib-sriov cni to each node                          | `true`                                       |
+| `plugins.installIpoibCNI`        | install ipoib cni to each node                             | `true`                                       |
 | `plugins.image.registry`         | the image registry of plugins                              | `ghcr.io`                                    |
 | `plugins.image.repository`       | the image repository of plugins                            | `spidernet-io/spiderpool/spiderpool-plugins` |
 | `plugins.image.pullPolicy`       | the image pullPolicy of plugins                            | `IfNotPresent`                               |
 | `plugins.image.digest`           | the image digest of plugins                                | `""`                                         |
-| `plugins.image.tag`              | the image tag of plugins                                   | `v0.8.0`                                     |
+| `plugins.image.tag`              | the image tag of plugins                                   | `v0.9.2`                                     |
 | `plugins.image.imagePullSecrets` | the image imagePullSecrets of plugins                      | `[]`                                         |
 
 ### clusterDefaultPool parameters

--- a/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.8.3
+appVersion: 0.9.0
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,4 +16,4 @@ name: spiderpool
 sources:
 - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.8.3
+version: 0.9.0

--- a/charts/spiderpool/spiderpool/charts/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/README.md
@@ -214,13 +214,15 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | Name                             | Description                                                | Value                                        |
 | -------------------------------- | ---------------------------------------------------------- | -------------------------------------------- |
 | `plugins.installCNI`             | install all cni plugins to each node                       | `false`                                      |
-| `plugins.installRdmaCNI`         | install rdma cni used to isolate rdma device for sriov cni | `false`                                      |
-| `plugins.installOvsCNI`          | install ovs cni to each node                               | `false`                                      |
+| `plugins.installRdmaCNI`         | install rdma cni used to isolate rdma device for sriov cni | `true`                                       |
+| `plugins.installOvsCNI`          | install ovs cni to each node                               | `true`                                       |
+| `plugins.installibSriovCNI`      | install ib-sriov cni to each node                          | `true`                                       |
+| `plugins.installIpoibCNI`        | install ipoib cni to each node                             | `true`                                       |
 | `plugins.image.registry`         | the image registry of plugins                              | `ghcr.io`                                    |
 | `plugins.image.repository`       | the image repository of plugins                            | `spidernet-io/spiderpool/spiderpool-plugins` |
 | `plugins.image.pullPolicy`       | the image pullPolicy of plugins                            | `IfNotPresent`                               |
 | `plugins.image.digest`           | the image digest of plugins                                | `""`                                         |
-| `plugins.image.tag`              | the image tag of plugins                                   | `v0.8.0`                                     |
+| `plugins.image.tag`              | the image tag of plugins                                   | `v0.9.2`                                     |
 | `plugins.image.imagePullSecrets` | the image imagePullSecrets of plugins                      | `[]`                                         |
 
 ### clusterDefaultPool parameters

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
@@ -75,6 +75,8 @@ spec:
                 type: string
               tunePodRoutes:
                 type: boolean
+              txQueueLen:
+                type: integer
             type: object
           status:
             description: CoordinationStatus defines the observed state of SpiderCoordinator.

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -38,11 +38,14 @@ spec:
             description: Spec is the specification of the MultusCNIConfig
             properties:
               cniType:
+                default: custom
                 enum:
                 - macvlan
                 - ipvlan
                 - sriov
                 - ovs
+                - ib-sriov
+                - ipoib
                 - custom
                 type: string
               coordinator:
@@ -85,6 +88,8 @@ spec:
                     type: string
                   tunePodRoutes:
                     type: boolean
+                  txQueueLen:
+                    type: integer
                 type: object
               customCNI:
                 description: OtherCniTypeConfig only used for CniType custom, valid
@@ -95,7 +100,62 @@ spec:
                 type: boolean
               enableCoordinator:
                 default: true
+                description: if CniType was set to custom, we'll mutate this field
+                  to be false
                 type: boolean
+              ibsriov:
+                properties:
+                  ibKubernetesEnabled:
+                    default: false
+                    type: boolean
+                  ippools:
+                    description: SpiderpoolPools could specify the IPAM spiderpool
+                      CNI configuration default IPv4&IPv6 pools.
+                    properties:
+                      ipv4:
+                        items:
+                          type: string
+                        type: array
+                      ipv6:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  linkState:
+                    default: enable
+                    enum:
+                    - auto
+                    - enable
+                    - disable
+                    type: string
+                  pkey:
+                    type: string
+                  rdmaIsolation:
+                    default: true
+                    type: boolean
+                  resourceName:
+                    type: string
+                required:
+                - resourceName
+                type: object
+              ipoib:
+                properties:
+                  ippools:
+                    description: SpiderpoolPools could specify the IPAM spiderpool
+                      CNI configuration default IPv4&IPv6 pools.
+                    properties:
+                      ipv4:
+                        items:
+                          type: string
+                        type: array
+                      ipv6:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  master:
+                    type: string
+                type: object
               ipvlan:
                 properties:
                   bond:
@@ -257,8 +317,6 @@ spec:
                 required:
                 - resourceName
                 type: object
-            required:
-            - cniType
             type: object
         type: object
     served: true

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
                       - linux
       {{- end }}
       initContainers:
-        {{- if or .Values.plugins.installCNI .Values.plugins.installRdmaCNI .Values.plugins.installOvsCNI }}
+        {{- if or .Values.plugins.installCNI .Values.plugins.installRdmaCNI .Values.plugins.installOvsCNI .Values.plugins.installibSriovCNI .Values.plugins.installIpoibCNI }}
         - name: install-plugins
           image: {{ include "plugins.image" . | quote }}
           imagePullPolicy: {{ .Values.plugins.image.pullPolicy }}
@@ -91,6 +91,10 @@ spec:
             value: {{ .Values.plugins.installOvsCNI | quote }}
           - name: INSTALL_RDMA_PLUGIN
             value: {{ .Values.plugins.installRdmaCNI | quote }}
+          - name: INSTALL_IB_SRIOV_PLUGIN
+            value: {{ .Values.plugins.installibSriovCNI | quote }}
+          - name: INSTALL_IPOIB_PLUGIN
+            value: {{ .Values.plugins.installIpoibCNI | quote }}
           command:
             - "/bin/sh"
             - "entrypoint.sh"
@@ -205,9 +209,11 @@ spec:
               - "/bin/sh"
               - "-c"
               - | 
+                {{- if .Values.multus.multusCNI.uninstall }}
                 rm -f /host/opt/cni/bin/multus || true
                 rm -rf /host/etc/cni/net.d/multus.d || true
                 rm -f /host/etc/cni/net.d/00-multus.conf || true
+                {{- end }}
                 {{ .Values.spiderpoolAgent.binName }} shutdown
         env:
         - name: SPIDERPOOL_POD_NAME
@@ -249,6 +255,10 @@ spec:
           mountPath: /host{{ .Values.global.cniBinHostPath }}
         - name: ipam-unix-socket-dir
           mountPath: {{ dir .Values.global.ipamUNIXSocketHostPath }}
+        {{- if .Values.multus.multusCNI.uninstall }}
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        {{- end }}
         {{- if .Values.spiderpoolAgent.extraVolumes }}
         {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.extraVolumeMounts "context" $ ) | nindent 8 }}
         {{- end }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
@@ -265,10 +265,16 @@ plugins:
   installCNI: false
 
   ## @param plugins.installRdmaCNI install rdma cni used to isolate rdma device for sriov cni
-  installRdmaCNI: false
+  installRdmaCNI: true
 
   ## @param plugins.installOvsCNI install ovs cni to each node
-  installOvsCNI: false
+  installOvsCNI: true
+
+  ## @param plugins.installibSriovCNI install ib-sriov cni to each node
+  installibSriovCNI: true
+
+  ## @param plugins.installIpoibCNI install ipoib cni to each node
+  installIpoibCNI: true
 
   image:
     ## @param plugins.image.registry the image registry of plugins
@@ -284,7 +290,7 @@ plugins:
     digest: ""
 
     ## @param plugins.image.tag the image tag of plugins
-    tag: v0.8.0
+    tag: v0.9.2
 
     ## @param plugins.image.imagePullSecrets the image imagePullSecrets of plugins
     imagePullSecrets: []
@@ -351,7 +357,7 @@ spiderpoolAgent:
     digest: ""
 
     ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-    tag: v0.8.3
+    tag: v0.9.0
 
     ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
     imagePullSecrets: []
@@ -535,7 +541,7 @@ spiderpoolController:
     digest: ""
 
     ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-    tag: v0.8.3
+    tag: v0.9.0
 
     ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
     imagePullSecrets: []
@@ -766,7 +772,7 @@ spiderpoolInit:
     digest: ""
 
     ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-    tag: v0.8.3
+    tag: v0.9.0
 
     ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
     imagePullSecrets: []

--- a/charts/spiderpool/spiderpool/values.schema.json
+++ b/charts/spiderpool/spiderpool/values.schema.json
@@ -1,45 +1,45 @@
 {
-    "$schema":"https://json-schema.org/draft-07/schema",
-    "type":"object",
-    "properties":{
-        "spiderpool":{
-            "title":"The spiderpool Schema",
-            "type":"object",
-            "properties":{
-                "global":{
-                    "title":"Global Setting",
-                    "type":"object",
-                    "required":[
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "spiderpool": {
+            "title": "The spiderpool Schema",
+            "type": "object",
+            "properties": {
+                "global": {
+                    "title": "Global Setting",
+                    "type": "object",
+                    "required": [
                         "imageRegistryOverride"
                     ],
-                    "properties":{
-                        "imageRegistryOverride":{
-                            "title":"global image Registry",
-                            "type":"string",
-                            "default":"ghcr.m.daocloud.io",
-                            "examples":[
+                    "properties": {
+                        "imageRegistryOverride": {
+                            "title": "global image Registry",
+                            "type": "string",
+                            "default": "ghcr.m.daocloud.io",
+                            "examples": [
                                 "ghcr.m.daocloud.io"
                             ]
                         }
                     }
                 },
-                "spiderpoolAgent":{
-                    "title":"Spiderpool Agent Setting",
-                    "description":"spiderpool agent is a daemonset",
-                    "type":"object",
-                    "properties":{
-                        "image":{
-                            "title":"Spiderpool Agent Image",
-                            "type":"object",
-                            "required":[
+                "spiderpoolAgent": {
+                    "title": "Spiderpool Agent Setting",
+                    "description": "spiderpool agent is a daemonset",
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "title": "Spiderpool Agent Image",
+                            "type": "object",
+                            "required": [
                                 "repository"
                             ],
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-agent",
-                                    "examples":[
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-agent",
+                                    "examples": [
                                         "spidernet-io/spiderpool/spiderpool-agent"
                                     ]
                                 }
@@ -47,73 +47,73 @@
                         }
                     }
                 },
-                "spiderpoolController":{
-                    "title":"Spiderpool Controller Setting",
-                    "description":"spiderpool controller is a deployment",
-                    "type":"object",
-                    "required":[
+                "spiderpoolController": {
+                    "title": "Spiderpool Controller Setting",
+                    "description": "spiderpool controller is a deployment",
+                    "type": "object",
+                    "required": [
                         "replicas"
                     ],
-                    "properties":{
-                        "replicas":{
-                            "title":"replicas number",
-                            "type":"integer",
-                            "default":1,
-                            "minimum":1,
-                            "examples":[
+                    "properties": {
+                        "replicas": {
+                            "title": "replicas number",
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1,
+                            "examples": [
                                 1
                             ]
                         },
-                        "image":{
-                            "title":"Spiderpool Controller Image",
-                            "type":"object",
-                            "required":[
+                        "image": {
+                            "title": "Spiderpool Controller Image",
+                            "type": "object",
+                            "required": [
                                 "repository"
                             ],
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-controller"
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-controller"
                                 }
                             }
                         }
                     }
                 },
-                "multus":{
-                    "type":"object",
-                    "title":"Multus Setting",
-                    "properties":{
-                        "multusCNI":{
-                            "type":"object",
-                            "required":[
+                "multus": {
+                    "type": "object",
+                    "title": "Multus Setting",
+                    "properties": {
+                        "multusCNI": {
+                            "type": "object",
+                            "required": [
                                 "install"
                             ],
-                            "properties":{
-                                "install":{
-                                    "type":"boolean",
-                                    "title":"Install Multus CNI",
-                                    "description":"If you already have multus installed, you can set it to false. Default to true",
-                                    "default":true,
-                                    "examples":[
+                            "properties": {
+                                "install": {
+                                    "type": "boolean",
+                                    "title": "Install Multus CNI",
+                                    "description": "If you already have multus installed, you can set it to false. Default to true",
+                                    "default": true,
+                                    "examples": [
                                         {
-                                            "install":true
+                                            "install": true
                                         }
                                     ]
                                 },
-                                "defaultCniCRName":{
-                                    "type":"string",
-                                    "title":"Default CNI Name",
-                                    "description":"The name of cluster default CNI name. Default is \"\", If this value is empty, spiderpool will automatically get default CNI according to the existed CNI conf file in /etc/cni/net.d/"
+                                "defaultCniCRName": {
+                                    "type": "string",
+                                    "title": "Default CNI Name",
+                                    "description": "The name of cluster default CNI name. Default is \"\", If this value is empty, spiderpool will automatically get default CNI according to the existed CNI conf file in /etc/cni/net.d/"
                                 },
-                                "image":{
-                                    "type":"object",
-                                    "title":"Multus Image",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/multus-cni"
+                                "image": {
+                                    "type": "object",
+                                    "title": "Multus Image",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/multus-cni"
                                         }
                                     }
                                 }
@@ -121,104 +121,104 @@
                         }
                     }
                 },
-                "sriov":{
-                    "type":"object",
-                    "title":"SriovCNI",
-                    "properties":{
-                        "install":{
-                            "type":"boolean",
-                            "title":"Install Sriov-CNI",
-                            "description":"Install all SR-IOV components on-demand through the SRIOV operator."
+                "sriov": {
+                    "type": "object",
+                    "title": "SriovCNI",
+                    "properties": {
+                        "install": {
+                            "type": "boolean",
+                            "title": "Install Sriov-CNI",
+                            "description": "Install all SR-IOV components on-demand through the SRIOV operator."
                         },
-                        "image":{
-                            "type":"object",
-                            "properties":{
-                                "operator":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator",
-                                            "examples":[
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "operator": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovCni":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-cni",
-                                            "examples":[
+                                "sriovCni": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-cni",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-cni"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovDevicePlugin":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-device-plugin",
-                                            "examples":[
+                                "sriovDevicePlugin": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-device-plugin",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-device-plugin"
                                             ]
                                         }
                                     }
                                 },
-                                "sriovConfigDaemon":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator-config-daemon",
-                                            "examples":[
+                                "sriovConfigDaemon": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator-config-daemon",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator-config-daemon"
                                             ]
                                         }
                                     }
                                 },
-                                "ibSriovCni":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/ib-sriov-cni",
-                                            "examples":[
+                                "ibSriovCni": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/ib-sriov-cni",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/ib-sriov-cni"
                                             ]
                                         }
                                     }
                                 },
-                                "resourcesInjector":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/network-resources-injector",
-                                            "examples":[
+                                "resourcesInjector": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/network-resources-injector",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/network-resources-injector"
                                             ]
                                         }
                                     }
                                 },
-                                "webhook":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"k8snetworkplumbingwg/sriov-network-operator-webhook",
-                                            "examples":[
+                                "webhook": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "k8snetworkplumbingwg/sriov-network-operator-webhook",
+                                            "examples": [
                                                 "k8snetworkplumbingwg/sriov-network-operator-webhook"
                                             ]
                                         }
@@ -228,55 +228,55 @@
                         }
                     }
                 },
-                "rdma":{
-                    "type":"object",
-                    "properties":{
-                        "rdmaSharedDevicePlugin":{
-                            "type":"object",
-                            "title":"RdmaSharedDevicePlugin",
-                            "properties":{
-                                "install":{
-                                    "type":"boolean",
-                                    "title":"Install RdmaSharedDevicePlugin",
-                                    "description":"RdmaSharedDevicePlugin can be used with macvlan for RDMA"
+                "rdma": {
+                    "type": "object",
+                    "properties": {
+                        "rdmaSharedDevicePlugin": {
+                            "type": "object",
+                            "title": "RdmaSharedDevicePlugin",
+                            "properties": {
+                                "install": {
+                                    "type": "boolean",
+                                    "title": "Install RdmaSharedDevicePlugin",
+                                    "description": "RdmaSharedDevicePlugin can be used with macvlan for RDMA"
                                 },
-                                "image":{
-                                    "type":"object",
-                                    "properties":{
-                                        "repository":{
-                                            "title":"repository",
-                                            "type":"string",
-                                            "default":"mellanox/k8s-rdma-shared-dev-plugin",
-                                            "examples":[
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "title": "repository",
+                                            "type": "string",
+                                            "default": "mellanox/k8s-rdma-shared-dev-plugin",
+                                            "examples": [
                                                 "mellanox/k8s-rdma-shared-dev-plugin"
                                             ]
                                         }
                                     }
                                 },
-                                "deviceConfig":{
-                                    "type":"object",
-                                    "title":"RdmaSharedDevicePlugin Config",
-                                    "properties":{
-                                        "resourceName":{
-                                            "type":"string",
-                                            "default":"hca_shared_devices",
-                                            "description":"Endpoint resource name. Should not contain special characters, must be unique in the scope of the resource prefix.",
-                                            "examples":[
+                                "deviceConfig": {
+                                    "type": "object",
+                                    "title": "RdmaSharedDevicePlugin Config",
+                                    "properties": {
+                                        "resourceName": {
+                                            "type": "string",
+                                            "default": "hca_shared_devices",
+                                            "description": "Endpoint resource name. Should not contain special characters, must be unique in the scope of the resource prefix.",
+                                            "examples": [
                                                 "hca_shared_devices"
                                             ]
                                         },
-                                        "deviceIDs":{
-                                            "type":"string",
-                                            "description":"A list of devices names to be selected. Examples: \"ens6f0np0\".",
-                                            "default":"1017",
-                                            "examples":[
+                                        "vendors": {
+                                            "type": "string",
+                                            "default": "15b3",
+                                            "description": "Target device's vendor Hex code as string, Example: \"15b3\"."
+                                        },
+                                        "deviceIDs": {
+                                            "type": "string",
+                                            "description": "A list of devices IDs to be selected. Examples: \"1017\".",
+                                            "default": "1017",
+                                            "examples": [
                                                 "1017"
                                             ]
-                                        },
-                                        "vendors":{
-                                            "type":"string",
-                                            "default":"15b3",
-                                            "description":"Target device's vendor Hex code as string, Example: \"15b3\"."
                                         }
                                     }
                                 }
@@ -284,156 +284,166 @@
                         }
                     }
                 },
-                "plugins":{
-                    "type":"object",
-                    "title":"CNI-Plugins",
-                    "properties":{
-                        "image":{
-                            "type":"object",
-                            "properties":{
-                                "repository":{
-                                    "title":"repository",
-                                    "type":"string",
-                                    "default":"spidernet-io/spiderpool/spiderpool-plugins",
-                                    "examples":[
+                "plugins": {
+                    "type": "object",
+                    "title": "CNI-Plugins",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "spidernet-io/spiderpool/spiderpool-plugins",
+                                    "examples": [
                                         "spidernet-io/spiderpool/spiderpool-plugins"
                                     ]
                                 }
                             }
                         },
-                        "installCNI":{
-                            "type":"boolean",
-                            "title":"install CNI-Plugins",
-                            "description":"install CNI-Plugins binary(macvlan, ipvlan, etc.) to each node. If you haven't installed it, you can set it to true. Default to false",
-                            "default":false,
-                            "examples":[
+                        "installCNI": {
+                            "type": "boolean",
+                            "title": "install CNI-Plugins",
+                            "description": "install CNI-Plugins binary(macvlan, ipvlan, etc.) to each node. If you haven't installed it, you can set it to true. Default to false",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "installRdmaCNI":{
-                            "type":"boolean",
-                            "title":"install RDMA-CNI",
-                            "description":"install RDMA-CNI plugin binary to each node. If you haven't installed it, you can set it to true. Default to false",
-                            "default":false,
-                            "examples":[
+                        "installRdmaCNI": {
+                            "type": "boolean",
+                            "title": "install RDMA-CNI",
+                            "description": "install RDMA-CNI plugin binary to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": true,
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "installibSriovCNI": {
+                            "type": "boolean",
+                            "title": "install ibSriov-CNI",
+                            "description": "install ib-sriov cni to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": false,
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "installIpoibCNI": {
+                            "type": "boolean",
+                            "title": "install Ipoib-CNI",
+                            "description": "install Ipoib cni to each node. If you haven't installed it, you can set it to true. Default to true",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         }
                     }
                 },
-                "ipam":{
-                    "title":"IP Family Setting",
-                    "type":"object",
-                    "default":{
-                        
-                    },
-                    "required":[
+                "ipam": {
+                    "title": "IP Family Setting",
+                    "type": "object",
+                    "default": {},
+                    "required": [
                         "enableIPv4",
                         "enableIPv6"
                     ],
-                    "properties":{
-                        "enableIPv4":{
-                            "title":"enable IPv4",
-                            "description":"enable IPAM IPv4 feature. Notice: required to create IPv4 ippool",
-                            "type":"boolean",
-                            "default":true,
-                            "examples":[
+                    "properties": {
+                        "enableIPv4": {
+                            "title": "enable IPv4",
+                            "description": "enable IPAM IPv4 feature. Notice: required to create IPv4 ippool",
+                            "type": "boolean",
+                            "default": true,
+                            "examples": [
                                 true
                             ]
                         },
-                        "enableIPv6":{
-                            "title":"enable IPv6",
-                            "description":"enable IPAM IPv6 feature. Notice: required to create IPv6 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                        "enableIPv6": {
+                            "title": "enable IPv6",
+                            "description": "enable IPAM IPv6 feature. Notice: required to create IPv6 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 true
                             ]
                         }
                     }
                 },
-                "clusterDefaultPool":{
-                    "title":"Cluster Default Ippool Installation",
-                    "type":"object",
-                    "default":{
-                        
-                    },
-                    "required":[
+                "clusterDefaultPool": {
+                    "title": "Cluster Default Ippool Installation",
+                    "type": "object",
+                    "default": {},
+                    "required": [
                         "installIPv4IPPool",
                         "installIPv6IPPool"
                     ],
-                    "properties":{
-                        "installIPv4IPPool":{
-                            "title":"install IPv4 ippool",
-                            "description":"when 'enable IPv4', required to install IPv4 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                    "properties": {
+                        "installIPv4IPPool": {
+                            "title": "install IPv4 ippool",
+                            "description": "when 'enable IPv4', required to install IPv4 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "installIPv6IPPool":{
-                            "title":"install IPv6 ippool",
-                            "description":"when 'enable IPv6', required to install IPv6 ippool",
-                            "type":"boolean",
-                            "default":false,
-                            "examples":[
+                        "installIPv6IPPool": {
+                            "title": "install IPv6 ippool",
+                            "description": "when 'enable IPv6', required to install IPv6 ippool",
+                            "type": "boolean",
+                            "default": false,
+                            "examples": [
                                 false
                             ]
                         },
-                        "ipv4Subnet":{
-                            "title":"IPv4 ippool subnet",
-                            "type":"string",
-                            "default":"192.168.1.0/24",
-                            "examples":[
+                        "ipv4Subnet": {
+                            "title": "IPv4 ippool subnet",
+                            "type": "string",
+                            "default": "192.168.1.0/24",
+                            "examples": [
                                 "192.168.1.0/24"
                             ]
                         },
-                        "ipv6Subnet":{
-                            "title":"IPv6 ippool subnet",
-                            "type":"string",
-                            "default":"fd00::/64",
-                            "examples":[
+                        "ipv6Subnet": {
+                            "title": "IPv6 ippool subnet",
+                            "type": "string",
+                            "default": "fd00::/64",
+                            "examples": [
                                 "fd00::/64"
                             ]
                         },
-                        "ipv4Gateway":{
-                            "title":"IPv4 ippool gateway",
-                            "default":"192.168.1.1",
-                            "type":"string"
+                        "ipv4Gateway": {
+                            "title": "IPv4 ippool gateway",
+                            "default": "192.168.1.1",
+                            "type": "string"
                         },
-                        "ipv6Gateway":{
-                            "title":"IPv6 ippool gateway",
-                            "default":"fd00::1",
-                            "type":"string"
+                        "ipv6Gateway": {
+                            "title": "IPv6 ippool gateway",
+                            "default": "fd00::1",
+                            "type": "string"
                         },
-                        "ipv4IPRanges":{
-                            "title":"IP Ranges for default IPv4 ippool",
-                            "type":"array",
-                            "description":"each item could be range format like '192.168.0.10-192.168.0.100', or comma format like '192.168.0.10,192.168.0.11,192.168.0.12'. Notice: all IP address must belong to ipv4Subnet",
-                            "default":[
-                                
-                            ],
-                            "items":{
-                                "type":"string"
+                        "ipv4IPRanges": {
+                            "title": "IP Ranges for default IPv4 ippool",
+                            "type": "array",
+                            "description": "each item could be range format like '192.168.0.10-192.168.0.100', or comma format like '192.168.0.10,192.168.0.11,192.168.0.12'. Notice: all IP address must belong to ipv4Subnet",
+                            "default": [],
+                            "items": {
+                                "type": "string"
                             },
-                            "examples":[
+                            "examples": [
                                 [
                                     "192.168.1.10-192.168.1.200"
                                 ]
                             ]
                         },
-                        "ipv6IPRanges":{
-                            "title":"IP Ranges for default IPv6 ippool",
-                            "type":"array",
-                            "description":"each item could be range format like 'fd00::10-fd00::200', or comma format like 'fd00::10,fd00::20,fd00::30'. Notice: all IP address must belong to ipv6Subnet ",
-                            "default":[
-                                
-                            ],
-                            "items":{
-                                "type":"string"
+                        "ipv6IPRanges": {
+                            "title": "IP Ranges for default IPv6 ippool",
+                            "type": "array",
+                            "description": "each item could be range format like 'fd00::10-fd00::200', or comma format like 'fd00::10,fd00::20,fd00::30'. Notice: all IP address must belong to ipv6Subnet ",
+                            "default": [],
+                            "items": {
+                                "type": "string"
                             },
-                            "examples":[
+                            "examples": [
                                 [
                                     "fd00::10-fd00::200"
                                 ]

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -202,9 +202,13 @@ spiderpool:
     ## @param plugins.installCNI install all cni plugins to each node
     installCNI: false
     ## @param plugins.installRdmaCNI install rdma cni used to isolate rdma device for sriov cni
-    installRdmaCNI: false
+    installRdmaCNI: true
     ## @param plugins.installOvsCNI install ovs cni to each node
-    installOvsCNI: false
+    installOvsCNI: true
+    ## @param plugins.installibSriovCNI install ib-sriov cni to each node
+    installibSriovCNI: true
+    ## @param plugins.installIpoibCNI install ipoib cni to each node
+    installIpoibCNI: true
     image:
       ## @param plugins.image.registry the image registry of plugins
       registry: ghcr.m.daocloud.io
@@ -215,7 +219,7 @@ spiderpool:
       ## @param plugins.image.digest the image digest of plugins
       digest: ""
       ## @param plugins.image.tag the image tag of plugins
-      tag: v0.8.0
+      tag: v0.9.2
       ## @param plugins.image.imagePullSecrets the image imagePullSecrets of plugins
       imagePullSecrets: []
   ## @section clusterDefaultPool parameters
@@ -264,7 +268,7 @@ spiderpool:
       ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
       digest: ""
       ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-      tag: v0.8.3
+      tag: v0.9.0
       ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -402,7 +406,7 @@ spiderpool:
       ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
       digest: ""
       ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-      tag: v0.8.3
+      tag: v0.9.0
       ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -579,7 +583,7 @@ spiderpool:
       ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
       digest: ""
       ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-      tag: v0.8.3
+      tag: v0.9.0
       ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
       imagePullSecrets: []
       # - name: "image-pull-secret"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:


- update spiderpool to 0.9.0
- ibsriov-cni and ipoib-cni are supported.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #