### PR TITLE
metallb: opt resource usage

### DIFF
--- a/charts/metallb/custom.sh
+++ b/charts/metallb/custom.sh
@@ -46,10 +46,10 @@ yq -i '
    .metallb.controller.image.tag=strenv(IMAGE_VERSION) |
    .metallb.controller.image.registry="quay.m.daocloud.io" |
    .metallb.controller.image.repository="metallb/controller" |
-   .metallb.controller.resources.requests.cpu="10m" |
-   .metallb.controller.resources.requests.memory="50Mi" |
-   .metallb.controller.resources.limits.cpu="100m" |
-   .metallb.controller.resources.limits.memory="200Mi" |
+   .metallb.controller.resources.requests.cpu="50m" |
+   .metallb.controller.resources.requests.memory="100Mi" |
+   .metallb.controller.resources.limits.cpu="500m" |
+   .metallb.controller.resources.limits.memory="500Mi" |
    .metallb.speaker.image.registry="quay.m.daocloud.io" |
    .metallb.speaker.image.repository="metallb/speaker" |
    .metallb.speaker.image.tag=strenv(IMAGE_VERSION) |

--- a/charts/metallb/metallb/README.md
+++ b/charts/metallb/metallb/README.md
@@ -50,10 +50,10 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | metallb.controller.readinessProbe.periodSeconds | int | `10` |  |
 | metallb.controller.readinessProbe.successThreshold | int | `1` |  |
 | metallb.controller.readinessProbe.timeoutSeconds | int | `1` |  |
-| metallb.controller.resources.limits.cpu | string | `"100m"` |  |
-| metallb.controller.resources.limits.memory | string | `"200Mi"` |  |
-| metallb.controller.resources.requests.cpu | string | `"10m"` |  |
-| metallb.controller.resources.requests.memory | string | `"50Mi"` |  |
+| metallb.controller.resources.limits.cpu | string | `"500m"` |  |
+| metallb.controller.resources.limits.memory | string | `"500Mi"` |  |
+| metallb.controller.resources.requests.cpu | string | `"50m"` |  |
+| metallb.controller.resources.requests.memory | string | `"100Mi"` |  |
 | metallb.controller.runtimeClassName | string | `""` |  |
 | metallb.controller.securityContext.fsGroup | int | `65534` |  |
 | metallb.controller.securityContext.runAsNonRoot | bool | `true` |  |

--- a/charts/metallb/metallb/values.yaml
+++ b/charts/metallb/metallb/values.yaml
@@ -199,11 +199,11 @@ metallb:
       fsGroup: 65534
     resources:
       requests:
-        cpu: 10m
-        memory: 50Mi
+        cpu: 50m
+        memory: 100Mi
       limits:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 500m
+        memory: 500Mi
     # limits:
     # cpu: 100m
     # memory: 100Mi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

metallb 无法正常启动，因为配置的 limit 资源太小


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #