### PR TITLE
fix: gpu operator push chart error

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -143,7 +143,7 @@ jobs:
           for ITEM in ${{ steps.package.outputs.project_list }} ; do
               DAO_PROJECT=` grep "DAOCLOUD_REPO_PROJECT" ${ROOT_DIR}/charts/${ITEM}/config | awk -F= '{print $2}' | tr -d ' ' `
               [ -z "$DAO_PROJECT" ] && echo "error, failed to find DAOCLOUD_REPO_PROJECT config in charts/${ITEM}/config " && exit 1
-              CHART_FILE=` ls | grep -o -E "^${ITEM}-[0-9]+.[0-9]+.[0-9]+.*.tgz" `
+              CHART_FILE=` ls | grep -o -E "^${ITEM}-[v0-9]+.[0-9]+.[0-9]+.*.tgz" `
               [ ! -f "${CHART_FILE}" ] && echo "error, failed to find chart.tgz for $ITEM " && ls && exit 2
               DAO_ADDRESS=${{ env.DAOCLOUD_HARBOR_URL }}/chartrepo/${DAO_PROJECT}
               echo "push $CHART_FILE to $DAO_ADDRESS "


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

fix：https://github.com/DaoCloud/dce-charts-repackage/issues/2200

![Code 2024-06-23 15 39 31](https://github.com/DaoCloud/dce-charts-repackage/assets/51119718/fc45917d-4a12-482a-a61f-40328c0dee45)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #