### PR TITLE
bump spiderpool to 0.9.2

### DIFF
--- a/charts/spiderpool/config
+++ b/charts/spiderpool/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/spiderpool
 export REPO_NAME=spiderpool
 export CHART_NAME=spiderpool
-export VERSION=0.9.1
+export VERSION=0.9.2
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/spiderpool/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.1
+appVersion: 0.9.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,8 +16,8 @@ name: spiderpool
 sources:
   - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.9.1
+version: 0.9.2
 dependencies:
   - name: spiderpool
-    version: "0.9.1"
+    version: "0.9.2"
     repository: "https://spidernet-io.github.io/spiderpool"

--- a/charts/spiderpool/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/README.md
@@ -127,18 +127,19 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### ipam parameters
 
-| Name                                   | Description                                                                 | Value  |
-| -------------------------------------- | --------------------------------------------------------------------------- | ------ |
-| `ipam.enableIPv4`                      | enable ipv4                                                                 | `true` |
-| `ipam.enableIPv6`                      | enable ipv6                                                                 | `true` |
-| `ipam.enableStatefulSet`               | the network mode                                                            | `true` |
-| `ipam.enableKubevirtStaticIP`          | the feature to keep kubevirt vm pod static IP                               | `true` |
-| `ipam.enableSpiderSubnet`              | SpiderSubnet feature gate.                                                  | `true` |
-| `ipam.subnetDefaultFlexibleIPNumber`   | the default flexible IP number of SpiderSubnet feature auto-created IPPools | `1`    |
-| `ipam.gc.enabled`                      | enable retrieve IP in spiderippool CR                                       | `true` |
-| `ipam.gc.gcAll.intervalInSecond`       | the gc all interval duration                                                | `600`  |
-| `ipam.gc.GcDeletingTimeOutPod.enabled` | enable retrieve IP for the pod who times out of deleting graceful period    | `true` |
-| `ipam.gc.GcDeletingTimeOutPod.delay`   | the gc delay seconds after the pod times out of deleting graceful period    | `0`    |
+| Name                                        | Description                                                                                      | Value  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
+| `ipam.enableIPv4`                           | enable ipv4                                                                                      | `true` |
+| `ipam.enableIPv6`                           | enable ipv6                                                                                      | `true` |
+| `ipam.enableStatefulSet`                    | the network mode                                                                                 | `true` |
+| `ipam.enableKubevirtStaticIP`               | the feature to keep kubevirt vm pod static IP                                                    | `true` |
+| `ipam.enableSpiderSubnet`                   | SpiderSubnet feature gate.                                                                       | `true` |
+| `ipam.subnetDefaultFlexibleIPNumber`        | the default flexible IP number of SpiderSubnet feature auto-created IPPools                      | `1`    |
+| `ipam.gc.enabled`                           | enable retrieve IP in spiderippool CR                                                            | `true` |
+| `ipam.gc.gcAll.intervalInSecond`            | the gc all interval duration                                                                     | `600`  |
+| `ipam.gc.statelessPod.zombieOnReadyNode`    | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
+| `ipam.gc.statelessPod.zombieOnNotReadyNode` | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
+| `ipam.gc.gcDeletingTimeOutPodDelay`         | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
 
 ### grafanaDashboard parameters
 

--- a/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.1
+appVersion: 0.9.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,4 +16,4 @@ name: spiderpool
 sources:
 - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.9.1
+version: 0.9.2

--- a/charts/spiderpool/spiderpool/charts/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/README.md
@@ -127,18 +127,19 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### ipam parameters
 
-| Name                                   | Description                                                                 | Value  |
-| -------------------------------------- | --------------------------------------------------------------------------- | ------ |
-| `ipam.enableIPv4`                      | enable ipv4                                                                 | `true` |
-| `ipam.enableIPv6`                      | enable ipv6                                                                 | `true` |
-| `ipam.enableStatefulSet`               | the network mode                                                            | `true` |
-| `ipam.enableKubevirtStaticIP`          | the feature to keep kubevirt vm pod static IP                               | `true` |
-| `ipam.enableSpiderSubnet`              | SpiderSubnet feature gate.                                                  | `true` |
-| `ipam.subnetDefaultFlexibleIPNumber`   | the default flexible IP number of SpiderSubnet feature auto-created IPPools | `1`    |
-| `ipam.gc.enabled`                      | enable retrieve IP in spiderippool CR                                       | `true` |
-| `ipam.gc.gcAll.intervalInSecond`       | the gc all interval duration                                                | `600`  |
-| `ipam.gc.GcDeletingTimeOutPod.enabled` | enable retrieve IP for the pod who times out of deleting graceful period    | `true` |
-| `ipam.gc.GcDeletingTimeOutPod.delay`   | the gc delay seconds after the pod times out of deleting graceful period    | `0`    |
+| Name                                        | Description                                                                                      | Value  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
+| `ipam.enableIPv4`                           | enable ipv4                                                                                      | `true` |
+| `ipam.enableIPv6`                           | enable ipv6                                                                                      | `true` |
+| `ipam.enableStatefulSet`                    | the network mode                                                                                 | `true` |
+| `ipam.enableKubevirtStaticIP`               | the feature to keep kubevirt vm pod static IP                                                    | `true` |
+| `ipam.enableSpiderSubnet`                   | SpiderSubnet feature gate.                                                                       | `true` |
+| `ipam.subnetDefaultFlexibleIPNumber`        | the default flexible IP number of SpiderSubnet feature auto-created IPPools                      | `1`    |
+| `ipam.gc.enabled`                           | enable retrieve IP in spiderippool CR                                                            | `true` |
+| `ipam.gc.gcAll.intervalInSecond`            | the gc all interval duration                                                                     | `600`  |
+| `ipam.gc.statelessPod.zombieOnReadyNode`    | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
+| `ipam.gc.statelessPod.zombieOnNotReadyNode` | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
+| `ipam.gc.gcDeletingTimeOutPodDelay`         | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
 
 ### grafanaDashboard parameters
 

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
@@ -94,6 +94,8 @@ spec:
                 type: array
               phase:
                 type: string
+              reason:
+                type: string
               serviceCIDR:
                 items:
                   type: string

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderendpoints.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderendpoints.yaml
@@ -98,6 +98,7 @@ spec:
                           type: array
                         vlan:
                           default: 0
+                          description: 'DEPRECATED: Vlan is deprecated.'
                           format: int64
                           maximum: 4094
                           minimum: 0

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/deployment.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/deployment.yaml
@@ -161,16 +161,22 @@ spec:
           value: {{ .Values.spiderpoolController.httpPort | quote }}
         - name: SPIDERPOOL_GC_IP_ENABLED
           value: {{ .Values.ipam.gc.enabled | quote }}
-        - name: SPIDERPOOL_GC_TERMINATING_POD_IP_ENABLED
-          value: {{ .Values.ipam.gc.GcDeletingTimeOutPod.enabled | quote }}
+        - name: SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_READY_NODE_ENABLED
+          value: {{ .Values.ipam.gc.statelessPod.zombieOnReadyNode | quote }}
+        - name: SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED
+          value: {{ .Values.ipam.gc.statelessPod.zombieOnNotReadyNode | quote }}
         - name: SPIDERPOOL_GC_ADDITIONAL_GRACE_DELAY
-          value: {{ .Values.ipam.gc.GcDeletingTimeOutPod.delay | quote }}
+          value: {{ .Values.ipam.gc.gcDeletingTimeOutPodDelay | quote }}
         - name: SPIDERPOOL_GC_DEFAULT_INTERVAL_DURATION
           value: {{ .Values.ipam.gc.gcAll.intervalInSecond | quote }}
         - name: SPIDERPOOL_MULTUS_CONFIG_ENABLED
           value: {{ .Values.multus.enableMultusConfig | quote }}
         - name: SPIDERPOOL_CNI_CONFIG_DIR
           value: {{ .Values.global.cniConfHostPath | quote }}
+        - name: SPIDERPOOL_COORDINATOR_ENABLED
+          value: {{ .Values.coordinator.enabled | quote }}
+        - name: SPIDERPOOL_COORDINATOR_DEAFULT_NAME
+          value: {{ .Values.coordinator.name | quote }}
         - name: SPIDERPOOL_CILIUM_CONFIGMAP_NAMESPACE_NAME
           value: {{ .Values.global.ciliumConfigMap | quote }}
         - name: SPIDERPOOL_POD_NAME

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/tls.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/tls.yaml
@@ -116,6 +116,7 @@ webhooks:
     resources:
     - spiderreservedips
   sideEffects: None
+{{- if .Values.coordinator.enabled }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -142,6 +143,7 @@ webhooks:
     resources:
     - spidercoordinators
   sideEffects: None
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -231,6 +233,7 @@ webhooks:
     resources:
     - spiderreservedips
   sideEffects: None
+{{- if .Values.coordinator.enabled }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -257,6 +260,7 @@ webhooks:
     resources:
     - spidercoordinators
   sideEffects: None
+{{- end }}
 {{- if .Values.multus.enableMultusConfig }}
 - admissionReviewVersions:
     - v1

--- a/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
@@ -67,12 +67,15 @@ ipam:
       ## @param ipam.gc.gcAll.intervalInSecond the gc all interval duration
       intervalInSecond: 600
 
-    GcDeletingTimeOutPod:
-      ## @param ipam.gc.GcDeletingTimeOutPod.enabled enable retrieve IP for the pod who times out of deleting graceful period
-      enabled: true
+    statelessPod:
+      ## @param ipam.gc.statelessPod.zombieOnReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node
+      zombieOnReadyNode: true
 
-      ## @param ipam.gc.GcDeletingTimeOutPod.delay the gc delay seconds after the pod times out of deleting graceful period
-      delay: 0
+      ## @param ipam.gc.statelessPod.zombieOnNotReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node
+      zombieOnNotReadyNode: true
+
+    ## @param ipam.gc.gcDeletingTimeOutPodDelay the gc delay seconds after the pod times out of deleting graceful period
+    gcDeletingTimeOutPodDelay: 0
 
 ## @section grafanaDashboard parameters
 ##
@@ -357,7 +360,7 @@ spiderpoolAgent:
     digest: ""
 
     ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.1
+    tag: v0.9.2
 
     ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
     imagePullSecrets: []
@@ -541,7 +544,7 @@ spiderpoolController:
     digest: ""
 
     ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.1
+    tag: v0.9.2
 
     ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
     imagePullSecrets: []
@@ -772,7 +775,7 @@ spiderpoolInit:
     digest: ""
 
     ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.1
+    tag: v0.9.2
 
     ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
     imagePullSecrets: []

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -52,11 +52,13 @@ spiderpool:
       gcAll:
         ## @param ipam.gc.gcAll.intervalInSecond the gc all interval duration
         intervalInSecond: 600
-      GcDeletingTimeOutPod:
-        ## @param ipam.gc.GcDeletingTimeOutPod.enabled enable retrieve IP for the pod who times out of deleting graceful period
-        enabled: true
-        ## @param ipam.gc.GcDeletingTimeOutPod.delay the gc delay seconds after the pod times out of deleting graceful period
-        delay: 0
+      statelessPod:
+        ## @param ipam.gc.statelessPod.zombieOnReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node
+        zombieOnReadyNode: true
+        ## @param ipam.gc.statelessPod.zombieOnNotReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node
+        zombieOnNotReadyNode: true
+      ## @param ipam.gc.gcDeletingTimeOutPodDelay the gc delay seconds after the pod times out of deleting graceful period
+      gcDeletingTimeOutPodDelay: 0
   ## @section grafanaDashboard parameters
   ##
   grafanaDashboard:
@@ -268,7 +270,7 @@ spiderpool:
       ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
       digest: ""
       ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.1
+      tag: v0.9.2
       ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -406,7 +408,7 @@ spiderpool:
       ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
       digest: ""
       ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.1
+      tag: v0.9.2
       ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -583,7 +585,7 @@ spiderpool:
       ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
       digest: ""
       ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.1
+      tag: v0.9.2
       ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
       imagePullSecrets: []
       # - name: "image-pull-secret"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

bump spiderpool to 0.9.2

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #