### PR TITLE
upgrade nvidia-vgpu image version

### DIFF
--- a/charts/nvidia-vgpu/custom-sub.sh
+++ b/charts/nvidia-vgpu/custom-sub.sh
@@ -138,18 +138,6 @@ elif [ $os == "Linux" ];then
           " charts/hami/values.yaml
 fi
 
-# add device-cores-scaling config key
-line=$(sed -n -e '/deviceMemoryScaling: 1/=' charts/hami/values.yaml  | head -n 1)
-if [ $os == "Darwin" ];then
-    sed -i "" "$((line)) i\\
-  deviceCoresScaling: 1.0
-    " charts/hami/values.yaml
-elif [ $os == "Linux" ];then
-    sed -i "$((line)) i\\
-  deviceCoresScaling: 1.0
-    " charts/hami/values.yaml
-fi
-
 # add resources config key
 cat >> charts/hami/values.yaml << EOL
 resources:

--- a/charts/nvidia-vgpu/custom.sh
+++ b/charts/nvidia-vgpu/custom.sh
@@ -328,6 +328,6 @@ yq -i '.devicePlugin.deviceMemoryScaling=1.0' charts/hami/values.yaml
 
 yq -i '.hami.devicePlugin.deviceMemoryScaling=1.0' values.yaml
 
-# fix version to 2.3.10
-yq -i '.hami.version="v2.3.10"' values.yaml
-yq -i '.version="v2.3.10"' charts/hami/values.yaml
+# fix version to 2.3.11
+yq -i '.hami.version="v2.3.11"' values.yaml
+yq -i '.version="v2.3.11"' charts/hami/values.yaml

--- a/charts/nvidia-vgpu/nvidia-vgpu/charts/hami/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/charts/hami/values.yaml
@@ -3,7 +3,7 @@
 nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
-version: "v2.3.10"
+version: "v2.3.11"
 #Nvidia GPU Parameters
 resourceName: "nvidia.com/vgpu"
 resourceMem: "nvidia.com/gpumem"
@@ -108,7 +108,6 @@ devicePlugin:
   monitorctrPath: /usr/local/vgpu/containers
   imagePullPolicy: IfNotPresent
   deviceSplitCount: 10
-  deviceCoresScaling: 1.0
   deviceMemoryScaling: 1.0
   deviceCoreScaling: 1.0
   runtimeClassName: ""

--- a/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
+++ b/charts/nvidia-vgpu/nvidia-vgpu/values.yaml
@@ -4,7 +4,7 @@ hami:
   nameOverride: ""
   fullnameOverride: ""
   imagePullSecrets: []
-  version: "v2.3.10"
+  version: "v2.3.11"
   #Nvidia GPU Parameters
   resourceName: "nvidia.com/vgpu"
   resourceMem: "nvidia.com/gpumem"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
当前这个PR是 对 这个PR的 补充。
https://github.com/DaoCloud/dce-charts-repackage/pull/2107 


这个 PR 升级了 HAMi 的版本。
但是 HAMi 因为发版本的问题，chart 包升级了，但是 image 版本是没有跟着升级。


这个 PR. 是将镜像也升级一下。 不升级镜像将不能使用，因为旧版本还没有 ascend 相关的参数

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


<img width="1428" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/17962021/ea8bee0d-1bbb-4080-a7c0-85236f50e4f3">


<img width="738" alt="image" src="https://github.com/DaoCloud/dce-charts-repackage/assets/17962021/2f6bc63b-6467-42bf-983a-31e591004b49">
