### PR TITLE
add ascend mindxdl chart

### DIFF
--- a/charts/ascend-mindxdl/ascend-mindxdl/.relok8s-images.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.repository }}/{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.image }}:{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.version }}"
+- "{{ .ascend-mindxdl.npuExporter.repository }}/{{ .ascend-mindxdl.npuExporter.image }}:{{ .ascend-mindxdl.npuExporter.version }}"

--- a/charts/ascend-mindxdl/ascend-mindxdl/Chart.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: ascend-mindxdl
+type: application
+version: 0.0.1
+dependencies:
+  - name: ascend-mindxdl
+    version: "0.0.1"
+    repository: "https://megacloudcontainer.github.io/ascend-mindxdl"
+keywords:
+  - npu
+  - ascend

--- a/charts/ascend-mindxdl/ascend-mindxdl/README.md
+++ b/charts/ascend-mindxdl/ascend-mindxdl/README.md
@@ -1,0 +1,53 @@
+# 安装
+
+## 前置条件
+### 昇腾相关驱动与固件安装
+请参考官方文档进行安装：https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/80RC1alpha002/softwareinst/instg/instg_0001.html
+
+### 创建用户
+需要创建默认运行用户，不同系统参考下述命令创建：
+
+**Centos**：
+```
+useradd -d /home/hwMindX -u 9000 -m -s /sbin/nologin hwMindX
+usermod -a -G HwHiAiUser hwMindX
+```
+**ubuntu**
+```
+useradd -d /home/hwMindX -u 9000 -m -s /sbin/nologin hwMindX
+usermod -a -G HwHiAiUser hwMindX
+```
+
+### 创建日志目录
+
+**创建父目录**
+```
+mkdir -m 755 /var/log/mindx-dl
+chown root:root /var/log/mindx-dl
+```
+**根据安装的组件自行选择**
+
+
+1.Ascend Device Plugin
+```
+mkdir -m 750 /var/log/mindx-dl/devicePlugin
+chown hwMindX:hwMindX /var/log/mindx-dl/devicePlugin
+```
+2.NPU-Exporter
+```
+mkdir -m 750 /var/log/mindx-dl/npu-exporter
+chown hwMindX:hwMindX /var/log/mindx-dl/npu
+```
+
+### 创建节点标签
+参考下述命令，在计算节点创建标签
+```
+// 在安装了驱动的计算节点创建此标签
+kubectl label node {nodename} huawei.com.ascend/Driver=installed
+kubectl label node {nodename} node-role.kubernetes.io/worker=worker
+kubectl label node {nodename} workerselector=dls-worker-node
+kubectl label node {nodename} host-arch=huawei-arm //或者host-arch=huawei-x86 ，根据实际情况选择
+kubectl label node {nodename} accelerator=huawei-Ascend910 // 根据实际情况进行选择
+// 在控制节点创建此标签
+kubectl label node {nodename} masterselector=dls-master-node
+```

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/.helmignore
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/Chart.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: ascend-mindxdl
+type: application
+version: 0.0.1

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/README.md
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/README.md
@@ -1,0 +1,53 @@
+# 安装
+
+## 前置条件
+### 昇腾相关驱动与固件安装
+请参考官方文档进行安装：https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/80RC1alpha002/softwareinst/instg/instg_0001.html
+
+### 创建用户
+需要创建默认运行用户，不同系统参考下述命令创建：
+
+**Centos**：
+```
+useradd -d /home/hwMindX -u 9000 -m -s /sbin/nologin hwMindX
+usermod -a -G HwHiAiUser hwMindX
+```
+**ubuntu**
+```
+useradd -d /home/hwMindX -u 9000 -m -s /sbin/nologin hwMindX
+usermod -a -G HwHiAiUser hwMindX
+```
+
+### 创建日志目录
+
+**创建父目录**
+```
+mkdir -m 755 /var/log/mindx-dl
+chown root:root /var/log/mindx-dl
+```
+**根据安装的组件自行选择**
+
+
+1.Ascend Device Plugin
+```
+mkdir -m 750 /var/log/mindx-dl/devicePlugin
+chown hwMindX:hwMindX /var/log/mindx-dl/devicePlugin
+```
+2.NPU-Exporter
+```
+mkdir -m 750 /var/log/mindx-dl/npu-exporter
+chown hwMindX:hwMindX /var/log/mindx-dl/npu
+```
+
+### 创建节点标签
+参考下述命令，在计算节点创建标签
+```
+// 在安装了驱动的计算节点创建此标签
+kubectl label node {nodename} huawei.com.ascend/Driver=installed
+kubectl label node {nodename} node-role.kubernetes.io/worker=worker
+kubectl label node {nodename} workerselector=dls-worker-node
+kubectl label node {nodename} host-arch=huawei-arm //或者host-arch=huawei-x86 ，根据实际情况选择
+kubectl label node {nodename} accelerator=huawei-Ascend910 // 根据实际情况进行选择
+// 在控制节点创建此标签
+kubectl label node {nodename} masterselector=dls-master-node
+```

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/_helpers.tpl
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ascend-mindxdl.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ascend-mindxdl.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ascend-mindxdl.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ascend-mindxdl.labels" -}}
+helm.sh/chart: {{ include "ascend-mindxdl.chart" . }}
+{{ include "ascend-mindxdl.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "ascend-mindxdl.npu-exporter.serviceMonitor.labels" -}}
+{{- if .Values.npuExporter.serviceMonitor.labels }}
+{{- range $key, $value := .Values.npuExporter.serviceMonitor.labels -}}
+{{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ascend-mindxdl.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ascend-mindxdl.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ascend-mindxdl.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ascend-mindxdl.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Full image name with tag
+*/}}
+{{- define "devicePlugin.fullimage" -}}
+{{- .Values.devicePlugin.daemonsets.devicePlugin.repository -}}/{{- .Values.devicePlugin.daemonsets.devicePlugin.image -}}:{{- .Values.devicePlugin.daemonsets.devicePlugin.version | default .Chart.AppVersion -}}
+{{- end }}
+
+{{- define "npuExporter.fullimage" -}}
+{{- .Values.npuExporter.repository -}}/{{- .Values.npuExporter.image -}}:{{- .Values.npuExporter.version | default .Chart.AppVersion -}}
+{{- end }}

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/device-plugin/daemonset.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/device-plugin/daemonset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ascend-device-plugin-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: ascend-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+      labels:
+        name: ascend-device-plugin-ds
+    spec:
+     {{- with .Values.devicePlugin.daemonsets.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+     {{- end }}
+      {{- if .Values.devicePlugin.daemonsets.priorityClassName }}
+      priorityClassName: {{ .Values.devicePlugin.daemonsets.priorityClassName }}
+      {{- end }}
+      {{- with .Values.devicePlugin.daemonsets.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ascend-mindxdl.serviceAccountName" . }}
+      containers:
+      - image: {{ include "devicePlugin.fullimage" . }}
+        name: device-plugin
+        resources: {{ toYaml .Values.devicePlugin.daemonsets.devicePlugin.resources | nindent 12 }}
+        command: [ "/bin/bash", "-c", "--"]
+        args: [ "device-plugin  -useAscendDocker=true
+                 -logFile=/var/log/mindx-dl/devicePlugin/devicePlugin.log -logLevel=0" ]
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        imagePullPolicy: {{ .Values.devicePlugin.daemonsets.devicePlugin.imagePullPolicy }}
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+          - name: pod-resource
+            mountPath: /var/lib/kubelet/pod-resources
+          - name: hiai-driver
+            mountPath: /usr/local/Ascend/driver
+            readOnly: true
+          - name: log-path
+            mountPath: /var/log/mindx-dl/devicePlugin
+          - name: tmp
+            mountPath: /tmp
+          {{- if .Values.isVirtualMachine }}
+          - mountPath: /usr/sbin/dmidecode
+            name: dmidecode
+          {{- end }}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: pod-resource
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: hiai-driver
+          hostPath:
+            path: /usr/local/Ascend/driver
+        - name: log-path
+          hostPath:
+            path: /var/log/mindx-dl/devicePlugin
+            type: Directory
+        - name: tmp
+          hostPath:
+            path: /tmp
+        {{- if .Values.isVirtualMachine }}
+        - name: dmidecode
+          hostPath:
+            path: /usr/sbin/dmidecode
+            type: ""
+        {{- end }}

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/device-plugin/serviceaccount.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/device-plugin/serviceaccount.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ascend-mindxdl.serviceAccountName" . }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ascend-mindxdl.serviceAccountName" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "update", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes/status"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create" ]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ascend-mindxdl.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ascend-mindxdl.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ascend-mindxdl.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/daemonset.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/daemonset.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.npuExporter.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: npu-exporter
+spec:
+  selector:
+    matchLabels:
+      app: npu-exporter
+  template:
+    metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+      labels:
+        app: npu-exporter
+    spec:
+      {{- with .Values.npuExporter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: npu-exporter
+        image: {{ include "npuExporter.fullimage" . }}
+        resources: {{ toYaml .Values.resources | nindent 12 }}
+        imagePullPolicy: {{ .Values.npuExporter.imagePullPolicy }}
+        command: [ "/bin/bash", "-c", "--"]
+        # pair firstly
+        args: [ "umask 027;npu-exporter -port=8082 -ip=0.0.0.0  -updateTime=5
+                 -logFile=/var/log/mindx-dl/npu-exporter/npu-exporter.log -logLevel=0 -containerMode=docker" ]
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+          runAsUser: 0
+          runAsGroup: 0
+        ports:
+          - name: http
+            containerPort: 8082
+            protocol: TCP
+        volumeMounts:
+          - name: log-npu-exporter
+            mountPath: /var/log/mindx-dl/npu-exporter
+          - name: localtime
+            mountPath: /etc/localtime
+            readOnly: true
+          - name: ascend-driver
+            mountPath: /usr/local/Ascend/driver
+            readOnly: true
+          - name: ascend-dcmi
+            mountPath: /usr/local/dcmi
+            readOnly: true
+          - name: sys
+            mountPath: /sys
+            readOnly: true
+          - name: docker-shim  # delete when only use containerd or isula
+            mountPath: /var/run/dockershim.sock
+            readOnly: true
+          - name: docker  # delete when only use containerd or isula
+            mountPath: /var/run/docker
+            readOnly: true
+          - name: cri-dockerd  # reserve when k8s version is 1.24+ and the container runtime is docker
+            mountPath: /var/run/cri-dockerd.sock
+            readOnly: true
+          - name: containerd  # delete when only use isula
+            mountPath: /run/containerd
+            readOnly: true
+          - name: isulad  # delete when use containerd or docker
+            mountPath: /run/isulad.sock
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          {{- if .Values.isVirtualMachine }}
+          - mountPath: /usr/sbin/dmidecode
+            name: dmidecode
+          {{- end }}
+      volumes:
+        - name: log-npu-exporter
+          hostPath:
+            path: /var/log/mindx-dl/npu-exporter
+            type: Directory
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: ascend-driver
+          hostPath:
+            path: /usr/local/Ascend/driver
+        - name: ascend-dcmi
+          hostPath:
+            path: /usr/local/dcmi
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: docker-shim # delete when only use containerd or isula
+          hostPath:
+            path: /var/run/dockershim.sock
+        - name: docker  # delete when only use containerd or isula
+          hostPath:
+            path: /var/run/docker
+        - name: cri-dockerd # reserve when k8s version is 1.24+ and the container runtime is docker
+          hostPath:
+            path: /var/run/cri-dockerd.sock
+        - name: containerd  # delete when only use isula
+          hostPath:
+            path: /run/containerd
+        - name: isulad  # delete when use containerd or docker
+          hostPath:
+            path: /run/isulad.sock
+        - name: tmp
+          hostPath:
+            path: /tmp
+        {{- if .Values.isVirtualMachine }}
+        - name: dmidecode
+          hostPath:
+            path: /usr/sbin/dmidecode
+            type: ""
+        {{- end }}
+{{- end }}

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/service.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.npuExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: npu-exporter
+  labels:
+    app: npu-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8082
+      targetPort: http
+      protocol: TCP
+      name: npu-metrics
+  selector:
+    app: npu-exporter
+{{- end }}

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/servicemonitor.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/templates/npu-exporter/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.npuExporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: npu-exporter
+    {{- include "ascend-mindxdl.npu-exporter.serviceMonitor.labels" . | nindent 4}}
+  name: npu-exporter
+spec:
+  endpoints:
+    - bearerTokenSecret:
+        key: ''
+      interval: 15s
+      path: /metrics
+      port: npu-metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_endpoint_node_name
+          targetLabel: node
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: npu-exporter
+{{- end }}

--- a/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/values.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/charts/ascend-mindxdl/values.yaml
@@ -1,0 +1,77 @@
+# Default values for ascend-mindxdl.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+podAnnotations: {}
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+
+devicePlugin:
+  daemonsets:
+    labels: {}
+    annotations: {}
+    priorityClassName: "system-node-critical"
+    nodeSelector:
+      huawei.com.ascend/Driver: installed
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: huawei.com/Ascend310
+        operator: Exists
+        effect: NoSchedule
+      - key: "device-plugin"
+        operator: "Equal"
+        value: "v2"
+        effect: NoSchedule
+    devicePlugin:
+      repository: release.daocloud.io
+      image: ascend/ascend-k8sdeviceplugin
+      version: v5.0.0
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          cpu: 500m
+          memory: 500Mi
+        requests:
+          cpu: 500m
+          memory: 500Mi
+npuExporter:
+  enabled: true
+  repository: release.daocloud.io
+  image: ascend/npu-exporter
+  version: v5.0.0
+  imagePullPolicy: IfNotPresent
+  nodeSelector:
+    huawei.com.ascend/Driver: installed
+    workerselector: dls-worker-node
+  serviceMonitor:
+    enabled: true
+    labels:
+      operator.insight.io/managed-by: insight
+  resources:
+    limits:
+      cpu: 600m
+      memory: 500Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+isVirtualMachine: false

--- a/charts/ascend-mindxdl/ascend-mindxdl/values.schema.json
+++ b/charts/ascend-mindxdl/ascend-mindxdl/values.schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "required": [],
+    "properties": {
+        "ascend-mindxdl": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "devicePlugin": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                        "daemonsets": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {
+                                "devicePlugin": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "npuExporter": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "image": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "isVirtualMachine": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/charts/ascend-mindxdl/ascend-mindxdl/values.yaml
+++ b/charts/ascend-mindxdl/ascend-mindxdl/values.yaml
@@ -1,0 +1,78 @@
+# child values
+ascend-mindxdl:
+  # Default values for ascend-mindxdl.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+  podAnnotations: {}
+  podSecurityContext: {}
+  # fsGroup: 2000
+
+  securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+  devicePlugin:
+    daemonsets:
+      labels: {}
+      annotations: {}
+      priorityClassName: "system-node-critical"
+      nodeSelector:
+        huawei.com.ascend/Driver: installed
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: huawei.com/Ascend310
+          operator: Exists
+          effect: NoSchedule
+        - key: "device-plugin"
+          operator: "Equal"
+          value: "v2"
+          effect: NoSchedule
+      devicePlugin:
+        repository: release.daocloud.io
+        image: ascend/ascend-k8sdeviceplugin
+        version: v5.0.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+  npuExporter:
+    enabled: true
+    repository: release.daocloud.io
+    image: ascend/npu-exporter
+    version: v5.0.0
+    imagePullPolicy: IfNotPresent
+    nodeSelector:
+      huawei.com.ascend/Driver: installed
+      workerselector: dls-worker-node
+    serviceMonitor:
+      enabled: true
+      labels:
+        operator.insight.io/managed-by: insight
+    resources:
+      limits:
+        cpu: 600m
+        memory: 500Mi
+      requests:
+        cpu: 500m
+        memory: 500Mi
+  isVirtualMachine: false

--- a/charts/ascend-mindxdl/config
+++ b/charts/ascend-mindxdl/config
@@ -1,0 +1,22 @@
+helm export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://megacloudcontainer.github.io/ascend-mindxdl
+export REPO_NAME=ascend-mindxdl
+export CHART_NAME=ascend-mindxdl
+export VERSION=0.0.1
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=CoderTH
+export TEST_ASSIGNER=CoderTH
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+export NO_TRIVY=true
+
+SKIP_SCHEMA=false

--- a/charts/ascend-mindxdl/custom.sh
+++ b/charts/ascend-mindxdl/custom.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+os=$(uname)
+echo $os
+
+echo "custom.sh"
+
+script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# set serviceMonitor
+yq -i '
+    .ascend-mindxdl.npuExporter.serviceMonitor.labels={"operator.insight.io/managed-by": "insight"}
+' values.yaml
+
+yq -i '
+    .npuExporter.serviceMonitor.labels={"operator.insight.io/managed-by": "insight"}
+' charts/ascend-mindxdl/values.yaml
+
+if ! grep "keywords:" Chart.yaml &>/dev/null ; then
+    echo "keywords:" >> Chart.yaml
+    echo "  - npu" >> Chart.yaml
+    echo "  - ascend" >> Chart.yaml
+fi

--- a/charts/ascend-mindxdl/parent/.relok8s-images.yaml
+++ b/charts/ascend-mindxdl/parent/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.repository }}/{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.image }}:{{ .ascend-mindxdl.devicePlugin.daemonsets.devicePlugin.version }}"
+- "{{ .ascend-mindxdl.npuExporter.repository }}/{{ .ascend-mindxdl.npuExporter.image }}:{{ .ascend-mindxdl.npuExporter.version }}"

--- a/charts/ascend-mindxdl/parent/values.schema.json
+++ b/charts/ascend-mindxdl/parent/values.schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "required": [],
+    "properties": {
+        "ascend-mindxdl": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "devicePlugin": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                        "daemonsets": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {
+                                "devicePlugin": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "npuExporter": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "image": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "isVirtualMachine": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/test/ascend-mindxdl/install.sh
+++ b/test/ascend-mindxdl/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd "$CURRENT_FILENAME" || exit; pwd)
+
+KIND_KUBECONFIG=$1
+
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+
+helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+set -x
+
+# install ascend-mindxdl need node having ascend npu card, so skip install
+exit 0
+
+
+
+# deploy the docker-registry
+helm install ascend-mindxdl chart-museum/ascend-mindxdl  ${HELM_MUST_OPTION}
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+  exit 0
+else
+  echo "error, faild to deploy $CHART_DIR"
+    kubectl --kubeconfig ${KIND_KUBECONFIG} get pod -o wide -A
+
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

添加 ascend-mindxdl chart包

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #