### PR TITLE
bump spiderpool to v1.0.0-rc0

### DIFF
--- a/charts/spiderpool/append/smc_initcontainer.txt
+++ b/charts/spiderpool/append/smc_initcontainer.txt
@@ -1,0 +1,20 @@
+        {{- if .Values.dra.enabled }}
+        - name: smc
+          imagePullPolicy: {{ .Values.netmaterial.image.pullPolicy }}
+          image: {{ include "netmaterial.image" . | quote }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /lib/modules
+            name: lib-modules
+            readOnly: true
+          - mountPath: /host/etc/os-release
+            name: os-release
+            readOnly: true
+          - mountPath: /usr/lib
+            name: library
+          - mountPath: /usr/lib64
+            name: library64
+          - mountPath: /host/usr/bin/
+            name: ofed
+        {{- end }}

--- a/charts/spiderpool/append/smc_volumes.txt
+++ b/charts/spiderpool/append/smc_volumes.txt
@@ -1,0 +1,17 @@
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /etc/os-release
+          type: File
+        name: os-release
+      - hostPath:
+          path: /usr/lib
+        name: library
+      - hostPath:
+          path: /usr/lib64
+        name: library64
+      - hostPath:
+          path: /usr/bin
+          type: Directory
+        name: ofed

--- a/charts/spiderpool/config
+++ b/charts/spiderpool/config
@@ -4,11 +4,11 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/spiderpool
 export REPO_NAME=spiderpool
 export CHART_NAME=spiderpool
-export VERSION=0.9.3
+export VERSION=1.0.0-rc0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr
-export UPGRADE_REVIWER=Icarus9913
+export UPGRADE_REVIWER=cyclinder
 export TEST_ASSIGNER=ty-dc
 
 # optional, for wrapper chart

--- a/charts/spiderpool/parent/.relok8s-images.yaml
+++ b/charts/spiderpool/parent/.relok8s-images.yaml
@@ -11,3 +11,4 @@
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.sriovDevicePlugin.repository }}:{{ .spiderpool.sriov.image.sriovDevicePlugin.tag }}"
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.resourcesInjector.repository }}:{{ .spiderpool.sriov.image.resourcesInjector.tag }}"
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.webhook.repository }}:{{ .spiderpool.sriov.image.webhook.tag }}"
+- "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.netmaterial.image.repository }}:{{ .spiderpool.netmaterial.image.tag }}"

--- a/charts/spiderpool/parent/values.schema.json
+++ b/charts/spiderpool/parent/values.schema.json
@@ -80,6 +80,32 @@
                         }
                     }
                 },
+                "dra": {
+                    "type": "object",
+                    "description": "Dra Configuration",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable dra"
+                        }
+                    }
+                },
+                "netmaterial": {
+                    "type": "object",
+                    "description": "Netmaterial Image Configuration",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "daocloud/netmaterial"
+                                }
+                            }
+                        }
+                    }
+                },
                 "multus": {
                     "type": "object",
                     "title": "Multus Setting",

--- a/charts/spiderpool/skip-check.yaml
+++ b/charts/spiderpool/skip-check.yaml
@@ -1,0 +1,2 @@
+spiderpool:
+  - "netmaterial"

--- a/charts/spiderpool/spiderpool/.relok8s-images.yaml
+++ b/charts/spiderpool/spiderpool/.relok8s-images.yaml
@@ -11,3 +11,4 @@
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.sriovDevicePlugin.repository }}:{{ .spiderpool.sriov.image.sriovDevicePlugin.tag }}"
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.resourcesInjector.repository }}:{{ .spiderpool.sriov.image.resourcesInjector.tag }}"
 - "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.sriov.image.webhook.repository }}:{{ .spiderpool.sriov.image.webhook.tag }}"
+- "{{ .spiderpool.global.imageRegistryOverride }}/{{ .spiderpool.netmaterial.image.repository }}:{{ .spiderpool.netmaterial.image.tag }}"

--- a/charts/spiderpool/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.3
+appVersion: 1.0.0-rc0
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,8 +16,8 @@ name: spiderpool
 sources:
   - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.9.3
+version: 1.0.0-rc0
 dependencies:
   - name: spiderpool
-    version: "0.9.3"
+    version: "1.0.0-rc0"
     repository: "https://spidernet-io.github.io/spiderpool"

--- a/charts/spiderpool/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/README.md
@@ -127,19 +127,20 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### ipam parameters
 
-| Name                                        | Description                                                                                      | Value  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
-| `ipam.enableIPv4`                           | enable ipv4                                                                                      | `true` |
-| `ipam.enableIPv6`                           | enable ipv6                                                                                      | `true` |
-| `ipam.enableStatefulSet`                    | the network mode                                                                                 | `true` |
-| `ipam.enableKubevirtStaticIP`               | the feature to keep kubevirt vm pod static IP                                                    | `true` |
-| `ipam.enableSpiderSubnet`                   | SpiderSubnet feature gate.                                                                       | `true` |
-| `ipam.subnetDefaultFlexibleIPNumber`        | the default flexible IP number of SpiderSubnet feature auto-created IPPools                      | `1`    |
-| `ipam.gc.enabled`                           | enable retrieve IP in spiderippool CR                                                            | `true` |
-| `ipam.gc.gcAll.intervalInSecond`            | the gc all interval duration                                                                     | `600`  |
-| `ipam.gc.statelessPod.zombieOnReadyNode`    | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
-| `ipam.gc.statelessPod.zombieOnNotReadyNode` | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
-| `ipam.gc.gcDeletingTimeOutPodDelay`         | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
+| Name                                                  | Description                                                                                      | Value  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
+| `ipam.enableIPv4`                                     | enable ipv4                                                                                      | `true` |
+| `ipam.enableIPv6`                                     | enable ipv6                                                                                      | `true` |
+| `ipam.enableStatefulSet`                              | the network mode                                                                                 | `true` |
+| `ipam.enableKubevirtStaticIP`                         | the feature to keep kubevirt vm pod static IP                                                    | `true` |
+| `ipam.spidersubnet.enable`                            | SpiderSubnet feature.                                                                            | `true` |
+| `ipam.spidersubnet.autoPool.enable`                   | SpiderSubnet Auto IPPool feature.                                                                | `true` |
+| `ipam.spidersubnet.autoPool.defaultRedundantIPNumber` | the default redundant IP number of SpiderSubnet feature auto-created IPPools                     | `1`    |
+| `ipam.gc.enabled`                                     | enable retrieve IP in spiderippool CR                                                            | `true` |
+| `ipam.gc.gcAll.intervalInSecond`                      | the gc all interval duration                                                                     | `600`  |
+| `ipam.gc.statelessPod.zombieOnReadyNode`              | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
+| `ipam.gc.statelessPod.zombieOnNotReadyNode`           | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
+| `ipam.gc.gcDeletingTimeOutPodDelay`                   | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
 
 ### grafanaDashboard parameters
 
@@ -187,6 +188,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.rdmaHcaMax`             | rdma Hca Max                                            | `500`                                  |
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.vendors`                | rdma device vendors, default to mellanox device         | `15b3`                                 |
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs`              | rdma device IDs, default to mellanox device             | `1017`                                 |
+| `rdma.rdmaSharedDevicePlugin.deviceConfig.ifNames`                | rdma target device name, default to empty list.         | `[]`                                   |
 
 ### multus parameters
 
@@ -209,6 +211,14 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `multus.multusCNI.extraVolumeMounts`          | the additional hostPath mounts of multus-CNI daemonset pod container                                                                                                                                                                                                                                                                                                                             | `[]`                              |
 | `multus.multusCNI.log.logLevel`               | the multus-CNI daemonset pod log level                                                                                                                                                                                                                                                                                                                                                           | `debug`                           |
 | `multus.multusCNI.log.logFile`                | the multus-CNI daemonset pod log file                                                                                                                                                                                                                                                                                                                                                            | `/var/log/multus.log`             |
+
+### dra parameters
+
+| Name                 | Description                | Value          |
+| -------------------- | -------------------------- | -------------- |
+| `dra.enabled`        | to enable dra feature      | `false`        |
+| `dra.cdiRootPath`    | the dir of cdi root        | `/var/run/cdi` |
+| `dra.hostDevicePath` | the dir path of the device | `""`           |
 
 ### plugins parameters
 
@@ -368,6 +378,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `spiderpoolController.tls.auto.certExpiration`                                  | server cert expiration for auto method                                                                                            | `73000`                                         |
 | `spiderpoolController.tls.auto.extraIpAddresses`                                | extra IP addresses of server certificate for auto method                                                                          | `[]`                                            |
 | `spiderpoolController.tls.auto.extraDnsNames`                                   | extra DNS names of server cert for auto method                                                                                    | `[]`                                            |
+| `spiderpoolController.cleanup.enable`                                           | clean up resources when helm uninstall                                                                                            | `true`                                          |
 
 ### spiderpoolInit parameters
 

--- a/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.3
+appVersion: 1.0.0-rc0
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,4 +16,4 @@ name: spiderpool
 sources:
 - https://github.com/spidernet-io/spiderpool
 type: application
-version: 0.9.3
+version: 1.0.0-rc0

--- a/charts/spiderpool/spiderpool/charts/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/README.md
@@ -127,19 +127,20 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### ipam parameters
 
-| Name                                        | Description                                                                                      | Value  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
-| `ipam.enableIPv4`                           | enable ipv4                                                                                      | `true` |
-| `ipam.enableIPv6`                           | enable ipv6                                                                                      | `true` |
-| `ipam.enableStatefulSet`                    | the network mode                                                                                 | `true` |
-| `ipam.enableKubevirtStaticIP`               | the feature to keep kubevirt vm pod static IP                                                    | `true` |
-| `ipam.enableSpiderSubnet`                   | SpiderSubnet feature gate.                                                                       | `true` |
-| `ipam.subnetDefaultFlexibleIPNumber`        | the default flexible IP number of SpiderSubnet feature auto-created IPPools                      | `1`    |
-| `ipam.gc.enabled`                           | enable retrieve IP in spiderippool CR                                                            | `true` |
-| `ipam.gc.gcAll.intervalInSecond`            | the gc all interval duration                                                                     | `600`  |
-| `ipam.gc.statelessPod.zombieOnReadyNode`    | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
-| `ipam.gc.statelessPod.zombieOnNotReadyNode` | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
-| `ipam.gc.gcDeletingTimeOutPodDelay`         | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
+| Name                                                  | Description                                                                                      | Value  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
+| `ipam.enableIPv4`                                     | enable ipv4                                                                                      | `true` |
+| `ipam.enableIPv6`                                     | enable ipv6                                                                                      | `true` |
+| `ipam.enableStatefulSet`                              | the network mode                                                                                 | `true` |
+| `ipam.enableKubevirtStaticIP`                         | the feature to keep kubevirt vm pod static IP                                                    | `true` |
+| `ipam.spidersubnet.enable`                            | SpiderSubnet feature.                                                                            | `true` |
+| `ipam.spidersubnet.autoPool.enable`                   | SpiderSubnet Auto IPPool feature.                                                                | `true` |
+| `ipam.spidersubnet.autoPool.defaultRedundantIPNumber` | the default redundant IP number of SpiderSubnet feature auto-created IPPools                     | `1`    |
+| `ipam.gc.enabled`                                     | enable retrieve IP in spiderippool CR                                                            | `true` |
+| `ipam.gc.gcAll.intervalInSecond`                      | the gc all interval duration                                                                     | `600`  |
+| `ipam.gc.statelessPod.zombieOnReadyNode`              | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true` |
+| `ipam.gc.statelessPod.zombieOnNotReadyNode`           | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true` |
+| `ipam.gc.gcDeletingTimeOutPodDelay`                   | the gc delay seconds after the pod times out of deleting graceful period                         | `0`    |
 
 ### grafanaDashboard parameters
 
@@ -187,6 +188,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.rdmaHcaMax`             | rdma Hca Max                                            | `500`                                  |
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.vendors`                | rdma device vendors, default to mellanox device         | `15b3`                                 |
 | `rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs`              | rdma device IDs, default to mellanox device             | `1017`                                 |
+| `rdma.rdmaSharedDevicePlugin.deviceConfig.ifNames`                | rdma target device name, default to empty list.         | `[]`                                   |
 
 ### multus parameters
 
@@ -209,6 +211,14 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `multus.multusCNI.extraVolumeMounts`          | the additional hostPath mounts of multus-CNI daemonset pod container                                                                                                                                                                                                                                                                                                                             | `[]`                              |
 | `multus.multusCNI.log.logLevel`               | the multus-CNI daemonset pod log level                                                                                                                                                                                                                                                                                                                                                           | `debug`                           |
 | `multus.multusCNI.log.logFile`                | the multus-CNI daemonset pod log file                                                                                                                                                                                                                                                                                                                                                            | `/var/log/multus.log`             |
+
+### dra parameters
+
+| Name                 | Description                | Value          |
+| -------------------- | -------------------------- | -------------- |
+| `dra.enabled`        | to enable dra feature      | `false`        |
+| `dra.cdiRootPath`    | the dir of cdi root        | `/var/run/cdi` |
+| `dra.hostDevicePath` | the dir path of the device | `""`           |
 
 ### plugins parameters
 
@@ -368,6 +378,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `spiderpoolController.tls.auto.certExpiration`                                  | server cert expiration for auto method                                                                                            | `73000`                                         |
 | `spiderpoolController.tls.auto.extraIpAddresses`                                | extra IP addresses of server certificate for auto method                                                                          | `[]`                                            |
 | `spiderpoolController.tls.auto.extraDnsNames`                                   | extra DNS names of server cert for auto method                                                                                    | `[]`                                            |
+| `spiderpoolController.cleanup.enable`                                           | clean up resources when helm uninstall                                                                                            | `true`                                          |
 
 ### spiderpoolInit parameters
 

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderclaimparameters.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderclaimparameters.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: spiderclaimparameters.spiderpool.spidernet.io
+spec:
+  group: spiderpool.spidernet.io
+  names:
+    categories:
+    - spiderpool
+    kind: SpiderClaimParameter
+    listKind: SpiderClaimParameterList
+    plural: spiderclaimparameters
+    shortNames:
+    - scp
+    singular: spiderclaimparameter
+  scope: Namespaced
+  versions:
+  - name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: SpiderClaimParameter is the Schema for the spiderclaimparameters
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClaimParameterSpec defines the desired state of SpiderClaimParameter.
+            properties:
+              ippools:
+                items:
+                  type: string
+                type: array
+              multusNames:
+                items:
+                  type: string
+                type: array
+              rdma:
+                default: false
+                type: boolean
+              resources:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ResourceList is a set of (resource name, quantity) pairs.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderippools.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spiderippools.yaml
@@ -137,11 +137,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
@@ -189,11 +191,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
@@ -241,11 +245,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/_helpers.tpl
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/_helpers.tpl
@@ -475,3 +475,22 @@ return the sriov webhook image
 {{- end -}}
 
 #========================================
+{{/*
+return the netermarial image
+*/}}
+{{- define "netmaterial.image" -}}
+{{- $registryName := .Values.netmaterial.image.registry -}}
+{{- $repositoryName := .Values.netmaterial.image.repository -}}
+{{- if .Values.global.imageRegistryOverride }}
+    {{- printf "%s/%s" .Values.global.imageRegistryOverride $repositoryName -}}
+{{ else if $registryName }}
+    {{- printf "%s/%s" $registryName $repositoryName -}}
+{{- else -}}
+    {{- printf "%s" $repositoryName -}}
+{{- end -}}
+{{- if .Values.netmaterial.image.tag -}}
+    {{- printf ":%s" .Values.netmaterial.image.tag -}}
+{{- else -}}
+    {{- printf ":%s" "latest" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/configmap.yaml
@@ -19,12 +19,17 @@ data:
     enableIPv6: {{ .Values.ipam.enableIPv6 }}
     enableStatefulSet: {{ .Values.ipam.enableStatefulSet }}
     enableKubevirtStaticIP: {{ .Values.ipam.enableKubevirtStaticIP }}
-    enableSpiderSubnet: {{ .Values.ipam.enableSpiderSubnet }}
-    {{- if .Values.ipam.enableSpiderSubnet }}
-    clusterSubnetDefaultFlexibleIPNumber: {{ .Values.ipam.subnetDefaultFlexibleIPNumber }}
+    enableSpiderSubnet: {{ .Values.ipam.spidersubnet.enable }}
+    enableAutoPoolForApplication: {{ .Values.ipam.spidersubnet.autoPool.enable }}
+    {{- if and .Values.ipam.spidersubnet.enable .Values.ipam.spidersubnet.autoPool.enable }}
+    clusterSubnetDefaultFlexibleIPNumber: {{ .Values.ipam.spidersubnet.autoPool.defaultRedundantIPNumber }}
     {{- else}}
     clusterSubnetDefaultFlexibleIPNumber: 0
     {{- end }}
+    dra:
+      enabled: {{ .Values.dra.enabled }}
+      cdiRootPath: {{ .Values.dra.cdiRootPath }}
+      hostDevicePath: {{ .Values.dra.hostDevicePath }}
 {{- if .Values.multus.multusCNI.install }}
 ---
 kind: ConfigMap

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
@@ -80,6 +80,26 @@ spec:
                       - linux
       {{- end }}
       initContainers:
+        {{- if .Values.dra.enabled }}
+        - name: smc
+          imagePullPolicy: {{ .Values.netmaterial.image.pullPolicy }}
+          image: {{ include "netmaterial.image" . | quote }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /lib/modules
+            name: lib-modules
+            readOnly: true
+          - mountPath: /host/etc/os-release
+            name: os-release
+            readOnly: true
+          - mountPath: /usr/lib
+            name: library
+          - mountPath: /usr/lib64
+            name: library64
+          - mountPath: /host/usr/bin/
+            name: ofed
+        {{- end }}
         {{- if or .Values.plugins.installCNI .Values.plugins.installRdmaCNI .Values.plugins.installOvsCNI .Values.plugins.installibSriovCNI .Values.plugins.installIpoibCNI }}
         - name: install-plugins
           image: {{ include "plugins.image" . | quote }}
@@ -243,9 +263,14 @@ spec:
         {{- with .Values.spiderpoolAgent.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.spiderpoolAgent.securityContext }}
+        {{- if or .Values.dra.enabled .Values.spiderpoolAgent.securityContext }}
         securityContext:
+          {{- if .Values.dra.enabled }}
+          privileged: true
+          {{- end }}
+        {{- with .Values.spiderpoolAgent.securityContext }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         - name: config-path
@@ -258,6 +283,19 @@ spec:
         {{- if .Values.multus.multusCNI.uninstall }}
         - name: cni
           mountPath: /host/etc/cni/net.d
+        {{- end }}
+        {{- if .Values.dra.enabled }}
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
+        - name: plugins
+          mountPath: /var/lib/kubelet/plugins
+          mountPropagation: Bidirectional
+        - name: cdi
+          mountPath: /var/run/cdi
+        {{- if .Values.dra.hostDevicePath }}
+        - name: library
+          mountPath: {{ .Values.dra.hostDevicePath }}
+        {{- end }}
         {{- end }}
         {{- if .Values.spiderpoolAgent.extraVolumes }}
         {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.extraVolumeMounts "context" $ ) | nindent 8 }}
@@ -288,6 +326,39 @@ spec:
           items:
             - key: cni-conf.json
               path: 00-multus.conf
+      {{- end }}
+      {{- if .Values.dra.enabled }}
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /etc/os-release
+          type: File
+        name: os-release
+      - hostPath:
+          path: /usr/lib
+        name: library
+      - hostPath:
+          path: /usr/lib64
+        name: library64
+      - hostPath:
+          path: /usr/bin
+          type: Directory
+        name: ofed
+      - name: plugins-registry
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+      - name: plugins
+        hostPath:
+          path: /var/lib/kubelet/plugins
+      - name: cdi
+        hostPath:
+          path: /var/run/cdi
+      {{- if .Values.dra.hostDevicePath }}
+      - name: library
+        hostPath: 
+          path: {{ .Values.dra.hostDevicePath }}
+      {{- end }}
       {{- end }}
       {{- if .Values.spiderpoolAgent.extraVolumeMounts }}
       {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.extraVolumeMounts "context" $ ) | nindent 6 }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/deleteHook.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/deleteHook.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.spiderpoolController.cleanup.enable }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.spiderpoolController.name | trunc 48 | trimSuffix "-" }}-hook-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+      containers:
+        - name: pre-delete
+          image: {{ include "spiderpool.spiderpoolController.image" . | quote }}
+          command:
+            - {{ .Values.spiderpoolController.binName }}
+            - clean
+            - --validate
+            - {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+            - --mutating
+            - {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+          env:
+            - name: SPIDERPOOL_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SPIDERPOOL_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: Never
+  backoffLimit: 2
+{{- end }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
@@ -112,7 +112,7 @@ spec:
       value: {{ toJson .Values.clusterDefaultPool.ipv4IPRanges | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv4Gateway | quote }}
-    {{- if .Values.ipam.enableSpiderSubnet }}
+    {{- if .Values.ipam.spidersubnet.enable }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_SUBNET_NAME
       value: {{ .Values.clusterDefaultPool.ipv4SubnetName | quote }}
     {{- end }}
@@ -126,7 +126,7 @@ spec:
       value: {{ toJson .Values.clusterDefaultPool.ipv6IPRanges | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv6Gateway | quote }}
-    {{- if .Values.ipam.enableSpiderSubnet }}
+    {{- if .Values.ipam.spidersubnet.enable }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_SUBNET_NAME
       value: {{ .Values.clusterDefaultPool.ipv6SubnetName | quote }}
     {{- end }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/rdma-shared-dp/rdma-shared-dp.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/rdma-shared-dp/rdma-shared-dp.yaml
@@ -22,7 +22,8 @@ data:
              "rdmaHcaMax": {{ .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.rdmaHcaMax }},
              "selectors": {
                "vendors": [{{ .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.vendors | quote }}],
-               "deviceIDs": [{{ .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs | quote }}]
+               "deviceIDs": [{{ .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs | quote }}],
+               "ifNames": {{ toJson .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.ifNames }}
               }
         }]
     }

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/resourceclass.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/resourceclass.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.dra.enabled }}
+apiVersion: resource.k8s.io/v1alpha2
+kind: ResourceClass
+metadata:
+  name: netresources.spidernet.io
+driverName: netresources.spidernet.io
+{{- end }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/role.yaml
@@ -42,6 +42,31 @@ rules:
   - list
   - watch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets
@@ -97,6 +122,33 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - podschedulingcontexts
+  - podschedulingcontexts/status
+  - resourceclaims
+  - resourceclaims/status
+  - resourceclaimtemplates
+  - resourceclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spiderclaimparameters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - spiderpool.spidernet.io
   resources:

--- a/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
@@ -53,11 +53,16 @@ ipam:
   ## @param ipam.enableKubevirtStaticIP the feature to keep kubevirt vm pod static IP
   enableKubevirtStaticIP: true
 
-  ## @param ipam.enableSpiderSubnet SpiderSubnet feature gate.
-  enableSpiderSubnet: true
+  spidersubnet:
+    ## @param ipam.spidersubnet.enable SpiderSubnet feature.
+    enable: true
 
-  ## @param ipam.subnetDefaultFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
-  subnetDefaultFlexibleIPNumber: 1
+    autoPool:
+      ## @param ipam.spidersubnet.autoPool.enable SpiderSubnet Auto IPPool feature.
+      enable: true
+
+      ## @param ipam.spidersubnet.autoPool.defaultRedundantIPNumber the default redundant IP number of SpiderSubnet feature auto-created IPPools
+      defaultRedundantIPNumber: 1
 
   gc:
     ## @param ipam.gc.enabled enable retrieve IP in spiderippool CR
@@ -197,6 +202,9 @@ rdma:
       ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs rdma device IDs, default to mellanox device
       deviceIDs: "1017"
 
+      ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.ifNames rdma target device name, default to empty list.
+      ifNames: []
+
 ## @section multus parameters
 ##
 multus:
@@ -260,6 +268,16 @@ multus:
 
       ## @param multus.multusCNI.log.logFile the multus-CNI daemonset pod log file
       logFile: "/var/log/multus.log"
+
+## @section dra parameters
+##
+dra:
+  ## @param dra.enabled to enable dra feature
+  enabled: false
+  ## @param dra.cdiRootPath the dir of cdi root
+  cdiRootPath: "/var/run/cdi"
+  ## @param dra.hostDevicePath the dir path of the device
+  hostDevicePath: ""
 
 ## @section plugins parameters
 ##
@@ -360,7 +378,7 @@ spiderpoolAgent:
     digest: ""
 
     ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.3
+    tag: v1.0.0-rc0
 
     ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
     imagePullSecrets: []
@@ -544,7 +562,7 @@ spiderpoolController:
     digest: ""
 
     ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.3
+    tag: v1.0.0-rc0
 
     ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
     imagePullSecrets: []
@@ -749,6 +767,10 @@ spiderpoolController:
       ## @param spiderpoolController.tls.auto.extraDnsNames extra DNS names of server cert for auto method
       extraDnsNames: []
 
+  cleanup:
+    ## @param spiderpoolController.cleanup.enable clean up resources when helm uninstall
+    enable: true
+
 ## @section spiderpoolInit parameters
 ##
 spiderpoolInit:
@@ -775,7 +797,7 @@ spiderpoolInit:
     digest: ""
 
     ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.3
+    tag: v1.0.0-rc0
 
     ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
     imagePullSecrets: []

--- a/charts/spiderpool/spiderpool/values.schema.json
+++ b/charts/spiderpool/spiderpool/values.schema.json
@@ -80,6 +80,32 @@
                         }
                     }
                 },
+                "dra": {
+                    "type": "object",
+                    "description": "Dra Configuration",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable dra"
+                        }
+                    }
+                },
+                "netmaterial": {
+                    "type": "object",
+                    "description": "Netmaterial Image Configuration",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "title": "repository",
+                                    "type": "string",
+                                    "default": "daocloud/netmaterial"
+                                }
+                            }
+                        }
+                    }
+                },
                 "multus": {
                     "type": "object",
                     "title": "Multus Setting",

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -42,10 +42,14 @@ spiderpool:
     enableStatefulSet: true
     ## @param ipam.enableKubevirtStaticIP the feature to keep kubevirt vm pod static IP
     enableKubevirtStaticIP: true
-    ## @param ipam.enableSpiderSubnet SpiderSubnet feature gate.
-    enableSpiderSubnet: true
-    ## @param ipam.subnetDefaultFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
-    subnetDefaultFlexibleIPNumber: 1
+    spidersubnet:
+      ## @param ipam.spidersubnet.enable SpiderSubnet feature.
+      enable: true
+      autoPool:
+        ## @param ipam.spidersubnet.autoPool.enable SpiderSubnet Auto IPPool feature.
+        enable: true
+        ## @param ipam.spidersubnet.autoPool.defaultRedundantIPNumber the default redundant IP number of SpiderSubnet feature auto-created IPPools
+        defaultRedundantIPNumber: 1
     gc:
       ## @param ipam.gc.enabled enable retrieve IP in spiderippool CR
       enabled: true
@@ -148,6 +152,8 @@ spiderpool:
         vendors: "15b3"
         ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.deviceIDs rdma device IDs, default to mellanox device
         deviceIDs: "1017"
+        ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.ifNames rdma target device name, default to empty list.
+        ifNames: []
   ## @section multus parameters
   ##
   multus:
@@ -198,6 +204,15 @@ spiderpool:
         logLevel: "debug"
         ## @param multus.multusCNI.log.logFile the multus-CNI daemonset pod log file
         logFile: "/var/log/multus.log"
+  ## @section dra parameters
+  ##
+  dra:
+    ## @param dra.enabled to enable dra feature
+    enabled: false
+    ## @param dra.cdiRootPath the dir of cdi root
+    cdiRootPath: "/var/run/cdi"
+    ## @param dra.hostDevicePath the dir path of the device
+    hostDevicePath: "/usr/lib/libsmc-preload.so"
   ## @section plugins parameters
   ##
   plugins:
@@ -270,7 +285,7 @@ spiderpool:
       ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
       digest: ""
       ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.3
+      tag: v1.0.0-rc0
       ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -408,7 +423,7 @@ spiderpool:
       ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
       digest: ""
       ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.3
+      tag: v1.0.0-rc0
       ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -566,6 +581,9 @@ spiderpool:
         extraIpAddresses: []
         ## @param spiderpoolController.tls.auto.extraDnsNames extra DNS names of server cert for auto method
         extraDnsNames: []
+    cleanup:
+      ## @param spiderpoolController.cleanup.enable clean up resources when helm uninstall
+      enable: true
   ## @section spiderpoolInit parameters
   ##
   spiderpoolInit:
@@ -585,7 +603,7 @@ spiderpool:
       ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
       digest: ""
       ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-      tag: v0.9.3
+      tag: v1.0.0-rc0
       ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -710,3 +728,9 @@ spiderpool:
         repository: k8snetworkplumbingwg/sriov-network-operator-webhook
         ## @param sriov.image.webhook.tag the image tag
         tag: v1.2.0
+  netmaterial:
+    image:
+      registry: ghcr.m.daocloud.io
+      repository: daocloud/netmaterial
+      tag: latest
+      pullPolicy: IfNotPresent

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,14 +30,15 @@ e2e:
             	echo "the project $${ITEM}  needs a standby kind cluster" ; \
 				make init-kind -e KIND_CONFIG_PATH=$${CONFIG_PATH} || { echo "error, failed to setup kind for $${ITEM}"; exit 1 ;} ; \
             fi ; \
+			VERSION=`yq ".version"  $(ROOT_DIR)/charts/$(PROJECT)/$(PROJECT)/Chart.yaml ` || { echo "error, failed to get charts version" ; exit 1 ; } ;\
             if ( unset NO_IMAGE ;  source $(ROOT_DIR)/charts/$${ITEM}/config && [ "$${NO_IMAGE}" == "true" ] ) ; then \
               	echo "ignore sync project $${ITEM}"; \
             else \
 				echo "sync project $${ITEM}"; \
-				make sync -e PROJECT=$${ITEM} || { echo "error, failed to sync $${ITEM}" ; FAILED_PROJECT+=" $${ITEM} " ; continue ; } ; \
+				make sync -e PROJECT=$${ITEM} -e VERSION=$${VERSION} || { echo "error, failed to sync $${ITEM}" ; FAILED_PROJECT+=" $${ITEM} " ; continue ; } ; \
             fi ; \
 			echo "deploy project $${ITEM}"; \
-			make deploy -e INSTALL_PATH=$${INSTALL_PATH}  -e PROJECT=$${ITEM} || { echo "error, failed to deploy $${ITEM}" ;FAILED_PROJECT+=" $${ITEM} " ;  ./clean.sh "$(KIND_KUBECONFIG)" || true ; continue ; } ; \
+			make deploy -e INSTALL_PATH=$${INSTALL_PATH} -e PROJECT=$${ITEM} -e VERSION=$${VERSION} || { echo "error, failed to deploy $${ITEM}" ;FAILED_PROJECT+=" $${ITEM} " ;  ./clean.sh "$(KIND_KUBECONFIG)" || true ; continue ; } ; \
 			./clean.sh "$(KIND_KUBECONFIG)" || true ; \
 			SUCCEED_PROJECT+=" $${ITEM} " ; \
 	  	done ; \
@@ -93,10 +94,10 @@ init-kind: checkBin clean
 
 .PHONY: sync
 sync: PROJECT=
+sync: VERSION=
 sync: checkBin
 	@ echo "sync $(PROJECT) charts and images to local registry"
 	set -x ; CHART_PATH=$(ROOT_DIR)/charts/$(PROJECT) ; \
-	VERSION=`yq ".version"  $(ROOT_DIR)/charts/$(PROJECT)/$(PROJECT)/Chart.yaml ` || { echo "error, failed to get charts version" ; exit 1 ; } ;\
 	echo "chart move $(PROJECT) $${VERSION}" ; \
 	mkdir -p _tmp && DIR=_tmp ;\
     relok8s chart move $${CHART_PATH}/$(PROJECT) --to-intermediate-bundle $${DIR}/$(PROJECT)_$${VERSION}.bundle.tar -y --retries 3 || { echo "error, failed to save charts and images to local" ; exit 1 ; } ; \
@@ -110,17 +111,18 @@ target:  \n \
          url: http://127.0.0.1:30081"; \
      echo -e "$${CONFIG}" > $${DIR}/config.yaml ; \
      charts-syncer sync --config $${DIR}/config.yaml --insecure true || { echo "error, failed to sync charts and images to local registry" ; exit 1 ; } ; \
-	 make checkImages -e PROJECT=$${PROJECT} || { echo "error, failed to check $${PROJECT} images registry" ; exit 1 ; } ; \
+	 make checkImages -e PROJECT=$${PROJECT} -e VERSION=$${VERSION} || { echo "error, failed to check $${PROJECT} images registry" ; exit 1 ; } ; \
      rm -rf $${DIR} ;
 
 .PHONY: checkImages
 checkImages: PROJECT=
+checkImages: VERSION=
 checkImages: checkBin
 	@ echo "check $(PROJECT) images registry"
 	set -x ; helm repo update chart-museum  --kubeconfig $(KIND_KUBECONFIG) || { echo "error, failed to update helm chart-museum repo " ; exit 1 ; } ; \
-	helm search repo chart-museum  --kubeconfig $(KIND_KUBECONFIG) ; \
-	helm template test chart-museum/$${PROJECT} | grep " image: " ; \
-    IMAGE_LIST=` helm template test chart-museum/$${PROJECT}  | grep " image: " | tr -d "'" | tr -d '"' | tr -d '-' | grep -v " image: {{ "| awk '{print $$2}' | uniq ` ;\
+	helm search repo chart-museum --devel -l --kubeconfig $(KIND_KUBECONFIG) ; \
+	helm template test chart-museum/$${PROJECT} --version $${VERSION} --kubeconfig $(KIND_KUBECONFIG) | grep " image: " ; \
+    IMAGE_LIST=` helm template test chart-museum/$${PROJECT} --version $${VERSION} | grep " image: " | tr -d "'" | tr -d '"' | tr -d '-' | grep -v " image: {{ "| awk '{print $$2}' | uniq ` ;\
 	if [ -z "$${IMAGE_LIST}" ] ; then \
 		echo "error, failed to find image from chart template for $(PROJECT)" ; exit 1 ; \
 	else \
@@ -143,6 +145,7 @@ checkImages: checkBin
 .PHONY: deploy
 deploy: INSTALL_PATH=
 deploy: PROJECT=
+deploy: VERSION=
 deploy: TRY_LOAD_LOCAL_IMAGE ?= false
 deploy: checkBin
 	@ echo "helm install for $(PROJECT) with $(INSTALL_PATH)"
@@ -168,7 +171,7 @@ deploy: checkBin
             fi ; \
 		fi  ;\
 		chmod +x $(INSTALL_PATH) ; \
-		if $(INSTALL_PATH) "$(KIND_KUBECONFIG)" "$(KIND_CLUSTER_NAME)" ; then \
+		if $(INSTALL_PATH) "$(KIND_KUBECONFIG)" "$(KIND_CLUSTER_NAME)" "$(VERSION)" ; then \
 			echo "succeeded to deploy $(PROJECT)" ; \
 			exit 0 ; \
 		else  \

--- a/test/spiderpool/install.sh
+++ b/test/spiderpool/install.sh
@@ -4,13 +4,16 @@ CURRENT_FILENAME=$( basename "$0" )
 CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
 
 KIND_KUBECONFIG=$1
+CHART_VERSION=$3
 
 [ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+[ -n "$CHART_VERSION" ] || { echo "error, failed to find chart version $CHART_VERSION " ; exit 1 ; }
 
 echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+echo "CHART_VERSION: $CHART_VERSION"
 
 helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
-HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+HELM_MUST_OPTION=" --version ${CHART_VERSION} --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
 
 #==================== add your deploy code bellow =============
 #==================== notice , prometheus CRD has been deployed , so you no need to =============
@@ -45,13 +48,12 @@ helm install spiderpool chart-museum/spiderpool  ${HELM_MUST_OPTION} \
 
 if (($?==0)) ; then
   echo "succeeded to deploy $CHART_DIR"
+  kubectl --kubeconfig ${KIND_KUBECONFIG} get pod -o wide -A
   kubectl get spidercoordinator default -o yaml --kubeconfig ${KIND_KUBECONFIG}
   kubectl get smc -A -o yaml --kubeconfig ${KIND_KUBECONFIG}
-
   exit 0
 else
   echo "error, faild to deploy $CHART_DIR"
     kubectl --kubeconfig ${KIND_KUBECONFIG} get pod -o wide -A
-
   exit 1
 fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

bump spiderpool to v1.0.0-rc0

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #