### PR TITLE
update argo-rollouts to 2.35.3

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+    - kind: added
+      description: Support revisionHistoryLimit
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.0
+appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,8 +19,8 @@ maintainers:
 name: argo-rollouts
 sources:
   - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.35.3
 dependencies:
   - name: argo-rollouts
-    version: "2.32.0"
+    version: "2.35.3"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-rollouts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/README.md
@@ -50,6 +50,8 @@ For full list of changes please check ArtifactHub [changelog].
 | extraObjects | list | `[]` | Additional manifests to deploy within the chart. A list of objects. |
 | fullnameOverride | string | `nil` | String to fully override "argo-rollouts.fullname" template |
 | global.deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
+| global.deploymentLabels | object | `{}` | Labels for all deployed Deployments |
+| global.revisionHistoryLimit | int | `10` | Number of old deployment ReplicaSets to retain. The rest will be garbage collected. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | installCRDs | bool | `true` | Install and upgrade CRDs |
 | keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
@@ -60,11 +62,15 @@ For full list of changes please check ArtifactHub [changelog].
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
 | notifications.templates | object | `{}` | Notification templates |
 | notifications.triggers | object | `{}` | The trigger defines the condition when the notification should be sent |
+| providerRBAC.additionalRules | list | `[]` | Additional RBAC rules for others providers |
 | providerRBAC.enabled | bool | `true` | Toggles addition of provider-specific RBAC rules to the controller Role and ClusterRole |
 | providerRBAC.providers.ambassador | bool | `true` | Adds RBAC rules for the Ambassador provider |
 | providerRBAC.providers.apisix | bool | `true` | Adds RBAC rules for the Apisix provider |
 | providerRBAC.providers.awsAppMesh | bool | `true` | Adds RBAC rules for the AWS App Mesh provider |
 | providerRBAC.providers.awsLoadBalancerController | bool | `true` | Adds RBAC rules for the AWS Load Balancer Controller provider |
+| providerRBAC.providers.contour | bool | `true` | Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md` |
+| providerRBAC.providers.gatewayAPI | bool | `true` | Adds RBAC rules for the Gateway API provider |
+| providerRBAC.providers.glooPlatform | bool | `true` | Adds RBAC rules for the Gloo Platform provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform/blob/main/README.md` |
 | providerRBAC.providers.istio | bool | `true` | Adds RBAC rules for the Istio provider |
 | providerRBAC.providers.smi | bool | `true` | Adds RBAC rules for the SMI provider |
 | providerRBAC.providers.traefik | bool | `true` | Adds RBAC rules for the Traefik provider |
@@ -80,6 +86,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.containerPorts.metrics | int | `8090` | Metrics container port |
 | controller.createClusterRole | bool | `true` | flag to enable creation of cluster controller role (requires cluster RBAC) |
 | controller.deploymentAnnotations | object | `{}` | Annotations to be added to the controller deployment |
+| controller.deploymentLabels | object | `{}` | Labels to be added to the controller deployment |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-controller.  A list of flags. |
 | controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |
 | controller.extraEnv | list | `[]` | Additional environment variables for rollouts-controller. A list of name/value maps. |
@@ -89,6 +96,9 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | controller.initContainers | list | `[]` | Init containers to add to the rollouts controller pod |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
+| controller.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
+| controller.logging.kloglevel | string | `"0"` | Set the klog logging level |
+| controller.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
 | controller.metrics.service.annotations | object | `{}` | Service annotations |
@@ -107,6 +117,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
+| controller.podLabels | object | `{}` | Labels to be added to the application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
@@ -133,6 +144,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
 | dashboard.deploymentAnnotations | object | `{}` | Annotations to be added to the dashboard deployment |
+| dashboard.deploymentLabels | object | `{}` | Labels to be added to the dashboard deployment |
 | dashboard.enabled | bool | `false` | Deploy dashboard server |
 | dashboard.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-dashboard. A list of flags. |
 | dashboard.extraEnv | list | `[]` | Additional environment variables for rollouts-dashboard. A list of name/value maps. |
@@ -149,6 +161,8 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.ingress.pathType | string | `"Prefix"` | Dashboard ingress path type |
 | dashboard.ingress.paths | list | `["/"]` | Dashboard ingress paths |
 | dashboard.ingress.tls | list | `[]` | Dashboard ingress tls |
+| dashboard.logging.kloglevel | string | `"0"` | Set the klog logging level |
+| dashboard.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | dashboard.nodeSelector | object | `{}` | [Node selector] |
 | dashboard.pdb.annotations | object | `{}` | Annotations to be added to dashboard [Pod Disruption Budget] |
 | dashboard.pdb.enabled | bool | `false` | Deploy a [Pod Disruption Budget] for the dashboard |
@@ -156,6 +170,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
+| dashboard.podLabels | object | `{}` | Labels to be added to the application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.0
+    - kind: added
+      description: Support revisionHistoryLimit
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.0
+appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,4 +19,4 @@ maintainers:
 name: argo-rollouts
 sources:
 - https://github.com/argoproj/argo-rollouts
-version: 2.32.0
+version: 2.35.3

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
@@ -50,6 +50,8 @@ For full list of changes please check ArtifactHub [changelog].
 | extraObjects | list | `[]` | Additional manifests to deploy within the chart. A list of objects. |
 | fullnameOverride | string | `nil` | String to fully override "argo-rollouts.fullname" template |
 | global.deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
+| global.deploymentLabels | object | `{}` | Labels for all deployed Deployments |
+| global.revisionHistoryLimit | int | `10` | Number of old deployment ReplicaSets to retain. The rest will be garbage collected. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | installCRDs | bool | `true` | Install and upgrade CRDs |
 | keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
@@ -60,11 +62,15 @@ For full list of changes please check ArtifactHub [changelog].
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
 | notifications.templates | object | `{}` | Notification templates |
 | notifications.triggers | object | `{}` | The trigger defines the condition when the notification should be sent |
+| providerRBAC.additionalRules | list | `[]` | Additional RBAC rules for others providers |
 | providerRBAC.enabled | bool | `true` | Toggles addition of provider-specific RBAC rules to the controller Role and ClusterRole |
 | providerRBAC.providers.ambassador | bool | `true` | Adds RBAC rules for the Ambassador provider |
 | providerRBAC.providers.apisix | bool | `true` | Adds RBAC rules for the Apisix provider |
 | providerRBAC.providers.awsAppMesh | bool | `true` | Adds RBAC rules for the AWS App Mesh provider |
 | providerRBAC.providers.awsLoadBalancerController | bool | `true` | Adds RBAC rules for the AWS Load Balancer Controller provider |
+| providerRBAC.providers.contour | bool | `true` | Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md` |
+| providerRBAC.providers.gatewayAPI | bool | `true` | Adds RBAC rules for the Gateway API provider |
+| providerRBAC.providers.glooPlatform | bool | `true` | Adds RBAC rules for the Gloo Platform provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform/blob/main/README.md` |
 | providerRBAC.providers.istio | bool | `true` | Adds RBAC rules for the Istio provider |
 | providerRBAC.providers.smi | bool | `true` | Adds RBAC rules for the SMI provider |
 | providerRBAC.providers.traefik | bool | `true` | Adds RBAC rules for the Traefik provider |
@@ -80,6 +86,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.containerPorts.metrics | int | `8090` | Metrics container port |
 | controller.createClusterRole | bool | `true` | flag to enable creation of cluster controller role (requires cluster RBAC) |
 | controller.deploymentAnnotations | object | `{}` | Annotations to be added to the controller deployment |
+| controller.deploymentLabels | object | `{}` | Labels to be added to the controller deployment |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-controller.  A list of flags. |
 | controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |
 | controller.extraEnv | list | `[]` | Additional environment variables for rollouts-controller. A list of name/value maps. |
@@ -89,6 +96,9 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | controller.initContainers | list | `[]` | Init containers to add to the rollouts controller pod |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
+| controller.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
+| controller.logging.kloglevel | string | `"0"` | Set the klog logging level |
+| controller.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
 | controller.metrics.service.annotations | object | `{}` | Service annotations |
@@ -107,6 +117,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
+| controller.podLabels | object | `{}` | Labels to be added to the application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
@@ -133,6 +144,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
 | dashboard.deploymentAnnotations | object | `{}` | Annotations to be added to the dashboard deployment |
+| dashboard.deploymentLabels | object | `{}` | Labels to be added to the dashboard deployment |
 | dashboard.enabled | bool | `false` | Deploy dashboard server |
 | dashboard.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-dashboard. A list of flags. |
 | dashboard.extraEnv | list | `[]` | Additional environment variables for rollouts-dashboard. A list of name/value maps. |
@@ -149,6 +161,8 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.ingress.pathType | string | `"Prefix"` | Dashboard ingress path type |
 | dashboard.ingress.paths | list | `["/"]` | Dashboard ingress paths |
 | dashboard.ingress.tls | list | `[]` | Dashboard ingress tls |
+| dashboard.logging.kloglevel | string | `"0"` | Set the klog logging level |
+| dashboard.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | dashboard.nodeSelector | object | `{}` | [Node selector] |
 | dashboard.pdb.annotations | object | `{}` | Annotations to be added to dashboard [Pod Disruption Budget] |
 | dashboard.pdb.enabled | bool | `false` | Deploy a [Pod Disruption Budget] for the dashboard |
@@ -156,6 +170,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
+| dashboard.podLabels | object | `{}` | Labels to be added to the application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/clusterrole.yaml
@@ -94,11 +94,22 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get
   - list
   - watch
+{{- if .Values.providerRBAC.providers.gatewayAPI }}
+  - create
+  - update
+{{- end }}  
 # pod list/update needed for updating ephemeral data
 - apiGroups:
   - ""
@@ -254,6 +265,46 @@ rules:
   - watch
   - get
   - update
+{{- end }}
+{{- if .Values.providerRBAC.providers.contour }}
+  # Access needed when using the Contour provider
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+{{- end }}
+{{- if .Values.providerRBAC.providers.glooPlatform }}
+  # Access needed when using the Gloo Platform provider
+- apiGroups:
+  - networking.gloo.solo.io
+  resources:
+  - routetables
+  verbs:
+  - '*'
+{{- end }}
+{{- if .Values.providerRBAC.providers.gatewayAPI }}
+  # Access needed when using the Gateway API provider
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - grpcroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+{{- end }}
+{{- with .Values.providerRBAC.additionalRules }}
+{{ toYaml .  }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
+  {{- range $key, $value := (mergeOverwrite (deepCopy .Values.global.deploymentLabels) .Values.controller.deploymentLabels) }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
 spec:
@@ -20,6 +23,7 @@ spec:
   strategy:
     type: Recreate
   replicas: {{ .Values.controller.replicas }}
+  revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   template:
     metadata:
       {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.controller.podAnnotations) }}
@@ -31,7 +35,7 @@ spec:
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.controller.component }}
-        {{- range $key, $value := .Values.podLabels }}
+        {{- range $key, $value := (mergeOverwrite (deepCopy .Values.podLabels) .Values.controller.podLabels) }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
@@ -45,10 +49,13 @@ spec:
         args:
         - --healthzPort={{ .Values.controller.containerPorts.healthz }}
         - --metricsport={{ .Values.controller.containerPorts.metrics }}
+        - "--loglevel={{ .Values.controller.logging.level }}"
+        - "--logformat={{ .Values.controller.logging.format }}"
+        - "--kloglevel={{ .Values.controller.logging.kloglevel }}"
         {{- if not .Values.clusterInstall }}
         - --namespaced
         {{- end }}
-        {{- if gt .Values.controller.replicas 1.0 }}
+        {{- if gt (int .Values.controller.replicas) 1 }}
         - --leader-elect
         {{- end }}
         {{- with .Values.controller.extraArgs }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/role.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/role.yaml
@@ -95,11 +95,22 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get
   - list
   - watch
+{{- if .Values.providerRBAC.providers.gatewayAPI }}
+  - create
+  - update
+{{- end }}  
 # pod list/update needed for updating ephemeral data
 - apiGroups:
   - ""
@@ -254,6 +265,31 @@ rules:
   verbs:
   - watch
   - get
+  - update
+{{- end }}
+{{- if .Values.providerRBAC.providers.glooPlatform }}
+  # Access needed when using the Gloo Platform provider
+- apiGroups:
+  - networking.gloo.solo.io
+  resources:
+  - routetables
+  verbs:
+  - '*'
+{{- end }}
+{{- if .Values.providerRBAC.providers.gatewayAPI }}
+  # Access needed when using the Gateway API provider
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - grpcroutes
+  verbs:
+  - get
+  - list
+  - watch
   - update
 {{- end }}
 {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -189,13 +189,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2809,6 +2818,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2857,6 +2879,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}-dashboard
   namespace: {{ .Release.Namespace | quote }}
   labels:
+  {{- range $key, $value := (mergeOverwrite (deepCopy .Values.global.deploymentLabels) .Values.dashboard.deploymentLabels) }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
     app.kubernetes.io/component: {{ .Values.dashboard.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
 spec:
@@ -21,6 +24,7 @@ spec:
   strategy:
     type: Recreate
   replicas: {{ .Values.dashboard.replicas }}
+  revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   template:
     metadata:
       {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.dashboard.podAnnotations) }}
@@ -32,7 +36,7 @@ spec:
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.dashboard.component }}
-        {{- range $key, $value := .Values.podLabels }}
+        {{- range $key, $value := (mergeOverwrite (deepCopy .Values.podLabels) .Values.dashboard.podLabels) }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
@@ -45,6 +49,9 @@ spec:
       - image: {{ include "global.images.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global ) }}
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
         args:
+        - dashboard
+        - "--loglevel={{ .Values.dashboard.logging.level }}"
+        - "--kloglevel={{ .Values.dashboard.logging.kloglevel }}"
         {{- with .Values.dashboard.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
@@ -41,20 +41,35 @@ extraObjects: []
 global:
   # -- Annotations for all deployed Deployments
   deploymentAnnotations: {}
+  # -- Labels for all deployed Deployments
+  deploymentLabels: {}
+  # -- Number of old deployment ReplicaSets to retain. The rest will be garbage collected.
+  revisionHistoryLimit: 10
 
 controller:
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-controller
   # -- Annotations to be added to the controller deployment
   deploymentAnnotations: {}
+  # -- Labels to be added to the controller deployment
+  deploymentLabels: {}
   # -- Annotations to be added to application controller pods
   podAnnotations: {}
+  # -- Labels to be added to the application controller pods
+  podLabels: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
   tolerations: []
   # -- Assign custom [affinity] rules to the deployment
   affinity: {}
+  logging:
+    # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)
+    level: info
+    # -- Set the klog logging level
+    kloglevel: "0"
+    # -- Set the logging format (one of: `text`, `json`)
+    format: "text"
 
   # -- Assign custom [TopologySpreadConstraints] rules to the controller
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
@@ -262,6 +277,14 @@ providerRBAC:
     traefik: true
     # -- Adds RBAC rules for the Apisix provider
     apisix: true
+    # -- Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md`
+    contour: true
+    # -- Adds RBAC rules for the Gloo Platform provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform/blob/main/README.md`
+    glooPlatform: true
+    # -- Adds RBAC rules for the Gateway API provider
+    gatewayAPI: true
+  # -- Additional RBAC rules for others providers
+  additionalRules: []
 
 dashboard:
   # -- Deploy dashboard server
@@ -272,14 +295,23 @@ dashboard:
   component: rollouts-dashboard
   # -- Annotations to be added to the dashboard deployment
   deploymentAnnotations: {}
+  # -- Labels to be added to the dashboard deployment
+  deploymentLabels: {}
   # -- Annotations to be added to application dashboard pods
   podAnnotations: {}
+  # -- Labels to be added to the application dashboard pods
+  podLabels: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
   tolerations: []
   # -- Assign custom [affinity] rules to the deployment
   affinity: {}
+  logging:
+    # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)
+    level: info
+    # -- Set the klog logging level
+    kloglevel: "0"
 
   # -- Assign custom [TopologySpreadConstraints] rules to the dashboard server
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/charts/argo-rollouts/argo-rollouts/values.schema.json
+++ b/charts/argo-rollouts/argo-rollouts/values.schema.json
@@ -45,6 +45,9 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "extraArgs": {
                             "type": "array"
                         },
@@ -102,6 +105,20 @@
                                 },
                                 "timeoutSeconds": {
                                     "type": "integer"
+                                }
+                            }
+                        },
+                        "logging": {
+                            "type": "object",
+                            "properties": {
+                                "format": {
+                                    "type": "string"
+                                },
+                                "kloglevel": {
+                                    "type": "string"
+                                },
+                                "level": {
+                                    "type": "string"
                                 }
                             }
                         },
@@ -177,6 +194,9 @@
                             }
                         },
                         "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podLabels": {
                             "type": "object"
                         },
                         "priorityClassName": {
@@ -260,6 +280,9 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -321,6 +344,17 @@
                                 }
                             }
                         },
+                        "logging": {
+                            "type": "object",
+                            "properties": {
+                                "kloglevel": {
+                                    "type": "string"
+                                },
+                                "level": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "nodeSelector": {
                             "type": "object"
                         },
@@ -345,6 +379,9 @@
                             }
                         },
                         "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podLabels": {
                             "type": "object"
                         },
                         "podSecurityContext": {
@@ -442,11 +479,17 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "imageRegistry": {
                             "type": "string"
                         },
                         "repository": {
                             "type": "string"
+                        },
+                        "revisionHistoryLimit": {
+                            "type": "integer"
                         },
                         "tag": {
                             "type": "string"
@@ -510,6 +553,9 @@
                 "providerRBAC": {
                     "type": "object",
                     "properties": {
+                        "additionalRules": {
+                            "type": "array"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -526,6 +572,15 @@
                                     "type": "boolean"
                                 },
                                 "awsLoadBalancerController": {
+                                    "type": "boolean"
+                                },
+                                "contour": {
+                                    "type": "boolean"
+                                },
+                                "gatewayAPI": {
+                                    "type": "boolean"
+                                },
+                                "glooPlatform": {
                                     "type": "boolean"
                                 },
                                 "istio": {

--- a/charts/argo-rollouts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/values.yaml
@@ -36,22 +36,37 @@ argo-rollouts:
   global:
     # -- Annotations for all deployed Deployments
     deploymentAnnotations: {}
+    # -- Labels for all deployed Deployments
+    deploymentLabels: {}
+    # -- Number of old deployment ReplicaSets to retain. The rest will be garbage collected.
+    revisionHistoryLimit: 10
     imageRegistry: quay.m.daocloud.io
     repository: argoproj/argo-rollouts
-    tag: v1.6.0
+    tag: v1.6.6
   controller:
     # -- Value of label `app.kubernetes.io/component`
     component: rollouts-controller
     # -- Annotations to be added to the controller deployment
     deploymentAnnotations: {}
+    # -- Labels to be added to the controller deployment
+    deploymentLabels: {}
     # -- Annotations to be added to application controller pods
     podAnnotations: {}
+    # -- Labels to be added to the application controller pods
+    podLabels: {}
     # -- [Node selector]
     nodeSelector: {}
     # -- [Tolerations] for use with node taints
     tolerations: []
     # -- Assign custom [affinity] rules to the deployment
     affinity: {}
+    logging:
+      # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)
+      level: info
+      # -- Set the klog logging level
+      kloglevel: "0"
+      # -- Set the logging format (one of: `text`, `json`)
+      format: "text"
     # -- Assign custom [TopologySpreadConstraints] rules to the controller
     ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
     ## If labelSelector is left out, it will default to the labelSelector configuration of the deployment
@@ -70,7 +85,7 @@ argo-rollouts:
       # -- Repository to use
       repository: argoproj/argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.0"
+      tag: "v1.6.6"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-controller.  A list of flags.
@@ -242,6 +257,14 @@ argo-rollouts:
       traefik: true
       # -- Adds RBAC rules for the Apisix provider
       apisix: true
+      # -- Adds RBAC rules for the Contour provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/README.md`
+      contour: true
+      # -- Adds RBAC rules for the Gloo Platform provider, see `https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-glooplatform/blob/main/README.md`
+      glooPlatform: true
+      # -- Adds RBAC rules for the Gateway API provider
+      gatewayAPI: true
+    # -- Additional RBAC rules for others providers
+    additionalRules: []
   dashboard:
     # -- Deploy dashboard server
     enabled: false
@@ -251,14 +274,23 @@ argo-rollouts:
     component: rollouts-dashboard
     # -- Annotations to be added to the dashboard deployment
     deploymentAnnotations: {}
+    # -- Labels to be added to the dashboard deployment
+    deploymentLabels: {}
     # -- Annotations to be added to application dashboard pods
     podAnnotations: {}
+    # -- Labels to be added to the application dashboard pods
+    podLabels: {}
     # -- [Node selector]
     nodeSelector: {}
     # -- [Tolerations] for use with node taints
     tolerations: []
     # -- Assign custom [affinity] rules to the deployment
     affinity: {}
+    logging:
+      # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)
+      level: info
+      # -- Set the klog logging level
+      kloglevel: "0"
     # -- Assign custom [TopologySpreadConstraints] rules to the dashboard server
     ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
     ## If labelSelector is left out, it will default to the labelSelector configuration of the deployment
@@ -279,7 +311,7 @@ argo-rollouts:
       # --  Repository to use
       repository: argoproj/kubectl-argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.0"
+      tag: "v1.6.6"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-dashboard. A list of flags.

--- a/charts/argo-rollouts/config
+++ b/charts/argo-rollouts/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-rollouts
 export CHART_NAME=argo-rollouts
-export VERSION=2.32.0
+export VERSION=2.35.3
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/argo-rollouts/parent/values.schema.json
+++ b/charts/argo-rollouts/parent/values.schema.json
@@ -45,6 +45,9 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "extraArgs": {
                             "type": "array"
                         },
@@ -102,6 +105,20 @@
                                 },
                                 "timeoutSeconds": {
                                     "type": "integer"
+                                }
+                            }
+                        },
+                        "logging": {
+                            "type": "object",
+                            "properties": {
+                                "format": {
+                                    "type": "string"
+                                },
+                                "kloglevel": {
+                                    "type": "string"
+                                },
+                                "level": {
+                                    "type": "string"
                                 }
                             }
                         },
@@ -177,6 +194,9 @@
                             }
                         },
                         "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podLabels": {
                             "type": "object"
                         },
                         "priorityClassName": {
@@ -260,6 +280,9 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -321,6 +344,17 @@
                                 }
                             }
                         },
+                        "logging": {
+                            "type": "object",
+                            "properties": {
+                                "kloglevel": {
+                                    "type": "string"
+                                },
+                                "level": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "nodeSelector": {
                             "type": "object"
                         },
@@ -345,6 +379,9 @@
                             }
                         },
                         "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podLabels": {
                             "type": "object"
                         },
                         "podSecurityContext": {
@@ -442,11 +479,17 @@
                         "deploymentAnnotations": {
                             "type": "object"
                         },
+                        "deploymentLabels": {
+                            "type": "object"
+                        },
                         "imageRegistry": {
                             "type": "string"
                         },
                         "repository": {
                             "type": "string"
+                        },
+                        "revisionHistoryLimit": {
+                            "type": "integer"
                         },
                         "tag": {
                             "type": "string"
@@ -510,6 +553,9 @@
                 "providerRBAC": {
                     "type": "object",
                     "properties": {
+                        "additionalRules": {
+                            "type": "array"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -526,6 +572,15 @@
                                     "type": "boolean"
                                 },
                                 "awsLoadBalancerController": {
+                                    "type": "boolean"
+                                },
+                                "contour": {
+                                    "type": "boolean"
+                                },
+                                "gatewayAPI": {
+                                    "type": "boolean"
+                                },
+                                "glooPlatform": {
                                     "type": "boolean"
                                 },
                                 "istio": {


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #