### PR TITLE
add monkeys chart

### DIFF
--- a/charts/monkeys-core/config
+++ b/charts/monkeys-core/config
@@ -1,0 +1,20 @@
+export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://inf-monkeys.github.io/helm-charts
+export REPO_NAME=inf-monkeys
+export CHART_NAME=core
+export VERSION=v0.1.9
+
+# pr issue
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=zgfh
+export TEST_ASSIGNER=zgfh
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+export NO_TRIVY=false

--- a/charts/monkeys-core/custom.sh
+++ b/charts/monkeys-core/custom.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+yq -i '
+  .core.images.server.registry = "m.daocloud.io/docker.io" |
+  .core.images.web.registry = "m.daocloud.io/docker.io" |
+  .core.images.web.registry = "m.daocloud.io/docker.io" |
+  .core.images.admin.registry = "m.daocloud.io/docker.io" |
+  .core.images.conductor.registry = "m.daocloud.io/docker.io" |
+  .core.images.oneapi.registry = "m.daocloud.io/docker.io" |
+  .core.images.busybox.registry = "m.daocloud.io/docker.io" |
+  .core.images.clash.registry = "m.daocloud.io/docker.io" |
+  .core.images.nginx.registry = "m.daocloud.io/docker.io" |
+  .core.oneapi.enabled=false |
+  .core.proxy.resources={"limits":{"cpu":"1000m","memory":"2048M"},"requests":{"cpu":"100m","memory":"125M"}} |
+  .core.server.resources={"limits":{"cpu":"1000m","memory":"2048M"},"requests":{"cpu":"100m","memory":"125M"}} |
+  .core.web.resources={"limits":{"cpu":"1000m","memory":"2048M"},"requests":{"cpu":"100m","memory":"125M"}} |
+  .core.conductor.resources={"limits":{"cpu":"1000m","memory":"2048M"},"requests":{"cpu":"100m","memory":"125M"}} |
+  .core.GProductNavigator.enabled=true |
+  .core.postgresql.enabled=false |
+  .core.externalPostgresql.enabled=true |
+  .core.externalPostgresql.host="pg-svc.infra-drun.svc" |
+  .core.externalPostgresql.port=5432 |
+  .core.externalPostgresql.username="postgres" |
+  .core.externalConductorPostgresql.enabled=true |
+  .core.externalConductorPostgresql.host="pg-svc.infra-drun.svc" |
+  .core.externalConductorPostgresql.port=5432 |
+  .core.externalConductorPostgresql.username="postgres" |
+  .core.oneapi.enabled=false |
+  .core.elasticsearch.enabled=false |
+  .core.externalElasticsearch.enabled=true |
+  .core.externalElasticsearch.url="http://mcamel-common-es-cluster-masters-es-http.mcamel-system.svc:9200" |
+  .core.externalElasticsearch.username="elastic" |
+  .core.minio.enabled=false |
+  .core.externalS3.enabled=true |
+  .core.externalS3.endpoint="https://minio-svc.infra-drun.svc" |
+  .core.externalS3.accessKeyId="minio" |
+  .core.externalS3.region="us-east-1" |
+  .core.externalS3.bucket="monkeys" 
+  
+
+ ' values.yaml
+
+
+
+yq -i '
+   .dependencies |= map(select(.name != "elasticsearch")) |
+   .dependencies |= map(select(.name != "postgresql")) |
+   .dependencies |= map(select(.name != "redis")) |
+   .dependencies |= map(select(.name != "minio")) |
+   .name="monkeys-core" |
+   .maintainers=[{"name":"inf-monkeys","url":"https://github.com/inf-monkeys/helm-charts"}] |
+   .keywords=["infra"] |
+   .home="https://github.com/inf-monkeys/helm-charts" |
+   .sources[0]="https://github.com/inf-monkeys/helm-charts" |
+   .name="monkeys-core" 
+' Chart.yaml
+
+cp charts/core/.relok8s-images.yaml .
+
+sed 's@.images@.core.images@g' charts/core/.relok8s-images.yaml > .relok8s-images.yaml
+sed -i '/oneapi/d' .relok8s-images.yaml
+sed -i '/clash/d' .relok8s-images.yaml
+
+rm -rf charts/core/.relok8s-images.yaml
+rm -rf charts/core/charts/*
+rm -rf charts/core/templates/tests/*
+exit 0

--- a/charts/monkeys-core/monkeys-core/.relok8s-images.yaml
+++ b/charts/monkeys-core/monkeys-core/.relok8s-images.yaml
@@ -1,0 +1,6 @@
+- "{{ .core.images.server.registry }}/{{ .core.images.server.repository }}:{{ .core.images.server.tag }}"
+- "{{ .core.images.web.registry }}/{{ .core.images.web.repository }}:{{ .core.images.web.tag }}"
+- "{{ .core.images.admin.registry }}/{{ .core.images.admin.repository }}:{{ .core.images.admin.tag }}"
+- "{{ .core.images.conductor.registry }}/{{ .core.images.conductor.repository }}:{{ .core.images.conductor.tag }}"
+- "{{ .core.images.busybox.registry }}/{{ .core.images.busybox.repository }}:{{ .core.images.busybox.tag }}"
+- "{{ .core.images.nginx.registry }}/{{ .core.images.nginx.repository }}:{{ .core.images.nginx.tag }}"

--- a/charts/monkeys-core/monkeys-core/Chart.yaml
+++ b/charts/monkeys-core/monkeys-core/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: 1.16.0
+dependencies:
+  - name: core
+    version: v0.1.9
+    repository: https://inf-monkeys.github.io/helm-charts
+description: A Helm chart for Monkeys core service.
+name: monkeys-core
+type: application
+version: 0.1.9
+maintainers:
+  - name: inf-monkeys
+    url: https://github.com/inf-monkeys/helm-charts
+keywords:
+  - infra
+home: https://github.com/inf-monkeys/helm-charts
+sources:
+  - https://github.com/inf-monkeys/helm-charts

--- a/charts/monkeys-core/monkeys-core/README.md
+++ b/charts/monkeys-core/monkeys-core/README.md
@@ -1,0 +1,566 @@
+<div align="center">
+
+# Core Helm Chart<!-- omit in toc -->
+
+</div>
+
+[中文](./README_zh.md) | English
+
+
+# Table of Contents<!-- omit in toc -->
+
+- [Install](#install)
+  - [Check status](#check-status)
+  - [Visit the service](#visit-the-service)
+  - [Update configuration](#update-configuration)
+  - [Uninstall](#uninstall)
+- [Images](#images)
+- [Service Configuration](#service-configuration)
+  - [ClusterIP Mode Example](#clusterip-mode-example)
+  - [NodePort Mode Example](#nodeport-mode-example)
+- [Site Configuration](#site-configuration)
+- [Authentication](#authentication)
+  - [OIDC Single Sign-On](#oidc-single-sign-on)
+  - [Phone Number Verification Code Login](#phone-number-verification-code-login)
+- [Built-IN LLM Models](#built-in-llm-models)
+- [OneAPI Service Configuration](#oneapi-service-configuration)
+  - [Using the Built-in OneAPI Service](#using-the-built-in-oneapi-service)
+  - [Using an External OneAPI Service](#using-an-external-oneapi-service)
+- [Pre-built Tools](#pre-built-tools)
+  - [Tool Configuration Details](#tool-configuration-details)
+- [Admin Dashboard Configuration](#admin-dashboard-configuration)
+- [Clash Proxy](#clash-proxy)
+- [Replicas](#replicas)
+- [Middleware Configuration](#middleware-configuration)
+  - [Postgres Database](#postgres-database)
+    - [Using Built-in Database](#using-built-in-database)
+    - [Using External Database](#using-external-database)
+      - [Monkeys Business Database](#monkeys-business-database)
+      - [Conductor Database](#conductor-database)
+  - [Elasticsearch 7](#elasticsearch-7)
+    - [Using Built-in Elasticsearch 7](#using-built-in-elasticsearch-7)
+    - [Using External Elasticsearch 7](#using-external-elasticsearch-7)
+  - [Redis](#redis)
+    - [Using Built-in Redis](#using-built-in-redis)
+    - [Using External Redis](#using-external-redis)
+      - [Standalone Redis](#standalone-redis)
+      - [Redis Cluster](#redis-cluster)
+        - [Redis Sentinel](#redis-sentinel)
+  - [MinIO(S3) Storage](#minios3-storage)
+    - [Using Built-in Minio Storage](#using-built-in-minio-storage)
+    - [Using External S3 Storage](#using-external-s3-storage)
+
+
+## Install
+
+```sh
+# Add the helm repo
+helm repo add monkeys https://inf-monkeys.github.io/helm-charts
+
+# Install monkeys core service
+helm install monkeys monkeys/core -n monkeys --create-namespace
+```
+
+### Check status
+
+> By default monkeys use internal middleware (postgres, elasticsearch, redis, etc), It may take some time to wait for middlewares startup.
+
+Check installation progress by:
+
+```sh
+kubectl get pods -n monkeys
+kubectl get svc -n monkeys
+```
+
+### Visit the service
+
+
+By default `values.yaml` uses ClusterIP mode, you can visit monkeys web ui through **monkeys-proxy** service:
+
+```sh
+# Get current pod list
+kubectl get pods 
+
+# Port Forward monkey-core-proxy-xxxx-xxxx Pod, in this example use local machine's 8080 port.
+kubectl port-forward --address 0.0.0.0 monkey-core-proxy-xxxx-xxxx 8080:80 -n monkeys
+
+# Try
+curl http://localhost:8080
+```
+
+And if your service is behide a firewall, no forget to open that port.
+
+### Update configuration
+
+Create a new values file, `prod-core-values.yaml` for example.
+
+For example if you want to modify server image version, add this to `prod-core-values.yaml`:
+
+```yaml
+images:
+  server:
+    tag: some-new-tag
+```
+
+Then run:
+
+```sh
+helm upgrade monkeys --values ./prod-core-values.yaml --namespace monkeys
+```
+
+For the complete list of configuration options, see: [Core Helm Chart](./charts/core/README.md)
+
+### Uninstall
+
+```sh
+helm uninstall monkeys -n monkeys
+```
+
+
+## Images
+
+| Parameter                      | Description                                                             | Default Value              |
+| ------------------------------ | ----------------------------------------------------------------------- | -------------------------- |
+| `images.server.registry`       | Docker Registry                                                         | `docker.io`                |
+| `images.server.repository`     | [monkeys](https://github.com/inf-monkeys/monkeys) service Docker image  | `infmonkeys/monkeys`       |
+| `images.server.tag`            | Version                                                                 | `latest`                   |
+| `images.server.pullPolicy`     | Image pull policy                                                       | `IfNotPresent`             |
+| `images.server.pullSecrets`    | Image pull secrets                                                      | `""`                       |
+| `images.web.registry`          | Docker Registry                                                         | `docker.io`                |
+| `images.web.repository`        | [Frontend](https://github.com/inf-monkeys/monkeys/tree/main/ui) image   | `infmonkeys/monkeys-ui`    |
+| `images.web.tag`               | Version                                                                 | `latest`                   |
+| `images.web.pullPolicy`        | Image pull policy                                                       | `IfNotPresent`             |
+| `images.web.pullSecrets`       | Image pull secrets                                                      | `""`                       |
+| `images.conductor.registry`    | Docker Registry                                                         | `docker.io`                |
+| `images.conductor.repository`  | [conductor](https://github.com/inf-monkeys/conductor) engine image      | `infmonkeys/conductor`     |
+| `images.conductor.tag`         | Version                                                                 | `latest`                   |
+| `images.conductor.pullPolicy`  | Image pull policy                                                       | `IfNotPresent`             |
+| `images.conductor.pullSecrets` | Image pull secrets                                                      | `""`                       |
+| `images.oneapi.registry`       | Image Registry                                                          | `docker.io`                |
+| `images.oneapi.repository`     | Image repository for [one-api](https://github.com/songquanpeng/one-api) | `justsong/one-api`         |
+| `images.oneapi.tag`            | Version                                                                 | `latest`                   |
+| `images.oneapi.pullPolicy`     | Image pull policy                                                       | `IfNotPresent`             |
+| `images.oneapi.pullSecrets`    | Image pull secrets                                                      | `""`                       |
+| `images.admin.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.admin.repository`      | Admin dashboard image                                                   | `infmonkeys/monkeys-admin` |
+| `images.admin.tag`             | Version                                                                 | `latest`                   |
+| `images.admin.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.admin.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+| `images.clash.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.clash.repository`      | Clash proxy service image                                               | `infmonkeys/clash`         |
+| `images.clash.tag`             | Version                                                                 | `latest`                   |
+| `images.clash.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.clash.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+| `images.busybox.registry`      | Docker Registry                                                         | `docker.io`                |
+| `images.busybox.repository`    | BusyBox image                                                           | `busybox`                  |
+| `images.busybox.tag`           | Version                                                                 | `latest`                   |
+| `images.busybox.pullPolicy`    | Image pull policy                                                       | `IfNotPresent`             |
+| `images.busybox.pullSecrets`   | Image pull secrets                                                      | `""`                       |
+| `images.nginx.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.nginx.repository`      | Nginx image                                                             | `nginx`                    |
+| `images.nginx.tag`             | Version                                                                 | `latest`                   |
+| `images.nginx.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.nginx.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+
+
+## Service Configuration
+
+By default, the service uses ClusterIP mode and exposes services on port `80` of the `monkeys-core-proxy` (Nginx reverse proxy) `svc`.
+
+| Parameter           | Description                  | Default Value |
+| ------------------- | ---------------------------- | ------------- |
+| `service.type`      | `ClusterIP` or `NodePort`    | `ClusterIP`   |
+| `service.port`      | Proxy component (Nginx) port | `80`          |
+| `service.clusterIP` | ClusterIP                    | `""`          |
+| `service.nodePort`  | Node Port                    | `""`          |
+
+### ClusterIP Mode Example
+
+```yaml
+service:
+  type: ClusterIP
+  port: 80
+  clusterIP: ""
+```
+
+### NodePort Mode Example
+
+```yaml
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30080
+```
+## Site Configuration
+
+Customize your site with Application ID, external URL, title, logo, authentication methods, etc.
+
+| Parameter                                  | Description                                                                                 | Default Value                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `server.site.appId`                        | Unique ID for the deployment, used as prefix for database tables and redis keys.            | `monkeys`                                                      |
+| `server.site.appUrl`                       | External URL, affects OIDC SSO and custom triggers, other functionalities are not affected. | `http://localhost:3000`                                        |
+| `server.site.customization.title`          | Website title                                                                               | `Infinite Monkeys`                                             |
+| `server.site.customization.logo.light`     | Top-left logo (Light mode)                                                                  | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `server.site.customization.logo.dark`      | Top-left logo (Dark mode)                                                                   | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `server.site.customization.favicon`        | Browser Favicon                                                                             | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `server.site.customization.colors.primary` | Primary color                                                                               | `#52ad1f`                                                      |
+
+## Authentication
+
+Currently, the following three user authentication methods are supported:
+
+- `password`: Email password authentication;
+- `phone`: Phone number verification code authentication;
+- `oidc`: OIDC Single Sign-On;
+
+| Parameter                | Description                                                                 | Default Value |
+| ------------------------ | --------------------------------------------------------------------------- | ------------- |
+| `server.auth.enabled`    | Enabled authentication methods, default is password login only. Options are `password`, `oidc`, `phone` | `password`    |
+
+### OIDC Single Sign-On
+
+| Parameter                                       | Description                                                                                                      | Default Value    |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `server.auth.oidc.auto_signin`                  | Whether to automatically use OIDC for login when the user signs in. If set to `false`, users need to manually click the OIDC login button to proceed with OIDC authentication. | `false`          |
+| `server.auth.oidc.issuer`                       | OIDC Issuer address, e.g., `https://console.d.run/auth/realms/ghippo`                                             | `""`             |
+| `server.auth.oidc.client_id`                    | OIDC Client ID                                                                                                    | `""`             |
+| `server.auth.oidc.client_secret`                | OIDC Client Secret                                                                                                | `""`             |
+| `server.auth.oidc.scope`                        | Scope set during OIDC authorization. For Daocloud DEC, set to `openid profile email phone`                        | `openid profile` |
+| `server.auth.oidc.button_text`                  | Text for the OIDC login button                                                                                    | `Use OIDC Login` |
+| `server.auth.oidc.id_token_signed_response_alg` | OIDC ID Token encryption method                                                                                   | `RS256`          |
+
+### Phone Number Verification Code Login
+
+| Parameter                             | Description                                                 | Default Value |
+| ------------------------------------- | ----------------------------------------------------------- | ------------- |
+| `server.auth.sms.provider`            | SMS verification code service provider, currently only supports Aliyun SMS. Options are `dysms`. | `dysms`      |
+| `server.auth.sms.config.accessKeyId`  | Aliyun accessKeyId                                          | `""`         |
+| `server.auth.sms.config.accessKeySecret` | Aliyun accessKeySecret                                      | `""`         |
+| `server.auth.sms.config.signName`     | SMS signature name                                          | `""`         |
+| `server.auth.sms.config.templateCode` | SMS template code                                           | `""`         |
+
+## Built-IN LLM Models
+
+You can configure the built-in large language model, which can be used by all teams within the system.​⬤
+
+| Parameter   | Description                                                                                                            | Default Value |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `llmModels` | Enabled language models, see [Language Model Configuration Details](#language-model-configuration-details) for details | `[]`          |
+
+
+You can add any OpenAI-compatible LLMmodels with the following configuration:
+
+| Parameter                 | Description                                                                                                                             | Default Value |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `model`                   | Model name, e.g., `gpt-3.5-turbo`                                                                                                       |               |
+| `baseURL`                 | Access URL, e.g., `https://api.openai.com/v1`                                                                                           |               |
+| `apiKey`                  | API Key, optional                                                                                                                       |               |
+| `type`                    | Model type, `chat_completions` or `completions`, for chat or text completion models. Leave empty to support both.                       | `""`          |
+| `autoMergeSystemMessages` | Automatically merge multiple System Messages. Required for VLLM models that cannot handle multiple system messages for the same `role`. | `false`       |
+| `defaultParams`           | Default request parameters, e.g., `top` parameters for specific models like `Qwen/Qwen-7B-Chat-Int4`.                                   |               |
+
+Here are an example: 
+
+```yaml
+models:
+  - model: gpt-3.5-turbo
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - chat_completions
+  - model: davinci-002
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - completions
+  - model: Qwen/Qwen-7B-Chat-Int4
+    baseURL: http://127.0.0.1:8000/v1
+    apiKey: token-abc123
+    autoMergeSystemMessages: true
+    defaultParams:
+      stop:
+        - <|im_start|>
+        - <|im_end|>
+```
+
+
+## OneAPI Service Configuration
+
+If you need users to configure their own large language models, you need to deploy [one-api](https://github.com/songquanpeng/one-api) (this Helm Chart will automatically start the one-api service by default).
+
+### Using the Built-in OneAPI Service
+
+The default username and password for [one-api](https://github.com/songquanpeng/one-api) are `root` and `123456` (**cannot be customized, please do not modify.**). Monkeys will use this account and password to create a Token, thereby [making API calls](https://github.com/songquanpeng/one-api/blob/main/docs/API.md).
+
+| Parameter             | Description                                     | Default Value |
+| --------------------- | ----------------------------------------------- | ------------- |
+| `oneapi.enabled`      | Whether to start the built-in `OneAPI` service. | `true`        |
+| `oneapi.rootUsername` | Default root username                           | `root`        |
+| `oneapi.rootPassword` | Default root password                           | `123456`      |
+
+### Using an External OneAPI Service
+
+You can also use an external OneAPI service:
+
+| Parameter                  | Description                                                                                                                            | Default Value |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `externalOneapi.enabled`   | Whether to start the built-in `OneAPI` service.                                                                                        | `false`       |
+| `externalOneapi.baseURL`   | Service address, such as `http://127.0.0.1:3000`, do not include a trailing `\`.                                                       | `""`          |
+| `externalOneapi.rootToken` | Root user's token, see [this document](https://github.com/songquanpeng/one-api/blob/main/docs/API.md) for details on how to obtain it. | `123456`      |
+
+## Pre-built Tools
+
+| Parameter | Description                                                                                     | Default Value |
+| --------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| `tools`   | Enabled pre-built tools. (Different tools should be installed via their respective Helm Charts) | `[]`          |
+
+### Tool Configuration Details
+
+You can use other tools provided by Monkeys (usually prefixed with `monkey-tools-`) via Helm, or use existing online services that meet the [Monkeys standard](https://inf-monkeys.github.io/docs/zh-cn/tools/build-custom-tools/).
+
+| Parameter     | Description                                                                                       | Default Value                                           |
+| ------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `name`        | Unique identifier for the tool, e.g., `knowledge-base`                                            |                                                         |
+| `manifestUrl` | URL of the tool's Manifest JSON, ensure that the Monkeys service environment can access this URL. | `http://monkey-tools-knowledge-base:5000/manifest.json` |
+
+
+Here are an example: 
+
+
+```yaml
+tools:
+  - name: knowledge-base
+    manifestUrl: http://monkey-tools-knowledge-base:5000/manifest.json
+```
+
+
+## Admin Dashboard Configuration
+
+Customize the admin dashboard with Application ID, external URL, title, logo, authentication methods, etc.
+
+| Parameter                                 | Description                                                                                                      | Default Value                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `admin.site.appId`                        | Unique ID for the deployment, used as prefix for database tables and redis keys. Must match `server.site.appId`. | `monkeys`                                                      |
+| `admin.site.customization.title`          | Website title                                                                                                    | `Infinite Monkeys`                                             |
+| `admin.site.customization.logo.light`     | Top-left logo (Light mode)                                                                                       | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `admin.site.customization.logo.dark`      | Top-left logo (Dark mode)                                                                                        | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `admin.site.customization.favicon`        | Browser Favicon                                                                                                  | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `admin.site.customization.colors.primary` | Primary color                                                                                                    | `#52ad1f`                                                      |
+| `admin.site.auth.enabled`                 | Enable authentication                                                                                            | `true`                                                         |
+| `admin.site.auth.defaultAdmin.email`      | Default email                                                                                                    | `admin@example.com`                                            |
+| `admin.site.auth.defaultAdmin.password`   | Default password                                                                                                 | `monkeys123`                                                   |
+
+## Clash Proxy
+
+Some functionalities might require internet access to reach specific services like `github` and `huggingface` models.
+
+| Parameter               | Description                                      | Default Value |
+| ----------------------- | ------------------------------------------------ | ------------- |
+| `clash.enabled`         | Enable Clash proxy service.                      | `false`       |
+| `clash.subscriptionUrl` | Clash subscription URL                           | `""`          |
+| `clash.secret`          | Secret for the Clash subscription URL, optional. | `""`          |
+
+## Replicas
+
+Control the number of replicas for each deployment with the following configuration:
+
+| Parameter            | Description        | Default Value |
+| -------------------- | ------------------ | ------------- |
+| `proxy.replicas`     | Number of replicas | `1`           |
+| `server.replicas`    | Number of replicas | `1`           |
+| `web.replicas`       | Frontend replicas  | `1`           |
+| `conductor.replicas` | Conductor replicas | `1`           |
+| `clash.replicas`     | Clash replicas     | `1`           |
+
+## Middleware Configuration
+
+### Postgres Database
+
+#### Using Built-in Database
+
+| Parameter                           | Description                                                                                                                                                 | Default Value |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `postgresql.enabled`                | Enable built-in database. If set to true, a new PostgreSQL instance will be created (not highly available). If you have an existing database, set to false. | `true`        |
+| `postgresql.auth.postgresPassword`  | Postgres user password                                                                                                                                      | `monkeys123`  |
+| `postgresql.auth.username`          | Username to be created                                                                                                                                      | `monkeys`     |
+| `postgresql.auth.password`          | Password for the created user                                                                                                                               | `monkeys123`  |
+| `postgresql.auth.monkeysDatabase`   | Monkeys Server Database                                                                                                                                     | `monkeys`     |
+| `postgresql.auth.conductorDatabase` | Conductor Server Database                                                                                                                                   | `conductor`   |
+| `postgresql.primary.initdb.scripts` | Init db scripts                                                                                                                                             | See below     |
+
+Database init scripts:
+
+```yaml
+scripts:
+  setup.sql: |
+    CREATE DATABASE monkeys;
+    CREATE DATABASE conductor;
+```
+
+
+#### Using External Database
+
+> Both monkeys-server and conductor require a PG database, it's recommended to allocate different databases for each.
+
+##### Monkeys Business Database
+
+| Parameter                     | Description           | Default Value |
+| ----------------------------- | --------------------- | ------------- |
+| `externalPostgresql.enabled`  | Use external database | `false`       |
+| `externalPostgresql.host`     | Host or IP address    | `""`          |
+| `externalPostgresql.port`     | Port                  | `5432`        |
+| `externalPostgresql.username` | Username              | `""`          |
+| `externalPostgresql.password` | Password              | `""`          |
+| `externalPostgresql.database` | Database              | `""`          |
+
+##### Conductor Database
+
+| Parameter                              | Description           | Default Value |
+| -------------------------------------- | --------------------- | ------------- |
+| `externalConductorPostgresql.enabled`  | Use external database | `false`       |
+| `externalConductorPostgresql.host`     | Host or IP address    | `""`          |
+| `externalConductorPostgresql.port`     | Port                  | `5432`        |
+| `externalConductorPostgresql.username` | Username              | `""`          |
+| `externalConductorPostgresql.password` | Password              | `""`          |
+| `externalConductorPostgresql.database` | Database              | `""`          |
+
+### Elasticsearch 7 
+
+We use ES7 to store Conductor workflow execution data.
+
+#### Using Built-in Elasticsearch 7
+
+| Parameter                          | Description                                                                                                                                                                  | Default Value                                   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `elasticsearch.enabled`            | Enable built-in Elasticsearch. If set to true, a new Elasticsearch 7 instance will be created (not highly available). If you have an existing Elasticsearch 7, set to false. | `true`                                          |
+| `elasticsearch.replicas`           | Number of replicas                                                                                                                                                           | `1`                                             |
+| `elasticsearch.repository`         | Image address                                                                                                                                                                | `docker.elastic.co/elasticsearch/elasticsearch` |
+| `elasticsearch.imageTag`           | Version, must be version 7                                                                                                                                                   | `7.17.3`                                        |
+| `elasticsearch.minimumMasterNodes` | Minimum number of master nodes                                                                                                                                               | `1`                                             |
+| `elasticsearch.esMajorVersion`     | Major version of Elasticsearch, must be 7                                                                                                                                    | `7`                                             |
+| `elasticsearch.secret.password`    | Password                                                                                                                                                                     | `monkeys123`                                    |
+| `elasticsearch.indexReplicasCount` | Number of index replicas                                                                                                                                                     | `0`                                             |
+| `elasticsearch.clusterHealthColor` | Cluster health color indicator                                                                                                                                               | `yellow`                                        |
+
+#### Using External Elasticsearch 7
+
+| Parameter                                  | Description                                      | Default Value |
+| ------------------------------------------ | ------------------------------------------------ | ------------- |
+| `externalElasticsearch.enabled`            | Enable external Elasticsearch, must be version 7 | `true`        |
+| `externalElasticsearch.indexReplicasCount` | Number of workflow data replicas                 | `0`           |
+| `externalElasticsearch.clusterHealthColor` | Cluster health color indicator                   | `yellow`      |
+| `externalElasticsearch.url`                | Connection URL                                   | `""`          |
+| `externalElasticsearch.username`           | Username                                         | `""`          |
+| `externalElasticsearch.password`           | Password                                         | `""`          |
+
+
+### Redis
+
+#### Using Built-in Redis
+
+| Parameter               | Description                                                                                                                                      | Default Value |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `redis.enabled`         | Enable built-in Redis. If set to true, a new Redis instance will be created (not highly available). If you have an existing Redis, set to false. | `true`        |
+| `redis.architecture`    | Deployment architecture, currently only supports `standalone` mode.                                                                              | `standalone`  |
+| `redis.global.password` | Password                                                                                                                                         | `monkeys123`  |
+
+#### Using External Redis
+
+##### Standalone Redis
+
+| Parameter               | Description                                                                                                          | Default Value              |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `externalRedis.enabled` | Use external Redis                                                                                                   | `false`                    |
+| `externalRedis.mode`    | Redis deployment architecture                                                                                        | `standalone`               |
+| `externalRedis.url`     | Redis connection URL, e.g., `redis://@localhost:6379/0`. Example with password: `redis://:password@localhost:6379/0` | `redis://localhost:6379/0` |
+
+##### Redis Cluster
+
+| Parameter                        | Description                   | Default Value |
+| -------------------------------- | ----------------------------- | ------------- |
+| `externalRedis.enabled`          | Use external Redis            | `false`       |
+| `externalRedis.mode`             | Redis deployment architecture | `cluster`     |
+| `externalRedis.nodes`            | Redis cluster nodes list      | `""`          |
+| `externalRedis.options.password` | Password                      | `""`          |
+
+Example of Redis cluster nodes list:
+
+```yaml
+nodes:
+  - host: 127.0.0.1
+    port: 7001
+  - host: 127.0.0.1
+    port: 7002
+  - host: 127.0.0.1
+    port: 7003
+  - host: 127.0.0.1
+    port: 7004
+  - host: 127.0.0.1
+    port: 7005
+  - host: 127.0.0.1
+    port: 7006
+```
+
+###### Redis Sentinel
+
+| Parameter                        | Description                   | Default Value |
+| -------------------------------- | ----------------------------- | ------------- |
+| `externalRedis.enabled`          | Use external Redis            | `false`       |
+| `externalRedis.mode`             | Redis deployment architecture | `sentinel`    |
+| `externalRedis.sentinels`        | Redis sentinel nodes list     | `""`          |
+| `externalRedis.sentinelName`     | Redis sentinel name           | `""`          |
+| `externalRedis.options.password` | Password                      | `""`          |
+
+Example of Redis sentinel nodes list:
+
+```yaml
+sentinels:
+  - host: 127.0.0.1
+    port: 7101
+```
+
+
+### MinIO(S3) Storage
+
+#### Using Built-in Minio Storage
+
+> This mode uses the root user and password as accessKey. Recommended for quick testing only.
+
+| Parameter                         | Description                                                                                                                                                                   | Default Value            |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `minio.enabled`                   | Enable built-in Minio. If set to true, a new Minio instance will be created (not highly available). If you have an existing Minio or any S3-compatible storage, set to false. | `true`                   |
+| `minio.isPrivate`                 | Is it a private repository                                                                                                                                                    | `false`                  |
+| `minio.mode`                      | Deployment architecture, currently only supports `standalone` mode.                                                                                                           | `standalone`             |
+| `minio.defaultBuckets`            | Default Bucket names to create, separated by commas.                                                                                                                          | `monkeys-static`         |
+| `minio.auth.rootUser`             | Root username                                                                                                                                                                 | `minio`                  |
+| `minio.auth.rootPassword`         | Root password                                                                                                                                                                 | `monkeys123`             |
+| `minio.service.type`              | Minio Service mode, this Minio needs to be accessible externally (via browser), defaults to `Nodeport` mode.                                                                  | `NodePort`               |
+| `minio.service.nodePorts.api`     | Minio API port mapped to the host port                                                                                                                                        | `31900`                  |
+| `minio.service.nodePorts.console` | Minio Console port mapped to the host port                                                                                                                                    | `31901`                  |
+| `minio.endpoint`                  | Minio API endpoint accessible externally. You might need to change it to the host server IP + API Node Port.                                                                  | `http://127.0.0.1:31900` |
+
+After startup, you should be able to access the Minio management console at the host IP + port (31901) with the above set credentials.
+
+> Note: If you are using a minikube cluster, you need to manually port forward the Minio service ports as follows:
+>
+> ```bash
+> kubectl port-forward svc/monkeys-minio 31900:9000 -n monkeys
+> kubectl port-forward svc/monkeys-minio 31901:9001 -n monkeys
+> ```
+> Also, make sure to open the host's ports to allow external access.
+> See [https://stackoverflow.com/a/55110218](https://stackoverflow.com/a/55110218) for details.
+
+#### Using External S3 Storage
+
+| Parameter                    | Description                                                                                          | Default Value |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `externalS3.enabled`         | Use external S3-compatible storage such as Minio, AWS S3, etc.                                       | `false`       |
+| `externalS3.isPrivate`       | Is it a private repository                                                                           | `false`       |
+| `externalS3.forcePathStyle`  | Use path-style endpoint, typically set to `true` when using Minio                                    | `false`       |
+| `externalS3.endpoint`        | Endpoint URL                                                                                         | `""`          |
+| `externalS3.accessKeyId`     | Access Key ID                                                                                        | `""`          |
+| `externalS3.secretAccessKey` | Secret Access Key                                                                                    | `""`          |
+| `externalS3.region`          | Region                                                                                               | `""`          |
+| `externalS3.bucket`          | Bucket name, use a public bucket to allow frontend access                                            | `""`          |
+| `externalS3.publicAccessUrl` | Publicly accessible URL, typically the CDN URL for the bucket, e.g., `https://static.infmonkeys.com` | `31900`       |
+

--- a/charts/monkeys-core/monkeys-core/charts/core/.helmignore
+++ b/charts/monkeys-core/monkeys-core/charts/core/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/monkeys-core/monkeys-core/charts/core/Chart.lock
+++ b/charts/monkeys-core/monkeys-core/charts/core/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: 7.17.3
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.5.6
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.13.2
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.1.4
+digest: sha256:15688969e3de1791def0f50e14290f7b633129cb342391b9fc485c1edddd4eb1
+generated: "2024-04-02T14:49:13.437011734+08:00"

--- a/charts/monkeys-core/monkeys-core/charts/core/Chart.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+appVersion: 1.16.0
+dependencies:
+- condition: elasticsearch.enabled
+  name: elasticsearch
+  repository: https://helm.elastic.co
+  tags:
+  - elasticsearch
+  version: 7.17.3
+- condition: postgresql.enabled
+  name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - postgres
+  version: 12.5.6
+- condition: redis.enabled
+  name: redis
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - redis
+  version: 16.13.2
+- condition: minio.enabled
+  name: minio
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - minio
+  version: 14.1.4
+description: A Helm chart for Monkeys core service.
+name: core
+type: application
+version: 0.1.9

--- a/charts/monkeys-core/monkeys-core/charts/core/README.md
+++ b/charts/monkeys-core/monkeys-core/charts/core/README.md
@@ -1,0 +1,566 @@
+<div align="center">
+
+# Core Helm Chart<!-- omit in toc -->
+
+</div>
+
+[中文](./README_zh.md) | English
+
+
+# Table of Contents<!-- omit in toc -->
+
+- [Install](#install)
+  - [Check status](#check-status)
+  - [Visit the service](#visit-the-service)
+  - [Update configuration](#update-configuration)
+  - [Uninstall](#uninstall)
+- [Images](#images)
+- [Service Configuration](#service-configuration)
+  - [ClusterIP Mode Example](#clusterip-mode-example)
+  - [NodePort Mode Example](#nodeport-mode-example)
+- [Site Configuration](#site-configuration)
+- [Authentication](#authentication)
+  - [OIDC Single Sign-On](#oidc-single-sign-on)
+  - [Phone Number Verification Code Login](#phone-number-verification-code-login)
+- [Built-IN LLM Models](#built-in-llm-models)
+- [OneAPI Service Configuration](#oneapi-service-configuration)
+  - [Using the Built-in OneAPI Service](#using-the-built-in-oneapi-service)
+  - [Using an External OneAPI Service](#using-an-external-oneapi-service)
+- [Pre-built Tools](#pre-built-tools)
+  - [Tool Configuration Details](#tool-configuration-details)
+- [Admin Dashboard Configuration](#admin-dashboard-configuration)
+- [Clash Proxy](#clash-proxy)
+- [Replicas](#replicas)
+- [Middleware Configuration](#middleware-configuration)
+  - [Postgres Database](#postgres-database)
+    - [Using Built-in Database](#using-built-in-database)
+    - [Using External Database](#using-external-database)
+      - [Monkeys Business Database](#monkeys-business-database)
+      - [Conductor Database](#conductor-database)
+  - [Elasticsearch 7](#elasticsearch-7)
+    - [Using Built-in Elasticsearch 7](#using-built-in-elasticsearch-7)
+    - [Using External Elasticsearch 7](#using-external-elasticsearch-7)
+  - [Redis](#redis)
+    - [Using Built-in Redis](#using-built-in-redis)
+    - [Using External Redis](#using-external-redis)
+      - [Standalone Redis](#standalone-redis)
+      - [Redis Cluster](#redis-cluster)
+        - [Redis Sentinel](#redis-sentinel)
+  - [MinIO(S3) Storage](#minios3-storage)
+    - [Using Built-in Minio Storage](#using-built-in-minio-storage)
+    - [Using External S3 Storage](#using-external-s3-storage)
+
+
+## Install
+
+```sh
+# Add the helm repo
+helm repo add monkeys https://inf-monkeys.github.io/helm-charts
+
+# Install monkeys core service
+helm install monkeys monkeys/core -n monkeys --create-namespace
+```
+
+### Check status
+
+> By default monkeys use internal middleware (postgres, elasticsearch, redis, etc), It may take some time to wait for middlewares startup.
+
+Check installation progress by:
+
+```sh
+kubectl get pods -n monkeys
+kubectl get svc -n monkeys
+```
+
+### Visit the service
+
+
+By default `values.yaml` uses ClusterIP mode, you can visit monkeys web ui through **monkeys-proxy** service:
+
+```sh
+# Get current pod list
+kubectl get pods 
+
+# Port Forward monkey-core-proxy-xxxx-xxxx Pod, in this example use local machine's 8080 port.
+kubectl port-forward --address 0.0.0.0 monkey-core-proxy-xxxx-xxxx 8080:80 -n monkeys
+
+# Try
+curl http://localhost:8080
+```
+
+And if your service is behide a firewall, no forget to open that port.
+
+### Update configuration
+
+Create a new values file, `prod-core-values.yaml` for example.
+
+For example if you want to modify server image version, add this to `prod-core-values.yaml`:
+
+```yaml
+images:
+  server:
+    tag: some-new-tag
+```
+
+Then run:
+
+```sh
+helm upgrade monkeys --values ./prod-core-values.yaml --namespace monkeys
+```
+
+For the complete list of configuration options, see: [Core Helm Chart](./charts/core/README.md)
+
+### Uninstall
+
+```sh
+helm uninstall monkeys -n monkeys
+```
+
+
+## Images
+
+| Parameter                      | Description                                                             | Default Value              |
+| ------------------------------ | ----------------------------------------------------------------------- | -------------------------- |
+| `images.server.registry`       | Docker Registry                                                         | `docker.io`                |
+| `images.server.repository`     | [monkeys](https://github.com/inf-monkeys/monkeys) service Docker image  | `infmonkeys/monkeys`       |
+| `images.server.tag`            | Version                                                                 | `latest`                   |
+| `images.server.pullPolicy`     | Image pull policy                                                       | `IfNotPresent`             |
+| `images.server.pullSecrets`    | Image pull secrets                                                      | `""`                       |
+| `images.web.registry`          | Docker Registry                                                         | `docker.io`                |
+| `images.web.repository`        | [Frontend](https://github.com/inf-monkeys/monkeys/tree/main/ui) image   | `infmonkeys/monkeys-ui`    |
+| `images.web.tag`               | Version                                                                 | `latest`                   |
+| `images.web.pullPolicy`        | Image pull policy                                                       | `IfNotPresent`             |
+| `images.web.pullSecrets`       | Image pull secrets                                                      | `""`                       |
+| `images.conductor.registry`    | Docker Registry                                                         | `docker.io`                |
+| `images.conductor.repository`  | [conductor](https://github.com/inf-monkeys/conductor) engine image      | `infmonkeys/conductor`     |
+| `images.conductor.tag`         | Version                                                                 | `latest`                   |
+| `images.conductor.pullPolicy`  | Image pull policy                                                       | `IfNotPresent`             |
+| `images.conductor.pullSecrets` | Image pull secrets                                                      | `""`                       |
+| `images.oneapi.registry`       | Image Registry                                                          | `docker.io`                |
+| `images.oneapi.repository`     | Image repository for [one-api](https://github.com/songquanpeng/one-api) | `justsong/one-api`         |
+| `images.oneapi.tag`            | Version                                                                 | `latest`                   |
+| `images.oneapi.pullPolicy`     | Image pull policy                                                       | `IfNotPresent`             |
+| `images.oneapi.pullSecrets`    | Image pull secrets                                                      | `""`                       |
+| `images.admin.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.admin.repository`      | Admin dashboard image                                                   | `infmonkeys/monkeys-admin` |
+| `images.admin.tag`             | Version                                                                 | `latest`                   |
+| `images.admin.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.admin.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+| `images.clash.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.clash.repository`      | Clash proxy service image                                               | `infmonkeys/clash`         |
+| `images.clash.tag`             | Version                                                                 | `latest`                   |
+| `images.clash.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.clash.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+| `images.busybox.registry`      | Docker Registry                                                         | `docker.io`                |
+| `images.busybox.repository`    | BusyBox image                                                           | `busybox`                  |
+| `images.busybox.tag`           | Version                                                                 | `latest`                   |
+| `images.busybox.pullPolicy`    | Image pull policy                                                       | `IfNotPresent`             |
+| `images.busybox.pullSecrets`   | Image pull secrets                                                      | `""`                       |
+| `images.nginx.registry`        | Docker Registry                                                         | `docker.io`                |
+| `images.nginx.repository`      | Nginx image                                                             | `nginx`                    |
+| `images.nginx.tag`             | Version                                                                 | `latest`                   |
+| `images.nginx.pullPolicy`      | Image pull policy                                                       | `IfNotPresent`             |
+| `images.nginx.pullSecrets`     | Image pull secrets                                                      | `""`                       |
+
+
+## Service Configuration
+
+By default, the service uses ClusterIP mode and exposes services on port `80` of the `monkeys-core-proxy` (Nginx reverse proxy) `svc`.
+
+| Parameter           | Description                  | Default Value |
+| ------------------- | ---------------------------- | ------------- |
+| `service.type`      | `ClusterIP` or `NodePort`    | `ClusterIP`   |
+| `service.port`      | Proxy component (Nginx) port | `80`          |
+| `service.clusterIP` | ClusterIP                    | `""`          |
+| `service.nodePort`  | Node Port                    | `""`          |
+
+### ClusterIP Mode Example
+
+```yaml
+service:
+  type: ClusterIP
+  port: 80
+  clusterIP: ""
+```
+
+### NodePort Mode Example
+
+```yaml
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30080
+```
+## Site Configuration
+
+Customize your site with Application ID, external URL, title, logo, authentication methods, etc.
+
+| Parameter                                  | Description                                                                                 | Default Value                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `server.site.appId`                        | Unique ID for the deployment, used as prefix for database tables and redis keys.            | `monkeys`                                                      |
+| `server.site.appUrl`                       | External URL, affects OIDC SSO and custom triggers, other functionalities are not affected. | `http://localhost:3000`                                        |
+| `server.site.customization.title`          | Website title                                                                               | `Infinite Monkeys`                                             |
+| `server.site.customization.logo.light`     | Top-left logo (Light mode)                                                                  | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `server.site.customization.logo.dark`      | Top-left logo (Dark mode)                                                                   | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `server.site.customization.favicon`        | Browser Favicon                                                                             | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `server.site.customization.colors.primary` | Primary color                                                                               | `#52ad1f`                                                      |
+
+## Authentication
+
+Currently, the following three user authentication methods are supported:
+
+- `password`: Email password authentication;
+- `phone`: Phone number verification code authentication;
+- `oidc`: OIDC Single Sign-On;
+
+| Parameter                | Description                                                                 | Default Value |
+| ------------------------ | --------------------------------------------------------------------------- | ------------- |
+| `server.auth.enabled`    | Enabled authentication methods, default is password login only. Options are `password`, `oidc`, `phone` | `password`    |
+
+### OIDC Single Sign-On
+
+| Parameter                                       | Description                                                                                                      | Default Value    |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `server.auth.oidc.auto_signin`                  | Whether to automatically use OIDC for login when the user signs in. If set to `false`, users need to manually click the OIDC login button to proceed with OIDC authentication. | `false`          |
+| `server.auth.oidc.issuer`                       | OIDC Issuer address, e.g., `https://console.d.run/auth/realms/ghippo`                                             | `""`             |
+| `server.auth.oidc.client_id`                    | OIDC Client ID                                                                                                    | `""`             |
+| `server.auth.oidc.client_secret`                | OIDC Client Secret                                                                                                | `""`             |
+| `server.auth.oidc.scope`                        | Scope set during OIDC authorization. For Daocloud DEC, set to `openid profile email phone`                        | `openid profile` |
+| `server.auth.oidc.button_text`                  | Text for the OIDC login button                                                                                    | `Use OIDC Login` |
+| `server.auth.oidc.id_token_signed_response_alg` | OIDC ID Token encryption method                                                                                   | `RS256`          |
+
+### Phone Number Verification Code Login
+
+| Parameter                             | Description                                                 | Default Value |
+| ------------------------------------- | ----------------------------------------------------------- | ------------- |
+| `server.auth.sms.provider`            | SMS verification code service provider, currently only supports Aliyun SMS. Options are `dysms`. | `dysms`      |
+| `server.auth.sms.config.accessKeyId`  | Aliyun accessKeyId                                          | `""`         |
+| `server.auth.sms.config.accessKeySecret` | Aliyun accessKeySecret                                      | `""`         |
+| `server.auth.sms.config.signName`     | SMS signature name                                          | `""`         |
+| `server.auth.sms.config.templateCode` | SMS template code                                           | `""`         |
+
+## Built-IN LLM Models
+
+You can configure the built-in large language model, which can be used by all teams within the system.​⬤
+
+| Parameter   | Description                                                                                                            | Default Value |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `llmModels` | Enabled language models, see [Language Model Configuration Details](#language-model-configuration-details) for details | `[]`          |
+
+
+You can add any OpenAI-compatible LLMmodels with the following configuration:
+
+| Parameter                 | Description                                                                                                                             | Default Value |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `model`                   | Model name, e.g., `gpt-3.5-turbo`                                                                                                       |               |
+| `baseURL`                 | Access URL, e.g., `https://api.openai.com/v1`                                                                                           |               |
+| `apiKey`                  | API Key, optional                                                                                                                       |               |
+| `type`                    | Model type, `chat_completions` or `completions`, for chat or text completion models. Leave empty to support both.                       | `""`          |
+| `autoMergeSystemMessages` | Automatically merge multiple System Messages. Required for VLLM models that cannot handle multiple system messages for the same `role`. | `false`       |
+| `defaultParams`           | Default request parameters, e.g., `top` parameters for specific models like `Qwen/Qwen-7B-Chat-Int4`.                                   |               |
+
+Here are an example: 
+
+```yaml
+models:
+  - model: gpt-3.5-turbo
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - chat_completions
+  - model: davinci-002
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - completions
+  - model: Qwen/Qwen-7B-Chat-Int4
+    baseURL: http://127.0.0.1:8000/v1
+    apiKey: token-abc123
+    autoMergeSystemMessages: true
+    defaultParams:
+      stop:
+        - <|im_start|>
+        - <|im_end|>
+```
+
+
+## OneAPI Service Configuration
+
+If you need users to configure their own large language models, you need to deploy [one-api](https://github.com/songquanpeng/one-api) (this Helm Chart will automatically start the one-api service by default).
+
+### Using the Built-in OneAPI Service
+
+The default username and password for [one-api](https://github.com/songquanpeng/one-api) are `root` and `123456` (**cannot be customized, please do not modify.**). Monkeys will use this account and password to create a Token, thereby [making API calls](https://github.com/songquanpeng/one-api/blob/main/docs/API.md).
+
+| Parameter             | Description                                     | Default Value |
+| --------------------- | ----------------------------------------------- | ------------- |
+| `oneapi.enabled`      | Whether to start the built-in `OneAPI` service. | `true`        |
+| `oneapi.rootUsername` | Default root username                           | `root`        |
+| `oneapi.rootPassword` | Default root password                           | `123456`      |
+
+### Using an External OneAPI Service
+
+You can also use an external OneAPI service:
+
+| Parameter                  | Description                                                                                                                            | Default Value |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `externalOneapi.enabled`   | Whether to start the built-in `OneAPI` service.                                                                                        | `false`       |
+| `externalOneapi.baseURL`   | Service address, such as `http://127.0.0.1:3000`, do not include a trailing `\`.                                                       | `""`          |
+| `externalOneapi.rootToken` | Root user's token, see [this document](https://github.com/songquanpeng/one-api/blob/main/docs/API.md) for details on how to obtain it. | `123456`      |
+
+## Pre-built Tools
+
+| Parameter | Description                                                                                     | Default Value |
+| --------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| `tools`   | Enabled pre-built tools. (Different tools should be installed via their respective Helm Charts) | `[]`          |
+
+### Tool Configuration Details
+
+You can use other tools provided by Monkeys (usually prefixed with `monkey-tools-`) via Helm, or use existing online services that meet the [Monkeys standard](https://inf-monkeys.github.io/docs/zh-cn/tools/build-custom-tools/).
+
+| Parameter     | Description                                                                                       | Default Value                                           |
+| ------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `name`        | Unique identifier for the tool, e.g., `knowledge-base`                                            |                                                         |
+| `manifestUrl` | URL of the tool's Manifest JSON, ensure that the Monkeys service environment can access this URL. | `http://monkey-tools-knowledge-base:5000/manifest.json` |
+
+
+Here are an example: 
+
+
+```yaml
+tools:
+  - name: knowledge-base
+    manifestUrl: http://monkey-tools-knowledge-base:5000/manifest.json
+```
+
+
+## Admin Dashboard Configuration
+
+Customize the admin dashboard with Application ID, external URL, title, logo, authentication methods, etc.
+
+| Parameter                                 | Description                                                                                                      | Default Value                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `admin.site.appId`                        | Unique ID for the deployment, used as prefix for database tables and redis keys. Must match `server.site.appId`. | `monkeys`                                                      |
+| `admin.site.customization.title`          | Website title                                                                                                    | `Infinite Monkeys`                                             |
+| `admin.site.customization.logo.light`     | Top-left logo (Light mode)                                                                                       | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `admin.site.customization.logo.dark`      | Top-left logo (Dark mode)                                                                                        | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `admin.site.customization.favicon`        | Browser Favicon                                                                                                  | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `admin.site.customization.colors.primary` | Primary color                                                                                                    | `#52ad1f`                                                      |
+| `admin.site.auth.enabled`                 | Enable authentication                                                                                            | `true`                                                         |
+| `admin.site.auth.defaultAdmin.email`      | Default email                                                                                                    | `admin@example.com`                                            |
+| `admin.site.auth.defaultAdmin.password`   | Default password                                                                                                 | `monkeys123`                                                   |
+
+## Clash Proxy
+
+Some functionalities might require internet access to reach specific services like `github` and `huggingface` models.
+
+| Parameter               | Description                                      | Default Value |
+| ----------------------- | ------------------------------------------------ | ------------- |
+| `clash.enabled`         | Enable Clash proxy service.                      | `false`       |
+| `clash.subscriptionUrl` | Clash subscription URL                           | `""`          |
+| `clash.secret`          | Secret for the Clash subscription URL, optional. | `""`          |
+
+## Replicas
+
+Control the number of replicas for each deployment with the following configuration:
+
+| Parameter            | Description        | Default Value |
+| -------------------- | ------------------ | ------------- |
+| `proxy.replicas`     | Number of replicas | `1`           |
+| `server.replicas`    | Number of replicas | `1`           |
+| `web.replicas`       | Frontend replicas  | `1`           |
+| `conductor.replicas` | Conductor replicas | `1`           |
+| `clash.replicas`     | Clash replicas     | `1`           |
+
+## Middleware Configuration
+
+### Postgres Database
+
+#### Using Built-in Database
+
+| Parameter                           | Description                                                                                                                                                 | Default Value |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `postgresql.enabled`                | Enable built-in database. If set to true, a new PostgreSQL instance will be created (not highly available). If you have an existing database, set to false. | `true`        |
+| `postgresql.auth.postgresPassword`  | Postgres user password                                                                                                                                      | `monkeys123`  |
+| `postgresql.auth.username`          | Username to be created                                                                                                                                      | `monkeys`     |
+| `postgresql.auth.password`          | Password for the created user                                                                                                                               | `monkeys123`  |
+| `postgresql.auth.monkeysDatabase`   | Monkeys Server Database                                                                                                                                     | `monkeys`     |
+| `postgresql.auth.conductorDatabase` | Conductor Server Database                                                                                                                                   | `conductor`   |
+| `postgresql.primary.initdb.scripts` | Init db scripts                                                                                                                                             | See below     |
+
+Database init scripts:
+
+```yaml
+scripts:
+  setup.sql: |
+    CREATE DATABASE monkeys;
+    CREATE DATABASE conductor;
+```
+
+
+#### Using External Database
+
+> Both monkeys-server and conductor require a PG database, it's recommended to allocate different databases for each.
+
+##### Monkeys Business Database
+
+| Parameter                     | Description           | Default Value |
+| ----------------------------- | --------------------- | ------------- |
+| `externalPostgresql.enabled`  | Use external database | `false`       |
+| `externalPostgresql.host`     | Host or IP address    | `""`          |
+| `externalPostgresql.port`     | Port                  | `5432`        |
+| `externalPostgresql.username` | Username              | `""`          |
+| `externalPostgresql.password` | Password              | `""`          |
+| `externalPostgresql.database` | Database              | `""`          |
+
+##### Conductor Database
+
+| Parameter                              | Description           | Default Value |
+| -------------------------------------- | --------------------- | ------------- |
+| `externalConductorPostgresql.enabled`  | Use external database | `false`       |
+| `externalConductorPostgresql.host`     | Host or IP address    | `""`          |
+| `externalConductorPostgresql.port`     | Port                  | `5432`        |
+| `externalConductorPostgresql.username` | Username              | `""`          |
+| `externalConductorPostgresql.password` | Password              | `""`          |
+| `externalConductorPostgresql.database` | Database              | `""`          |
+
+### Elasticsearch 7 
+
+We use ES7 to store Conductor workflow execution data.
+
+#### Using Built-in Elasticsearch 7
+
+| Parameter                          | Description                                                                                                                                                                  | Default Value                                   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `elasticsearch.enabled`            | Enable built-in Elasticsearch. If set to true, a new Elasticsearch 7 instance will be created (not highly available). If you have an existing Elasticsearch 7, set to false. | `true`                                          |
+| `elasticsearch.replicas`           | Number of replicas                                                                                                                                                           | `1`                                             |
+| `elasticsearch.repository`         | Image address                                                                                                                                                                | `docker.elastic.co/elasticsearch/elasticsearch` |
+| `elasticsearch.imageTag`           | Version, must be version 7                                                                                                                                                   | `7.17.3`                                        |
+| `elasticsearch.minimumMasterNodes` | Minimum number of master nodes                                                                                                                                               | `1`                                             |
+| `elasticsearch.esMajorVersion`     | Major version of Elasticsearch, must be 7                                                                                                                                    | `7`                                             |
+| `elasticsearch.secret.password`    | Password                                                                                                                                                                     | `monkeys123`                                    |
+| `elasticsearch.indexReplicasCount` | Number of index replicas                                                                                                                                                     | `0`                                             |
+| `elasticsearch.clusterHealthColor` | Cluster health color indicator                                                                                                                                               | `yellow`                                        |
+
+#### Using External Elasticsearch 7
+
+| Parameter                                  | Description                                      | Default Value |
+| ------------------------------------------ | ------------------------------------------------ | ------------- |
+| `externalElasticsearch.enabled`            | Enable external Elasticsearch, must be version 7 | `true`        |
+| `externalElasticsearch.indexReplicasCount` | Number of workflow data replicas                 | `0`           |
+| `externalElasticsearch.clusterHealthColor` | Cluster health color indicator                   | `yellow`      |
+| `externalElasticsearch.url`                | Connection URL                                   | `""`          |
+| `externalElasticsearch.username`           | Username                                         | `""`          |
+| `externalElasticsearch.password`           | Password                                         | `""`          |
+
+
+### Redis
+
+#### Using Built-in Redis
+
+| Parameter               | Description                                                                                                                                      | Default Value |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `redis.enabled`         | Enable built-in Redis. If set to true, a new Redis instance will be created (not highly available). If you have an existing Redis, set to false. | `true`        |
+| `redis.architecture`    | Deployment architecture, currently only supports `standalone` mode.                                                                              | `standalone`  |
+| `redis.global.password` | Password                                                                                                                                         | `monkeys123`  |
+
+#### Using External Redis
+
+##### Standalone Redis
+
+| Parameter               | Description                                                                                                          | Default Value              |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `externalRedis.enabled` | Use external Redis                                                                                                   | `false`                    |
+| `externalRedis.mode`    | Redis deployment architecture                                                                                        | `standalone`               |
+| `externalRedis.url`     | Redis connection URL, e.g., `redis://@localhost:6379/0`. Example with password: `redis://:password@localhost:6379/0` | `redis://localhost:6379/0` |
+
+##### Redis Cluster
+
+| Parameter                        | Description                   | Default Value |
+| -------------------------------- | ----------------------------- | ------------- |
+| `externalRedis.enabled`          | Use external Redis            | `false`       |
+| `externalRedis.mode`             | Redis deployment architecture | `cluster`     |
+| `externalRedis.nodes`            | Redis cluster nodes list      | `""`          |
+| `externalRedis.options.password` | Password                      | `""`          |
+
+Example of Redis cluster nodes list:
+
+```yaml
+nodes:
+  - host: 127.0.0.1
+    port: 7001
+  - host: 127.0.0.1
+    port: 7002
+  - host: 127.0.0.1
+    port: 7003
+  - host: 127.0.0.1
+    port: 7004
+  - host: 127.0.0.1
+    port: 7005
+  - host: 127.0.0.1
+    port: 7006
+```
+
+###### Redis Sentinel
+
+| Parameter                        | Description                   | Default Value |
+| -------------------------------- | ----------------------------- | ------------- |
+| `externalRedis.enabled`          | Use external Redis            | `false`       |
+| `externalRedis.mode`             | Redis deployment architecture | `sentinel`    |
+| `externalRedis.sentinels`        | Redis sentinel nodes list     | `""`          |
+| `externalRedis.sentinelName`     | Redis sentinel name           | `""`          |
+| `externalRedis.options.password` | Password                      | `""`          |
+
+Example of Redis sentinel nodes list:
+
+```yaml
+sentinels:
+  - host: 127.0.0.1
+    port: 7101
+```
+
+
+### MinIO(S3) Storage
+
+#### Using Built-in Minio Storage
+
+> This mode uses the root user and password as accessKey. Recommended for quick testing only.
+
+| Parameter                         | Description                                                                                                                                                                   | Default Value            |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `minio.enabled`                   | Enable built-in Minio. If set to true, a new Minio instance will be created (not highly available). If you have an existing Minio or any S3-compatible storage, set to false. | `true`                   |
+| `minio.isPrivate`                 | Is it a private repository                                                                                                                                                    | `false`                  |
+| `minio.mode`                      | Deployment architecture, currently only supports `standalone` mode.                                                                                                           | `standalone`             |
+| `minio.defaultBuckets`            | Default Bucket names to create, separated by commas.                                                                                                                          | `monkeys-static`         |
+| `minio.auth.rootUser`             | Root username                                                                                                                                                                 | `minio`                  |
+| `minio.auth.rootPassword`         | Root password                                                                                                                                                                 | `monkeys123`             |
+| `minio.service.type`              | Minio Service mode, this Minio needs to be accessible externally (via browser), defaults to `Nodeport` mode.                                                                  | `NodePort`               |
+| `minio.service.nodePorts.api`     | Minio API port mapped to the host port                                                                                                                                        | `31900`                  |
+| `minio.service.nodePorts.console` | Minio Console port mapped to the host port                                                                                                                                    | `31901`                  |
+| `minio.endpoint`                  | Minio API endpoint accessible externally. You might need to change it to the host server IP + API Node Port.                                                                  | `http://127.0.0.1:31900` |
+
+After startup, you should be able to access the Minio management console at the host IP + port (31901) with the above set credentials.
+
+> Note: If you are using a minikube cluster, you need to manually port forward the Minio service ports as follows:
+>
+> ```bash
+> kubectl port-forward svc/monkeys-minio 31900:9000 -n monkeys
+> kubectl port-forward svc/monkeys-minio 31901:9001 -n monkeys
+> ```
+> Also, make sure to open the host's ports to allow external access.
+> See [https://stackoverflow.com/a/55110218](https://stackoverflow.com/a/55110218) for details.
+
+#### Using External S3 Storage
+
+| Parameter                    | Description                                                                                          | Default Value |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `externalS3.enabled`         | Use external S3-compatible storage such as Minio, AWS S3, etc.                                       | `false`       |
+| `externalS3.isPrivate`       | Is it a private repository                                                                           | `false`       |
+| `externalS3.forcePathStyle`  | Use path-style endpoint, typically set to `true` when using Minio                                    | `false`       |
+| `externalS3.endpoint`        | Endpoint URL                                                                                         | `""`          |
+| `externalS3.accessKeyId`     | Access Key ID                                                                                        | `""`          |
+| `externalS3.secretAccessKey` | Secret Access Key                                                                                    | `""`          |
+| `externalS3.region`          | Region                                                                                               | `""`          |
+| `externalS3.bucket`          | Bucket name, use a public bucket to allow frontend access                                            | `""`          |
+| `externalS3.publicAccessUrl` | Publicly accessible URL, typically the CDN URL for the bucket, e.g., `https://static.infmonkeys.com` | `31900`       |
+

--- a/charts/monkeys-core/monkeys-core/charts/core/README_zh.md
+++ b/charts/monkeys-core/monkeys-core/charts/core/README_zh.md
@@ -1,0 +1,595 @@
+
+<div align="center">
+
+# 核心服务 Helm Chart<!-- omit in toc -->
+
+</div>
+
+中文 | [English](./README.md)
+
+
+# 目录<!-- omit in toc -->
+
+- [安装](#安装)
+  - [安装 Chart](#安装-chart)
+  - [检查运行状态](#检查运行状态)
+  - [访问服务](#访问服务)
+  - [更新配置](#更新配置)
+  - [卸载](#卸载)
+- [镜像地址与版本](#镜像地址与版本)
+- [服务配置](#服务配置)
+  - [ClusterIP 模式示例](#clusterip-模式示例)
+  - [NodePort 模式示例](#nodeport-模式示例)
+- [站点配置](#站点配置)
+- [认证配置](#认证配置)
+  - [OIDC 单点登录](#oidc-单点登录)
+  - [手机号验证码登录](#手机号验证码登录)
+- [内置大语言模型配置](#内置大语言模型配置)
+  - [语言模型配置项说明](#语言模型配置项说明)
+- [OneAPI 大语言模型转发服务配置](#oneapi-大语言模型转发服务配置)
+  - [使用内置的 OneAPI 服务](#使用内置的-oneapi-服务)
+  - [使用外置的 OneAPI 服务](#使用外置的-oneapi-服务)
+- [预制工具](#预制工具)
+  - [工具配置项说明](#工具配置项说明)
+- [管理后台配置](#管理后台配置)
+- [Clash 代理](#clash-代理)
+- [副本数](#副本数)
+- [中间件配置](#中间件配置)
+  - [Postgres 数据库](#postgres-数据库)
+    - [使用内置数据库](#使用内置数据库)
+    - [使用外置数据库](#使用外置数据库)
+      - [Monkeys 业务数据库](#monkeys-业务数据库)
+      - [Conductor 数据库](#conductor-数据库)
+  - [Elasticsearch 7](#elasticsearch-7)
+    - [使用内置 Elasticsearch 7](#使用内置-elasticsearch-7)
+    - [使用外置 Elasticsearch 7](#使用外置-elasticsearch-7)
+  - [Redis](#redis)
+    - [使用内置 Redis](#使用内置-redis)
+    - [使用外置 Redis](#使用外置-redis)
+      - [单机 Redis](#单机-redis)
+      - [Redis 集群](#redis-集群)
+        - [Redis sentinel](#redis-sentinel)
+  - [MinIO(S3) 存储](#minios3-存储)
+    - [使用内置 Minio 存储](#使用内置-minio-存储)
+    - [使用外部 S3 存储](#使用外部-s3-存储)
+- [其他](#其他)
+  - [Daocloud DCE 菜单配置](#daocloud-dce-菜单配置)
+
+
+## 安装
+
+### 安装 Chart
+
+```sh
+# 添加 Chart 依赖
+helm repo add monkeys https://inf-monkeys.github.io/helm-charts
+
+# 安装核心服务
+helm install monkeys monkeys/core -n monkeys --create-namespace
+```
+
+### 检查运行状态
+
+```sh
+kubectl get pods -n monkeys
+kubectl get svc -n monkeys
+```
+
+### 访问服务
+
+
+默认情况下 `values.yaml` 使用 ClusterIP 模式, 你可以通过 **monkeys-proxy** service 访问 monkeys web ui:
+
+```sh
+# Get current pod list
+kubectl get pods -n monkeys
+
+# Port Forward monkey-proxy-xxxx-xxxx Pod, in this example use local machine's 8080 port.
+kubectl port-forward --address 0.0.0.0 monkey--core-proxy-xxxx-xxxx 8080:80 -n monkeys
+
+# Try
+curl http://localhost:8080
+```
+
+如果你的服务运行在防火墙后面，请不要忘记打开防火墙。
+
+### 更新配置
+
+创建一个新的 Values yaml 文件, 比如 `prod-core-values.yaml`。
+
+比如说你需要更新 server 的镜像，添加下面的内容到 `prod-core-values.yaml` 中:
+
+```yaml
+images:
+  server:
+    tag: some-new-tag
+```
+
+然后执行：
+
+```sh
+helm upgrade monkeys .  --namespace monkeys --values ./prod-core-values.yaml
+```
+
+### 卸载
+
+```sh
+helm uninstall monkeys -n monkeys
+```
+
+
+## 镜像地址与版本
+
+| 参数                           | 描述                                                                          | 默认值                     |
+| ------------------------------ | ----------------------------------------------------------------------------- | -------------------------- |
+| `images.server.registry`       | 镜像 Registry                                                                 | `docker.io`                |
+| `images.server.repository`     | [monkeys](https://github.com/inf-monkeys/monkeys) 服务 Docker 镜像地址        | `infmonkeys/monkeys`       |
+| `images.server.tag`            | 版本号号                                                                      | `latest`                   |
+| `images.server.pullPolicy`     | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.server.pullSecrets`    | 镜像拉取密钥                                                                  | `""`                       |
+| `images.web.registry`          | 镜像 Registry                                                                 | `docker.io`                |
+| `images.web.repository`        | [前端](https://github.com/inf-monkeys/monkeys/tree/main/ui) Docker 镜像地址   | `infmonkeys/monkeys-ui`    |
+| `images.web.tag`               | 版本号                                                                        | `latest`                   |
+| `images.web.pullPolicy`        | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.web.pullSecrets`       | 镜像拉取密钥                                                                  | `""`                       |
+| `images.conductor.registry`    | 镜像 Registry                                                                 | `docker.io`                |
+| `images.conductor.repository`  | 流程编排引擎 [conductor](https://github.com/inf-monkeys/conductor) 的镜像地址 | `infmonkeys/conductor`     |
+| `images.conductor.tag`         | 版本号                                                                        | `latest`                   |
+| `images.conductor.pullPolicy`  | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.conductor.pullSecrets` | 镜像拉取密钥                                                                  | `""`                       |
+| `images.oneapi.registry`       | 镜像 Registry                                                                 | `docker.io`                |
+| `images.oneapi.repository`     | [one-api](https://github.com/songquanpeng/one-api) 的镜像地址                 | `justsong/one-api`         |
+| `images.oneapi.tag`            | 版本号                                                                        | `latest`                   |
+| `images.oneapi.pullPolicy`     | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.oneapi.pullSecrets`    | 镜像拉取密钥                                                                  | `""`                       |
+| `images.admin.registry`        | 镜像 Registry                                                                 | `docker.io`                |
+| `images.admin.repository`      | 管理后台的镜像地址                                                            | `infmonkeys/monkeys-admin` |
+| `images.admin.tag`             | 版本号                                                                        | `latest`                   |
+| `images.admin.pullPolicy`      | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.admin.pullSecrets`     | 镜像拉取密钥                                                                  | `""`                       |
+| `images.clash.registry`        | 镜像 Registry                                                                 | `docker.io`                |
+| `images.clash.repository`      | Clash 代理服务的镜像地址                                                      | `infmonkeys/clash`         |
+| `images.clash.tag`             | 版本号                                                                        | `latest`                   |
+| `images.clash.pullPolicy`      | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.clash.pullSecrets`     | 镜像拉取密钥                                                                  | `""`                       |
+| `images.busybox.registry`      | 镜像 Registry                                                                 | `docker.io`                |
+| `images.busybox.repository`    | Clash 代理服务的镜像地址                                                      | `busybox`                  |
+| `images.busybox.tag`           | 版本号                                                                        | `latest`                   |
+| `images.busybox.pullPolicy`    | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.busybox.pullSecrets`   | 镜像拉取密钥                                                                  | `""`                       |
+| `images.nginx.registry`        | 镜像 Registry                                                                 | `docker.io`                |
+| `images.nginx.repository`      | Nginx 的镜像地址                                                              | `nginx`                    |
+| `images.nginx.tag`             | 版本号                                                                        | `latest`                   |
+| `images.nginx.pullPolicy`      | 镜像拉取策略                                                                  | `IfNotPresent`             |
+| `images.nginx.pullSecrets`     | 镜像拉取密钥                                                                  | `""`                       |
+
+
+
+## 服务配置
+
+默认情况下，使用 ClusterIP 模式，可以 `monkeys-core-proxy`（Nginx 反向代理）`svc` 的 `80` 端口对外暴露服务。
+
+| 参数                | 描述                        | 默认值      |
+| ------------------- | --------------------------- | ----------- |
+| `service.type`      | `ClusterIP` 或者 `NodePort` | `ClusterIP` |
+| `service.port`      | Proxy 组件(Nginx) 暴露端口  | `80`        |
+| `service.clusterIP` | ClusterIP                   | `""`        |
+| `service.nodePort`  | Node Port 端口              | `""`        |
+
+
+### ClusterIP 模式示例
+
+```yaml
+service:
+  type: ClusterIP
+  port: 80
+  clusterIP: ""
+```
+
+### NodePort 模式示例
+
+```yaml
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30080
+```
+
+
+## 站点配置
+
+自定义你的站点，比应用 ID、对外访问地址、标题、Logo、认证方式等。
+
+| 参数                                       | 描述                                                                                             | 默认值                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| `server.site.appId`                        | 此次部署服务的唯一 ID，将会作为数据库表、redis key 的前缀。                                      | `monkeys`                                                      |
+| `server.site.appUrl`                       | 对外可访问的连接，此配置项会影响到 OIDC 单点登录跳转以及自定义触发器，除此之外不会影响其他功能。 | `http://localhost:3000`                                        |
+| `server.site.customization.title`          | 网站标题。                                                                                       | `猴子无限`                                                     |
+| `server.site.customization.logo.light`     | 左上角 Logo 图标(Light 模型)。                                                                   | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `server.site.customization.logo.dark`      | 左上角 Logo 图标(Dark 模型)。                                                                    | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `server.site.customization.favicon`        | 浏览器 Favicon 图标                                                                              | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `server.site.customization.colors.primary` | 主颜色                                                                                           | `#52ad1f`                                                      |
+
+## 认证配置
+
+目前共支持以下三种用户认证方式：
+ 
+- `password`: 邮箱密码认证；
+- `phone`: 手机号验证码认证；
+- `oidc`: OIDC 单点登录；
+
+| 参数                  | 描述                                                                     | 默认值     |
+| --------------------- | ------------------------------------------------------------------------ | ---------- |
+| `server.auth.enabled` | 启用的认证方式，默认只启用密码登录。可选值为 `password`, `oidc`, `phone` | `password` |
+
+### OIDC 单点登录
+
+| 参数                                            | 描述                                                                                                          | 默认值           |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `server.auth.oidc.auto_signin`                  | 用户登录时是否自动使用 OIDC 进行登录，设置为 `false` 则需要用户手动点击使用 OIDC 登录按钮才会进行 OIDC 认证。 | `false`          |
+| `server.auth.oidc.issuer`                       | OIDC Issuer 地址，如 `https://console.d.run/auth/realms/ghippo`                                               | `""`             |
+| `server.auth.oidc.client_id`                    | OIDC Client ID                                                                                                | `""`             |
+| `server.auth.oidc.client_secret`                | OIDC Client Secret                                                                                            | `""`             |
+| `server.auth.oidc.scope`                        | OIDC 授权时设置的 scope, 如果是 Daocloud DEC，请设置为 `openid profile email phone`                           | `openid profile` |
+| `server.auth.oidc.button_text`                  | OIDC 登录按钮文字                                                                                             | `使用 OIDC 登录` |
+| `server.auth.oidc.id_token_signed_response_alg` | OIDC ID Token 加密方式。                                                                                      | `RS256`          |
+
+### 手机号验证码登录
+
+
+| 参数                                     | 描述                                                       | 默认值  |
+| ---------------------------------------- | ---------------------------------------------------------- | ------- |
+| `server.auth.sms.provider`               | 短信验证码服务商，当前只支持阿里云短信。可选值为 `dysms`。 | `dysms` |
+| `server.auth.sms.config.accessKeyId`     | 阿里云 accessKeyId                                         | `""`    |
+| `server.auth.sms.config.accessKeySecret` | 阿里云 accessKeySecret                                     | `""`    |
+| `server.auth.sms.config.signName`        | 短信签名名称                                               | `""`    |
+| `server.auth.sms.config.templateCode`    | 短信模板 Code                                              | `""`    |
+
+
+## 内置大语言模型配置
+
+你可以设置内置的大语言模型，系统内置的大语言模型所有团队都可以使用。
+
+| 参数        | 描述                                                                  | 默认值 |
+| ----------- | --------------------------------------------------------------------- | ------ |
+| `llmModels` | 启用的语言模型，详细配置请见[语言模型配置项说明](#语言模型配置项说明) | `[]`   |
+
+### 语言模型配置项说明
+
+你可以按照下面的配置添加任意符合 OpenAI 标准的大语言模型：
+
+| 参数                      | 描述                                                                                                                                                                                                                                                    | 默认值  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `model`                   | model name，如 `gpt-3.5-turbo`                                                                                                                                                                                                                          |         |
+| `baseURL`                 | 访问地址，如 `https://api.openai.com/v1`                                                                                                                                                                                                                |         |
+| `apiKey`                  | APIKey，如果没有可不填。                                                                                                                                                                                                                                |         |
+| `type`                    | 此模型的类型，可选值为 `chat_completions` 和 `completions`，分别表示是一个对话模型还是文本补全模型。不填则表示两种方式都支持。                                                                                                                          | `""`    |
+| `autoMergeSystemMessages` | 是否自动合并多条 System Messages，通过 VLLM 部署的模型，不能连续传多条为同一个 `role` 的 `message`，如果有多条 System Message（通过知识库自动设置、大语言模型节点手动设置预制 Prompt、API 调用或第三方工具手动传入 `system` message），需要合并为一条。 | `false` |
+| `defaultParams`           | 默认请求参数，比如一些模型如 `Qwen/Qwen-7B-Chat-Int4`，需要设置 top 参数。                                                                                                                                                                              |         |
+
+
+以下是一个示例：
+
+```yaml
+models:
+  - model: gpt-3.5-turbo
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - chat_completions
+  - model: davinci-002
+    baseURL: https://api.openai.com/v1
+    apiKey: xxxxxxxxxxxxxx
+    type:
+      - completions
+  - model: Qwen/Qwen-7B-Chat-Int4
+    baseURL: http://127.0.0.1:8000/v1
+    apiKey: token-abc123
+    autoMergeSystemMessages: true
+    defaultParams:
+      stop:
+        - <|im_start|>
+        - <|im_end|>
+```
+
+## OneAPI 大语言模型转发服务配置
+
+如果你需要让用户可以配置自己的大语言模型，需要部署 [one-api](https://github.com/songquanpeng/one-api) （此 Helm Chart 默认会自动启动 one-api 服务）。
+
+### 使用内置的 OneAPI 服务
+
+[one-api](https://github.com/songquanpeng/one-api) 的默认用户名和密码为 `root` 和 `123456`（**无法自定义，请不要修改。**），Monkeys 会使用此账号密码创建 Token，从而[进行 API 调用](https://github.com/songquanpeng/one-api/blob/main/docs/API.md)。
+
+| 参数                  | 描述                           | 默认值   |
+| --------------------- | ------------------------------ | -------- |
+| `oneapi.enabled`      | 是否启动内置的 `OneAPI` 服务。 | `true`   |
+| `oneapi.rootUsername` | 默认的 root 用户名             | `root`   |
+| `oneapi.rootPassword` | 默认的 root 密码               | `123456` |
+
+### 使用外置的 OneAPI 服务
+
+你也可以使用外置的 OneAPI 服务：
+
+| 参数                       | 描述                                                                                                         | 默认值   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ | -------- |
+| `externalOneapi.enabled`   | 是否启动内置的 `OneAPI` 服务。                                                                               | `false`  |
+| `externalOneapi.baseURL`   | 服务地址，如 `http:127.0.0.1:3000`，最后面请不要带 `\`                                                       | `""`     |
+| `externalOneapi.rootToken` | Root 用户的 token，请见[此文档](https://github.com/songquanpeng/one-api/blob/main/docs/API.md)了解如何获取。 | `123456` |
+
+
+## 预制工具
+
+| 参数    | 描述                                                               | 默认值 |
+| ------- | ------------------------------------------------------------------ | ------ |
+| `tools` | 启用的预制工具。（不同的工具请通过其相应的 Helm Chart 来进行安装） | `[]`   |
+
+
+### 工具配置项说明
+
+你可以使用 Monkeys 提供的其他工具（一般以 `monkey-tools-` 开头）的 Helm 来安装，或者使用现成的[满足 Monkeys 标准](https://inf-monkeys.github.io/docs/zh-cn/tools/build-custom-tools/)的在线服务。
+
+| 参数          | 描述                                                                 | 默认值                                                  |
+| ------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| `name`        | 工具唯一标志，如 `knowledge-base`                                    |                                                         |
+| `manifestUrl` | 工具的 Manifest JSON 地址，需确保 Monkeys 服务环境能够访问到此连接。 | `http://monkey-tools-knowledge-base:5000/manifest.json` |
+
+以下是一个示例：
+
+
+```yaml
+tools:
+  - name: knowledge-base
+    manifestUrl: http://monkey-tools-knowledge-base:5000/manifest.json
+```
+
+## 管理后台配置
+
+自定义管理后台，比应用 ID、对外访问地址、标题、Logo、认证方式等。
+
+| 参数                                      | 描述                                                                                               | 默认值                                                         |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `admin.site.appId`                        | 此次部署服务的唯一 ID，将会作为数据库表、redis key 的前缀。必须要和 `server.site.appId` 保持一致。 | `monkeys`                                                      |
+| `admin.site.customization.title`          | 网站标题。                                                                                         | `猴子无限`                                                     |
+| `admin.site.customization.logo.light`     | 左上角 Logo 图标(Light 模型)。                                                                     | `https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg` |
+| `admin.site.customization.logo.dark`      | 左上角 Logo 图标(Dark 模型)。                                                                      | `https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg`  |
+| `admin.site.customization.favicon`        | 浏览器 Favicon 图标                                                                                | `https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg`        |
+| `admin.site.customization.colors.primary` | 主颜色                                                                                             | `#52ad1f`                                                      |
+| `admin.site.auth.enabled`                 | 是否开启认证                                                                                       | `true`                                                         |
+| `admin.site.auth.defaultAdmin.email`      | 默认邮箱                                                                                           | `admin@example.com`                                            |
+| `admin.site.auth.defaultAdmin.password`   | 默认密码。                                                                                         | `monkeys123`                                                   |
+
+
+## Clash 代理
+
+某些功能可能科学上网才能访问对应服务，比如 `github`、`huggingface` 模型等。
+
+| 参数                    | 描述                                 | 默认值  |
+| ----------------------- | ------------------------------------ | ------- |
+| `clash.enabled`         | 是否启用 Clash 代理服务。            | `false` |
+| `clash.subscriptionUrl` | Clash 订阅地址                       | `""`    |
+| `clash.secret`          | Clash 订阅地址的密钥，没有可以不填。 | `""`    |
+
+
+## 副本数
+
+通过以下配置控制每个 Depolyment 的副本数：
+
+| 参数                 | 描述             | 默认值 |
+| -------------------- | ---------------- | ------ |
+| `proxy.replicas`     | 副本数           | `1`    |
+| `server.replicas`    | 副本数           | `1`    |
+| `web.replicas`       | 前端副本数       | `1`    |
+| `conductor.replicas` | Conductor 副本数 | `1`    |
+| `clash.replicas`     | Clash 副本数     | `1`    |
+
+## 中间件配置
+
+### Postgres 数据库
+
+#### 使用内置数据库
+
+| 参数                                | 描述                                                                                                                              | 默认值       |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `postgresql.enabled`                | 是否启用内置数据库。如果设置为 true，将会创建一个新的 postgresql 实例（不保证高可用），如果你有其他现成的数据库，请设置为 false。 | `true`       |
+| `postgresql.auth.postgresPassword`  | Postgres 用户密码                                                                                                                 | `monkeys123` |
+| `postgresql.auth.username`          | 创建的用户名                                                                                                                      | `monkeys`    |
+| `postgresql.auth.password`          | 创建用户的密码                                                                                                                    | `monkeys123` |
+| `postgresql.auth.database`          | Monkeys Server 的 database                                                                                                        | `monkeys`    |
+| `postgresql.auth.conductorDatabase` | Conductor 的 database                                                                                                             | `conductor`  |
+| `postgresql.primary.initdb.scripts` | 初始化脚本，用于创建对应的数据库。                                                                                                | 见下文。     |
+
+数据库初始化脚本：
+
+```yaml
+scripts:
+  setup.sql: |
+    CREATE DATABASE monkeys;
+    CREATE DATABASE conductor;
+```
+
+#### 使用外置数据库
+
+> monkeys-server 和 conductor 均需要使用 PG 数据库，建议分配不同的 database。
+
+##### Monkeys 业务数据库
+
+| 参数                          | 描述                 | 默认值  |
+| ----------------------------- | -------------------- | ------- |
+| `externalPostgresql.enabled`  | 是否使用外置的数据库 | `false` |
+| `externalPostgresql.host`     | 域名或者 ip          | `""`    |
+| `externalPostgresql.port`     | 端口                 | `5432`  |
+| `externalPostgresql.username` | 用户名               | `""`    |
+| `externalPostgresql.password` | 密码                 | `""`    |
+| `externalPostgresql.database` | database             | `""`    |
+
+##### Conductor 数据库
+
+| 参数                                   | 描述                 | 默认值  |
+| -------------------------------------- | -------------------- | ------- |
+| `externalConductorPostgresql.enabled`  | 是否使用外置的数据库 | `false` |
+| `externalConductorPostgresql.host`     | 域名或者 ip          | `""`    |
+| `externalConductorPostgresql.port`     | 端口                 | `5432`  |
+| `externalConductorPostgresql.username` | 用户名               | `""`    |
+| `externalConductorPostgresql.password` | 密码                 | `""`    |
+| `externalConductorPostgresql.database` | database             | `""`    |
+
+
+### Elasticsearch 7 
+
+我们会用 ES7 存储 Conductor 工作流的执行数据。
+
+#### 使用内置 Elasticsearch 7
+
+
+| 参数                               | 描述                                                                                                                                                       | 默认值                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `elasticsearch.enabled`            | 是否启用内置的 Elasticsearch。如果设置为 true，将会创建一个新的 elasticsearch 7 实例（不保证高可用），如果你有其他现成的 elasticsearch 7，请设置为 false。 | `true`                                          |
+| `elasticsearch.replicas`           | 副本数                                                                                                                                                     | `1`                                             |
+| `elasticsearch.repository`         | 镜像地址                                                                                                                                                   | `docker.elastic.co/elasticsearch/elasticsearch` |
+| `elasticsearch.imageTag`           | 版本号，大版本号必须为 7                                                                                                                                   | `7.17.3`                                        |
+| `elasticsearch.minimumMasterNodes` | 最小 master 节点数                                                                                                                                         | `1`                                             |
+| `elasticsearch.esMajorVersion`     | ES 大版本号，必须为 7。                                                                                                                                    | `7`                                             |
+| `elasticsearch.secret.password`    | 密码                                                                                                                                                       | `monkeys123`                                    |
+| `elasticsearch.indexReplicasCount` | 索引副本数                                                                                                                                                 | `0`                                             |
+| `elasticsearch.clusterHealthColor` | 集群健康颜色指标                                                                                                                                           | `yellow`                                        |
+
+
+#### 使用外置 Elasticsearch 7
+
+
+| 参数                                       | 描述                                    | 默认值   |
+| ------------------------------------------ | --------------------------------------- | -------- |
+| `externalElasticsearch.enabled`            | 是否启用外置的 ES，要求大版本必须为 7。 | `true`   |
+| `externalElasticsearch.indexReplicasCount` | 工作流数据副本数                        | `0`      |
+| `externalElasticsearch.clusterHealthColor` | 集群健康颜色指标                        | `yellow` |
+| `externalElasticsearch.url`                | 连接地址                                | `""`     |
+| `externalElasticsearch.username`           | 用户名                                  | `""`     |
+| `externalElasticsearch.password`           | 密码                                    | `""`     |
+
+
+### Redis
+
+#### 使用内置 Redis
+
+
+| 参数                    | 描述                                                                                                                           | 默认值       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `redis.enabled`         | 是否启用内置的 Redis。如果设置为 true，将会创建一个新的 Redis 实例（不保证高可用），如果你有其他现成的 Redis，请设置为 false。 | `true`       |
+| `redis.architecture`    | 部署架构，目前只支持 `standalone` 单机模式。                                                                                   | `standalone` |
+| `redis.global.password` | 密码                                                                                                                           | `monkeys123` |
+
+
+#### 使用外置 Redis
+
+##### 单机 Redis
+
+| 参数                    | 描述                                                                                                 | 默认值                     |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------- |
+| `externalRedis.enabled` | 是否使用外置的 redis                                                                                 | `false`                    |
+| `externalRedis.mode`    | Redis 部署架构                                                                                       | `standalone`               |
+| `externalRedis.url`     | Redis 连接地址，如 `redis://@localhost:6379/0`，包含密码的示例: `redis://:password@localhost:6379/0` | `redis://localhost:6379/0` |
+
+##### Redis 集群
+
+| 参数                             | 描述                 | 默认值    |
+| -------------------------------- | -------------------- | --------- |
+| `externalRedis.enabled`          | 是否使用外置的 redis | `false`   |
+| `externalRedis.mode`             | Redis 部署架构       | `cluster` |
+| `externalRedis.nodes`            | Redis 集群节点列表   | `""`      |
+| `externalRedis.options.password` | 密码                 | `""`      |
+
+Redis 集群节点列表示例：
+
+```yaml
+nodes:
+  - host: 127.0.0.1
+    port: 7001
+  - host: 127.0.0.1
+    port: 7002
+  - host: 127.0.0.1
+    port: 7003
+  - host: 127.0.0.1
+    port: 7004
+  - host: 127.0.0.1
+    port: 7005
+  - host: 127.0.0.1
+    port: 7006
+```
+
+###### Redis sentinel
+
+| 参数                             | 描述                 | 默认值     |
+| -------------------------------- | -------------------- | ---------- |
+| `externalRedis.enabled`          | 是否使用外置的 redis | `false`    |
+| `externalRedis.mode`             | Redis 部署架构       | `sentinel` |
+| `externalRedis.sentinels`        | Redis 哨兵节点列表   | `""`       |
+| `externalRedis.sentinelName`     | Redis sentinel Name  | `""`       |
+| `externalRedis.options.password` | 密码                 | `""`       |
+
+Redis 哨兵节点列表示例：
+
+```yaml
+sentinels:
+  - host: 127.0.0.1
+    port: 7101
+```
+
+### MinIO(S3) 存储
+
+#### 使用内置 Minio 存储
+
+> 此模式会使用 root 用户和密码作为 accessKey，只推荐在快速测试时使用。
+
+| 参数                              | 描述                                                                                                                                                          | 默认值                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `minio.enabled`                   | 是否启用内置的 Minio。如果设置为 true，将会创建一个新的 Minio 实例（不保证高可用），如果你有其他现成的 Minio 或者任意满足 S3 协议的对象存储，请设置为 false。 | `true`                   |
+| `minio.isPrivate`                 | 是否为私有仓库                                                                                                                                                | `false`                  |
+| `minio.mode`                      | 部署架构，目前只支持 `standalone` 单机模式。                                                                                                                  | `standalone`             |
+| `minio.defaultBuckets`            | 默认创建的 Bucket Name，可以用逗号分隔。                                                                                                                      | `monkeys-static`         |
+| `minio.auth.rootUser`             | Root 用户名                                                                                                                                                   | `minio`                  |
+| `minio.auth.rootPassword`         | Root 用户密码                                                                                                                                                 | `monkeys123`             |
+| `minio.service.type`              | Minio Service 模式，次 Minio 需要能够被外部（浏览器）访问，默认使用 `Nodeport` 模式。                                                                         | `NodePort`               |
+| `minio.service.nodePorts.api`     | Minio API 端口挂载到宿主机的端口                                                                                                                              | `31900`                  |
+| `minio.service.nodePorts.console` | Minio Console 端口使用宿主机的端口                                                                                                                            | `31901`                  |
+| `minio.endpoint`                  | Minio API 端口对外可被访问到的地址。你可能需要改成宿主机服务器的 IP + API Node Port 端口                                                                      | `http://127.0.0.1:31900` |
+
+启动之后，访问宿主机 IP + 端口（31901） 应该能够访问到 minio 的管理后台，账号密码为上述设置的密码。
+
+> 注：如果你使用的是 minikube 搭建的集群，还需要手动 port forward minio service 的端口，如下所示：
+>
+> ```bash
+> kubectl port-forward svc/monkeys-minio 31900:9000 -n monkeys
+> kubectl port-forward svc/monkeys-minio 31901:9001 -n monkeys
+> ```
+> 并且注意需要开放宿主机的端口，外网才能访问。
+> 详情请见 [https://stackoverflow.com/a/55110218](https://stackoverflow.com/a/55110218)。
+
+#### 使用外部 S3 存储
+
+| 参数                         | 描述                                                                                                | 默认值  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- | ------- |
+| `externalS3.enabled`         | 使用使用外部的满足你 S3 协议的对象存储，如 Minio、AWS S3 等。                                       | `false` |
+| `externalS3.isPrivate`       | 是否为私有仓库                                                                                      | `false` |
+| `externalS3.forcePathStyle`  | 是否使用 path-style endpoint, 当你使用 minio 时，一般都需要设置为 `true`                            | `false` |
+| `externalS3.endpoint`        | 访问地址                                                                                            | `""`    |
+| `externalS3.accessKeyId`     | AccessKeyID                                                                                         | `""`    |
+| `externalS3.secretAccessKey` | Secret Access Key                                                                                   | `""`    |
+| `externalS3.region`          | 区域                                                                                                | `""`    |
+| `externalS3.bucket`          | Bucket 名称，请使用公开的 bucket，以便前端能够访问到。                                              | `""`    |
+| `externalS3.publicAccessUrl` | 请填写外部（浏览器）可访问的地址，一般为 Bucket 配置的 CDN 地址，如 `https://static.infmonkeys.com` | `31900` |
+
+## 其他
+
+### Daocloud DCE 菜单配置
+
+| 参数                                   | 描述                                                    | 默认值                                                    |
+| -------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| `GProductNavigator.enabled`            | 是否启用 Daocloud DCE 菜单                              | `false`                                                   |
+| `GProductNavigator.spec.name`          | 显示名称                                                | `流程编排`                                                |
+| `GProductNavigator.spec.iconUrl`       | Logo                                                    | `[false](https://static.infmonkeys.com/favicon-gray.svg)` |
+| `GProductNavigator.spec.localizedName` | 多语言名称配置                                          | `""`                                                      |
+| `GProductNavigator.spec.url`           | 点击菜单之后的跳转地址，请修改为 Monkeys 的方访问地址。 | `"https://ai.daocloud.cn/login"`                          |
+| `GProductNavigator.spec.category`      | 类型                                                    | `modelapplication`                                        |
+| `GProductNavigator.spec.visible`       | 是否显示。                                              | `true`                                                    |
+| `GProductNavigator.spec.order`         | 排序，数字越大，越靠上。                                | `0`                                                       |
+| `GProductNavigator.spec.gproduct`      | gproduct 名称.                                          | `monkeys`                                                 |

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/GProductNavigator.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/GProductNavigator.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.GProductNavigator.enabled}}
+apiVersion: ghippo.io/v1alpha1
+kind: GProductNavigator
+metadata:
+  name: monkeys # 命名规则：由小写的"spec.gproduct"与"-custom"而成
+data:
+  name: {{ .Values.GProductNavigator.spec.name }}
+  iconUrl: {{ .Values.GProductNavigator.spec.iconUrl }}
+  localizedName: # 定义菜单的中英文名称
+    {{- toYaml .Values.GProductNavigator.spec.localizedName | nindent 6 }}
+  url: {{ .Values.GProductNavigator.spec.url }}
+  category: {{ .Values.GProductNavigator.spec.category }} # 与parentGProduct二选一，用于区分一级菜单还是二级菜单，与NavigatorCategory的spec.name字段对应来完成匹配
+  visible: {{ .Values.GProductNavigator.spec.visible }} # 设置该菜单是否可见，默认为true
+  order: {{ .Values.GProductNavigator.spec.order }} # 排序，数字越大，越靠上
+  gproduct: {{ .Values.GProductNavigator.spec.gproduct }}
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/NOTES.txt
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/NOTES.txt
@@ -1,0 +1,24 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "monkeys.proxy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "monkeys.proxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "monkeys.proxy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+{{- if .Values.proxy.enabled }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "monkeys.name" . }},app.kubernetes.io/instance={{ .Release.Name }},component=proxy" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/_helpers.tpl
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/_helpers.tpl
@@ -1,0 +1,132 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "monkeys.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "monkeys.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified server name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.server.fullname" -}}
+{{ template "monkeys.fullname" . }}-server
+{{- end -}}
+
+{{/*
+Create a default fully qualified admin name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.admin.fullname" -}}
+{{ template "monkeys.fullname" . }}-admin
+{{- end -}}
+
+{{/*
+Create a default fully qualified clash name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.clash.fullname" -}}
+{{ template "monkeys.fullname" . }}-clash
+{{- end -}}
+
+{{/*
+Create a default fully qualified conductor name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.conductor.fullname" -}}
+{{ template "monkeys.fullname" . }}-conductor
+{{- end -}}
+
+{{/*
+Create a default fully qualified oneapi name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.oneapi.fullname" -}}
+{{ template "monkeys.fullname" . }}-oneapi
+{{- end -}}
+
+{{/*
+Create a default fully qualified web name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.web.fullname" -}}
+{{ template "monkeys.fullname" . }}-web
+{{- end -}}
+
+{{/*
+Create a default fully qualified web name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "monkeys.proxy.fullname" -}}
+{{ template "monkeys.fullname" . }}-proxy
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "monkeys.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "monkeys.labels" -}}
+helm.sh/chart: {{ include "monkeys.chart" . }}
+{{ include "monkeys.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "monkeys.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "monkeys.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "monkeys.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "monkeys.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* annotations defiend by user*/}}
+{{- define "monkeys.ud.annotations" -}}
+{{- if .Values.annotations }}
+{{- toYaml .Values.annotations }}
+{{- end -}}
+{{- end -}}
+
+{{/* labels defiend by user*/}}
+{{- define "monkeys.ud.labels" -}}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels }}
+{{- end -}}
+{{- end -}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/admin-config.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/admin-config.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.admin.enabled}}
+immutable: false
+kind: ConfigMap
+metadata:
+  name: {{ template "monkeys.admin.fullname" . }}
+apiVersion: v1
+data:
+  config.yaml: |
+    # Server config
+    server:
+    {{- toYaml .Values.admin.site | nindent 6 }}
+
+    servers:
+    {{- toYaml .Values.admin.sites | nindent 6 }}
+
+    # Database Config
+    {{- if .Values.postgresql.enabled }}
+    database:
+      type: postgres
+      host: {{ .Release.Name }}-postgresql
+      port: 5432
+      username: {{ .Values.postgresql.global.postgresql.auth.username }}
+      password: {{ .Values.postgresql.global.postgresql.auth.password }}
+      database: {{ .Values.postgresql.global.postgresql.auth.database }}
+    {{- else if .Values.externalPostgresql.enabled }}
+    database:
+      type: postgres
+      host: {{ .Values.externalPostgresql.host }}
+      port: {{ .Values.externalPostgresql.port }}
+      username: {{ .Values.externalPostgresql.username }}
+      password: {{ .Values.externalPostgresql.password }}
+      database: {{ .Values.externalPostgresql.database }}
+    {{- else }}
+    database:
+      type: better-sqlite3
+      database: data/db.sqlite
+    {{- end }}
+
+    # Redis Config
+    {{- if .Values.redis.enabled }}
+    redis:
+      url: redis://:{{ .Values.redis.global.redis.password }}@monkeys-redis-master:6379/0
+    {{- else if .Values.externalRedis.enabled }}
+    redis:
+      {{- toYaml .Values.externalRedis | nindent 6 }}
+    {{- else }}
+    {{- end }}
+
+    # Auth Config
+    auth:
+    {{- toYaml .Values.admin.auth | nindent 6 }}
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/admin-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/admin-deployment.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.admin.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: admin
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: admin
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.admin.fullname" . }}
+spec:
+  replicas: {{ .Values.admin.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: admin
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: admin
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- if .Values.images.admin.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.admin.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.postgresql.enabled }}
+      - name: wait-for-postgres
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.images.busybox.registry }}/{{ .Values.images.admin.repository }}:{{ .Values.images.admin.tag }}"
+          imagePullPolicy: "{{ .Values.images.admin.pullPolicy }}"
+          name: admin
+          ports:
+            - name: http-server
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.admin.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/monkeys-admin/config.yaml
+              name: {{ template "monkeys.admin.fullname" . }}
+              readOnly: true
+              subPath: config.yaml
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: {{ template "monkeys.admin.fullname" . }}
+          name: {{ template "monkeys.admin.fullname" . }}
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/admin-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/admin-service.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.admin.enabled}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.admin.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.admin.service.labels }}
+{{ toYaml .Values.admin.service.labels | indent 4 }}
+{{- end }}
+    component: "admin"
+{{- with .Values.admin.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.admin.service.clusterIP }}
+  clusterIP: {{ .Values.admin.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-server
+      port: {{ .Values.admin.service.port }}
+      protocol: TCP
+      targetPort: http-server
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "admin"
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/clash-config.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/clash-config.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.clash.enabled}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clash-config
+data:
+  env: |-
+    export CLASH_URL='{{ .Values.clash.subscriptionUrl }}'
+    export CLASH_SECRET='{{ .Values.clash.secret }}'
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/clash-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/clash-deployment.yaml
@@ -1,0 +1,96 @@
+{{- if and .Values.clash.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: clash
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: clash
+    # app: {{ template "monkeys.clash.fullname" . }}
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.clash.fullname" . }}
+spec:
+  replicas: {{ .Values.clash.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: clash
+      {{/*
+      # Required labels for istio
+      # app: {{ template "monkeys.clash.fullname" . }}
+      # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+      */}}
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: clash
+        {{/*
+        # Required labels for istio
+        # app: {{ template "monkeys.clash.fullname" . }}
+        # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+        */}}
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.images.clash.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.clash.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - image: "{{ .Values.images.clash.registry }}/{{ .Values.images.clash.repository }}:{{ .Values.images.clash.tag }}"
+        imagePullPolicy: "{{ .Values.images.clash.pullPolicy }}"
+        name: clash
+        env:
+        {{- if .Values.clash.extraEnv }}
+          {{- toYaml .Values.clash.extraEnv | nindent 8 }}
+        {{- end }}
+        ports:
+          - name: http-clash
+            containerPort: 7890
+            protocol: TCP
+          - name: http-dashboard
+            containerPort: 9090
+            protocol: TCP
+        resources:
+          {{- toYaml .Values.clash.resources | nindent 12 }}
+        volumeMounts:
+        - name: clash-config
+          mountPath: /app/clash-for-linux/.env
+          readOnly: true
+          subPath: env
+    {{- if and (.Values.nodeSelector) (not .Values.clash.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.clash.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.clash.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.clash.affinity) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.clash.affinity }}
+      affinity:
+{{ toYaml .Values.clash.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.clash.tolerations) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.clash.tolerations }}
+      tolerations:
+{{ toYaml .Values.clash.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: clash-config
+        configMap:
+          defaultMode: 420
+          name: clash-config
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/clash-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/clash-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.clash.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.clash.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.clash.enabled }}
+    component: "clash"
+{{- end }}
+{{- with .Values.clash.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-clash
+      port: 7890
+      protocol: TCP
+      targetPort: 7890
+    - name: http-dashboard
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "clash"
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-config.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-config.yaml
@@ -1,0 +1,62 @@
+kind: ConfigMap
+metadata:
+  annotations:
+    kubesphere.io/creator: admin
+    kubesphere.io/description: conductor 配置文件
+  name: conductor-config
+apiVersion: v1
+data:
+  config-local.properties: |
+    conductor.grpc-server.enabled=false
+
+    # Database persistence model.
+    {{- if .Values.postgresql.enabled }}
+    conductor.db.type=postgres
+    spring.datasource.url=jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.conductorDatabase }}
+    spring.datasource.username={{ .Values.postgresql.auth.username }}
+    spring.datasource.password={{ .Values.postgresql.auth.password }}
+    {{- else if .Values.externalConductorPostgresql.enabled }}
+    conductor.db.type=postgres
+    spring.datasource.url=jdbc:postgresql://{{ .Values.externalConductorPostgresql.host }}:{{ .Values.externalConductorPostgresql.port }}/{{ .Values.externalConductorPostgresql.database }}
+    spring.datasource.username={{ .Values.externalConductorPostgresql.username }}
+    spring.datasource.password={{ .Values.externalConductorPostgresql.password }}
+    {{- else }}
+    conductor.db.type=memory
+    {{- end }}
+
+    # Elastic search indexing
+    {{- if .Values.elasticsearch.enabled }}
+    conductor.indexing.enabled=true
+    conductor.elasticsearch.url=http://elasticsearch-master:9200
+    conductor.elasticsearch.version=7
+    conductor.elasticsearch.username=elastic
+    conductor.elasticsearch.password={{ .Values.elasticsearch.secret.password }}
+    conductor.elasticsearch.indexReplicasCount={{ .Values.elasticsearch.indexReplicasCount }}
+    conductor.elasticsearch.clusterHealthColor={{ .Values.elasticsearch.clusterHealthColor }}
+    {{- else if .Values.externalElasticsearch.enabled }}
+    conductor.indexing.enabled=true
+    conductor.elasticsearch.url={{ .Values.externalElasticsearch.url }}
+    conductor.elasticsearch.version=7
+    conductor.elasticsearch.username={{ .Values.externalElasticsearch.username }}
+    conductor.elasticsearch.password={{ .Values.externalElasticsearch.password }}
+    conductor.elasticsearch.indexReplicasCount={{ .Values.externalElasticsearch.indexReplicasCount }}
+    conductor.elasticsearch.clusterHealthColor={{ .Values.externalElasticsearch.clusterHealthColor }}
+    {{- else }}
+    conductor.indexing.enabled=false
+    {{- end }}
+
+    # Load sample kitchen sink workflow
+    loadSample=false
+
+    # Thresholds
+    conductor.app.workflowInputPayloadSizeThreshold=1MB
+    conductor.app.workflowOutputPayloadSizeThreshold=1MB
+    conductor.app.maxWorkflowOutputPayloadSizeThreshold=4GB
+    conductor.app.maxWorkflowInputPayloadSizeThreshold=4GB
+    conductor.app.taskInputPayloadSizeThreshold=1MB
+    conductor.app.taskOutputPayloadSizeThreshold=1MB
+    conductor.app.maxTaskInputPayloadSizeThreshold=4GB
+    conductor.app.maxTaskOutputPayloadSizeThreshold=4GB
+    conductor.app.maxWorkflowVariablesPayloadSizeThreshold=100MB
+    conductor.app.workflowOffsetTimeout=10m
+    conductor.app.asyncUpdateShortRunningWorkflowDuration=10m

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: conductor
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: conductor
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.conductor.fullname" . }}
+spec:
+  replicas: {{ .Values.conductor.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: conductor
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: conductor
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- if .Values.images.conductor.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.conductor.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.postgresql.enabled }}
+      - name: wait-for-postgres
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      {{- if .Values.elasticsearch.enabled }}
+      - name: wait-for-elasticsearch
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z elasticsearch-master 9200; do echo waiting for elasticsearch; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.images.conductor.registry }}/{{ .Values.images.conductor.repository }}:{{ .Values.images.conductor.tag }}"
+          imagePullPolicy: "{{ .Values.images.conductor.pullPolicy }}"
+          name: conductor
+          ports:
+            - name: http-conductor
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.conductor.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /app/config/config-local.properties
+              name: conductor-config
+              readOnly: true
+              subPath: config-local.properties
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: conductor-config
+          name: conductor-config

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/conductor-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.conductor.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.conductor.service.labels }}
+{{ toYaml .Values.conductor.service.labels | indent 4 }}
+{{- end }}
+    component: "conductor"
+{{- with .Values.conductor.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.conductor.service.clusterIP }}
+  clusterIP: {{ .Values.conductor.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-conductor
+      port: {{ .Values.conductor.service.port }}
+      protocol: TCP
+      targetPort: http-conductor
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "conductor"

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/hpa.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "monkeys.fullname" . }}
+  labels:
+    {{- include "monkeys.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "monkeys.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/ingress.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "monkeys.proxy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "monkeys.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/oneapi-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/oneapi-deployment.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.oneapi.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: oneapi
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: oneapi
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.oneapi.fullname" . }}
+spec:
+  replicas: {{ .Values.oneapi.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: oneapi
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: oneapi
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- if .Values.images.oneapi.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.oneapi.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.postgresql.enabled }}
+      - name: wait-for-postgres
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.images.oneapi.registry }}/{{ .Values.images.oneapi.repository }}:{{ .Values.images.oneapi.tag }}"
+          imagePullPolicy: "{{ .Values.images.oneapi.pullPolicy }}"
+          name: oneapi
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.oneapi.resources | nindent 12 }}
+          env:
+          {{- if .Values.postgresql.enabled }}
+            - name: SQL_DSN
+              value: postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.oneapiDatabase }}
+          {{- else if .Values.externalOneapiPostgresql.enabled }}
+            - name: SQL_DSN
+              value: postgres://{{ .Values.externalOneapiPostgresql.username }}:{{ .Values.externalOneapiPostgresql.password }}@{{ .Values.externalOneapiPostgresql.host }}:{{ .Values.externalOneapiPostgresql.port }}/{{ .Values.externalOneapiPostgresql.database }}
+          {{- end }}
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/oneapi-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/oneapi-service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.oneapi.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.oneapi.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.oneapi.enabled }}
+    component: "oneapi"
+{{- end }}
+{{- with .Values.oneapi.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "oneapi"
+{{- end}}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-config.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-config.yaml
@@ -1,0 +1,93 @@
+{{- if and .Values.proxy.enabled}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "monkeys.proxy.fullname" . }}
+data:
+  proxy.conf: |-
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+  nginx.conf: |-
+    user  nginx;
+    worker_processes  auto;
+    {{- if .Values.proxy.log.persistence.enabled }}
+    error_log  {{ .Values.proxy.log.persistence.mountPath }}/error.log notice;
+    {{- end }}
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    {{- if .Values.proxy.log.persistence.enabled }}
+        access_log  {{ .Values.proxy.log.persistence.mountPath }}/access.log  main;
+    {{- end }}
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+        client_max_body_size 15M;
+
+        include /etc/nginx/conf.d/*.conf;
+    }
+
+  default.conf: |-
+    server {
+        listen 80;
+        server_name _;
+
+        location /api {
+          proxy_pass http://{{ template "monkeys.server.fullname" . }}:{{ .Values.server.service.port }};
+          include proxy.conf;
+        }
+
+        location /v1 {
+          proxy_pass http://{{ template "monkeys.server.fullname" . }}:{{ .Values.server.service.port }};
+          include proxy.conf;
+        }
+
+        {{- if and .Values.admin.enabled}}
+        location /admin {
+          proxy_pass http://{{ template "monkeys.admin.fullname" . }}:{{ .Values.admin.service.port }};
+          include proxy.conf;
+        }
+        {{- end}}
+
+        location /openapi {
+          proxy_pass http://{{ template "monkeys.server.fullname" . }}:{{ .Values.server.service.port }};
+          include proxy.conf;
+        }
+
+        location /openapi-json {
+          proxy_pass http://{{ template "monkeys.server.fullname" . }}:{{ .Values.server.service.port }};
+          include proxy.conf;
+        }
+
+        location / {
+          proxy_pass http://{{ template "monkeys.web.fullname" . }}:{{ .Values.web.service.port }};
+          include proxy.conf;
+        }
+    }
+
+{{- range $key, $value := .Values.extraConfigFiles }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-deployment.yaml
@@ -1,0 +1,111 @@
+{{- if and .Values.proxy.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: nginx proxy
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: proxy
+    # app: {{ template "monkeys.proxy.fullname" . }}
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.proxy.fullname" . }}
+spec:
+  replicas: {{ .Values.proxy.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: proxy
+      {{/*
+      # Required labels for istio
+      # app: {{ template "monkeys.proxy.fullname" . }}
+      # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+      */}}
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: proxy
+        {{/*
+        # Required labels for istio
+        # app: {{ template "monkeys.proxy.fullname" . }}
+        # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+        */}}
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.images.nginx.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.nginx.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - image: "{{ .Values.images.nginx.registry }}/{{ .Values.images.nginx.repository }}:{{ .Values.images.nginx.tag }}"
+        imagePullPolicy: "{{ .Values.images.nginx.pullPolicy }}"
+        name: nginx
+        env:
+        {{- if .Values.proxy.extraEnv }}
+          {{- toYaml .Values.proxy.extraEnv | nindent 8 }}
+        {{- end }}
+        ports:
+          - name: http-proxy
+            containerPort: 80
+            protocol: TCP
+        resources:
+          {{- toYaml .Values.proxy.resources | nindent 12 }}
+        volumeMounts:
+        - name: nginx
+          mountPath: /etc/nginx/nginx.conf
+          readOnly: true
+          subPath: nginx.conf
+        - name: nginx
+          mountPath: /etc/nginx/proxy.conf
+          readOnly: true
+          subPath: proxy.conf
+        - name: nginx
+          mountPath: /etc/nginx/conf.d/default.conf
+          readOnly: true
+          subPath: default.conf
+        {{- if .Values.proxy.log.persistence.enabled }}
+        - name: nginx-logs-disk
+          mountPath: {{ .Values.proxy.log.persistence.mountPath | quote }}
+          subPath: {{ .Values.proxy.log.persistence.persistentVolumeClaim.subPath | default "" }}
+        {{- end }}
+    {{- if and (.Values.nodeSelector) (not .Values.proxy.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.proxy.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.proxy.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.proxy.affinity) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.proxy.affinity }}
+      affinity:
+{{ toYaml .Values.proxy.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.proxy.tolerations) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.proxy.tolerations }}
+      tolerations:
+{{ toYaml .Values.proxy.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: nginx
+        configMap:
+          defaultMode: 420
+          name: {{ template "monkeys.proxy.fullname" . }}
+      {{- if .Values.proxy.log.persistence.enabled }}
+      - name: nginx-logs-disk
+        persistentVolumeClaim:
+          claimName: {{ .Values.proxy.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "monkeys.proxy.fullname" . | trunc 58)) }}
+      {{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/proxy-service.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.proxy.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.proxy.enabled }}
+    component: "proxy"
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+  ports:
+    - name: http-proxy
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http-proxy
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{- end }}
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+{{- if and .Values.proxy.enabled }}
+    component: "proxy"
+{{- end }}
+{{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/server-config.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/server-config.yaml
@@ -1,0 +1,111 @@
+immutable: false
+kind: ConfigMap
+metadata:
+  name: {{ template "monkeys.server.fullname" . }}
+apiVersion: v1
+data:
+  config.yaml: |
+    # Server config
+    {{- if .Values.server.site }}
+    server:
+    {{- toYaml .Values.server.site | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.server.sites }}
+    servers:
+    {{- toYaml .Values.server.sites | nindent 6 }}
+    {{- end }}
+
+    # Database Config
+    {{- if .Values.postgresql.enabled }}
+    database:
+      type: postgres
+      host: {{ .Release.Name }}-postgresql
+      port: 5432
+      username: {{ .Values.postgresql.auth.username }}
+      password: {{ .Values.postgresql.auth.password }}
+      database: {{ .Values.postgresql.auth.monkeysDatabase }}
+    {{- else if .Values.externalPostgresql.enabled }}
+    database:
+      type: postgres
+      host: {{ .Values.externalPostgresql.host }}
+      port: {{ .Values.externalPostgresql.port }}
+      username: {{ .Values.externalPostgresql.username }}
+      password: {{ .Values.externalPostgresql.password }}
+      database: {{ .Values.externalPostgresql.database }}
+    {{- else }}
+    database:
+      type: better-sqlite3
+      database: data/db.sqlite
+    {{- end }}
+
+    # Redis Config
+    {{- if .Values.redis.enabled }}
+    redis:
+      url: redis://:{{ .Values.redis.global.redis.password }}@monkeys-redis-master:6379/0
+    {{- else if .Values.externalRedis.enabled }}
+    redis:
+      {{- toYaml .Values.externalRedis | nindent 6 }}
+    {{- else }}
+    {{- end }}
+
+    # Auth Config
+    auth:
+    {{- toYaml .Values.server.auth | nindent 6 }}
+
+    {{- if .Values.minio.enabled }}
+    s3:
+      endpoint: {{ .Values.minio.endpoint }}
+      isPrivate: {{ .Values.minio.isPrivate }}
+      forcePathStyle: true
+      accessKeyId: {{ if .Values.minio.accessKeyId }}{{ .Values.minio.accessKeyId }}{{ else }}{{ .Values.minio.auth.rootUser }}{{ end }}
+      secretAccessKey: {{ if .Values.minio.secretAccessKey }}{{ .Values.minio.secretAccessKey }}{{ else }}{{ .Values.minio.auth.rootPassword }}{{ end }}
+      region: 'us-east-1'
+      bucket: {{ .Values.minio.defaultBuckets }}
+      publicAccessUrl: {{ .Values.minio.endpoint }}/{{ .Values.minio.defaultBuckets }}
+    {{- else if .Values.externalS3.enabled }}
+    s3:
+      isPrivate: {{ .Values.externalS3.isPrivate }}
+      forcePathStyle: {{ .Values.externalS3.forcePathStyle }}
+      endpoint: {{ .Values.externalS3.endpoint }}
+      accessKeyId: {{ .Values.externalS3.accessKeyId }}
+      secretAccessKey: {{ .Values.externalS3.secretAccessKey }}
+      region: {{ .Values.externalS3.region }}
+      bucket: {{ .Values.externalS3.bucket }}
+      publicAccessUrl: {{ .Values.externalS3.publicAccessUrl }}
+    {{- else }}
+    {{- end }}
+
+    conductor:
+      baseUrl: http://{{ template "monkeys.conductor.fullname" . }}:8080/api
+
+    {{- if .Values.llmModels }}
+    models:
+    {{- toYaml .Values.llmModels | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.tools }}
+    tools:
+    {{- toYaml .Values.tools | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.admin.enabled }}
+    paymentServer:
+      enabled: {{ .Values.admin.enabled }}
+      baseUrl: http://{{ template "monkeys.admin.fullname" . }}:{{ .Values.admin.service.port }}
+    {{- end }}
+
+    {{- if .Values.oneapi.enabled }}
+    oneapi:
+      enabled: true
+      baseURL: http://{{ template "monkeys.oneapi.fullname" . }}:3000
+      rootUsername: {{ .Values.oneapi.rootUsername }}
+      rootPassword: {{ .Values.oneapi.rootPassword }}
+      rootToken: {{ .Values.oneapi.rootToken }}
+    {{- else if .Values.externalOneapi.enabled }}
+    oneapi:
+      enabled: true
+      baseURL: {{ .Values.externalOneapi.baseURL }}
+      rootToken: {{ .Values.externalOneapi.rootToken }}
+    {{- else }}
+    {{- end }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/server-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/server-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: server
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: server
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.server.fullname" . }}
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: server
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: server
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- if .Values.images.server.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.server.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.postgresql.enabled }}
+      - name: wait-for-postgres
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      {{- if .Values.redis.enabled }}
+      - name: wait-for-redis
+        image: {{ .Values.images.busybox.registry }}/{{ .Values.images.busybox.repository }}:{{ .Values.images.busybox.tag }}
+        command: ['sh', '-c', 'until nc -z monkeys-redis-master 6379; do echo waiting for redis; sleep 2; done;']
+        imagePullPolicy: {{ .Values.images.busybox.imagePullPolicy }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.images.server.registry }}/{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"
+          imagePullPolicy: "{{ .Values.images.server.pullPolicy }}"
+          name: monkeys
+          ports:
+            - name: http-server
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/monkeys/config.yaml
+              name: {{ template "monkeys.server.fullname" . }}
+              readOnly: true
+              subPath: config.yaml
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: {{ template "monkeys.server.fullname" . }}
+          name: {{ template "monkeys.server.fullname" . }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/server-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/server-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.server.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.server.service.labels }}
+{{ toYaml .Values.server.service.labels | indent 4 }}
+{{- end }}
+    component: "server"
+{{- with .Values.server.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.server.service.clusterIP }}
+  clusterIP: {{ .Values.server.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-server
+      port: {{ .Values.server.service.port }}
+      protocol: TCP
+      targetPort: http-server
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "server"

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/web-deployment.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/web-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "monkeys.ud.annotations" . | indent 4 }}
+    descriptions: web
+  labels:
+{{- include "monkeys.labels" . | nindent 4 }}
+    component: web
+{{ include "monkeys.ud.labels" . | indent 4 }}
+  name: {{ template "monkeys.web.fullname" . }}
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+{{- include "monkeys.selectorLabels" . | nindent 6 }}
+      component: web
+  template:
+    metadata:
+      annotations:
+{{ include "monkeys.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "monkeys.selectorLabels" . | nindent 8 }}
+        component: web
+{{ include "monkeys.ud.labels" . | indent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- if .Values.images.web.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.images.web.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.images.web.registry }}/{{ .Values.images.web.repository }}:{{ .Values.images.web.tag }}"
+          imagePullPolicy: "{{ .Values.images.web.pullPolicy }}"
+          name: web
+          ports:
+            - name: http-web
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}

--- a/charts/monkeys-core/monkeys-core/charts/core/templates/web-service.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/templates/web-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "monkeys.web.fullname" . }}
+  labels:
+{{ include "monkeys.labels" . | indent 4 }}
+{{- if .Values.web.service.labels }}
+{{ toYaml .Values.web.service.labels | indent 4 }}
+{{- end }}
+    component: "web"
+{{- with .Values.web.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.web.service.clusterIP }}
+  clusterIP: {{ .Values.web.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-web
+      port: {{ .Values.web.service.port }}
+      protocol: TCP
+      targetPort: http-web
+  selector:
+{{ include "monkeys.selectorLabels" . | indent 4 }}
+    component: "web"

--- a/charts/monkeys-core/monkeys-core/charts/core/values.yaml
+++ b/charts/monkeys-core/monkeys-core/charts/core/values.yaml
@@ -1,0 +1,577 @@
+fullnameOverride:
+
+###################################
+# Images
+###################################
+images:
+  server:
+    registry: docker.io
+    repository: infmonkeys/monkeys
+    # To use multi tenancy version
+    # repository: infmonkeys/monkeys-multi-tenancy
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets: 
+  
+  web:
+    registry: docker.io
+    repository: infmonkeys/monkeys-ui
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets: 
+
+  admin:
+    registry: docker.io
+    repository: infmonkeys/monkeys-admin
+    # To use multi tenancy version
+    # repository: infmonkeys/monkeys-admin-multi-tenancy
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets:
+
+  conductor:
+    registry: docker.io
+    repository: infmonkeys/conductor
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets: 
+
+  oneapi:
+    registry: docker.io
+    repository: justsong/one-api
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets: 
+
+  busybox:
+    registry: docker.io
+    repository: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets: 
+
+  clash:
+    registry: docker.io
+    repository: infmonkeys/clash
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets:
+
+  nginx:
+    registry: docker.io
+    repository: nginx
+    tag: latest
+    pullPolicy: IfNotPresent
+    pullSecrets:
+
+###################################
+# Nginx reverse proxy
+###################################
+proxy:
+  enabled: true
+
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  extraEnv:
+  # Apply your own Environment Variables if necessary
+  # - name: LANG
+  #   value: "C.UTF-8"
+  log:
+    persistence:
+      ## If true, create/use a Persistent Volume Claim for log
+      ## If false, flush logs to stdout & stderr
+      ##
+      enabled: false
+      mountPath: "/var/log/nginx"
+      annotations:
+        helm.sh/resource-policy: keep
+      persistentVolumeClaim:
+        existingClaim: ""
+        ## Nginx Logs Persistent Volume Storage Class
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.
+        ## ReadWriteMany access mode required for nginx
+        ##
+        storageClass:
+        accessModes: ReadWriteMany
+        size: 1Gi
+        subPath: ""
+  service:
+    port: 80
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+
+###################################
+# Monkeys Server
+###################################
+server:
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+  service:
+    port: 3000
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+  # For single tenant
+  site:
+    # Defaults to monkeys, will use as table name prefix and etc, you can change to your own.
+    appId: monkeys
+    # Change this to public visible url
+    appUrl: http://localhost:3000
+    customization:
+      title: 猴子无限
+      logo:
+        light: https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg
+        dark: https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg
+      favicon: https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg
+      colors:
+        primary: "#52ad1f"
+
+  # For multi tenant
+  # sites:
+  #   - appId: monkeys
+  #     appUrl: http://localhost:3000
+  #     host: localhost:3000
+  #     customization:
+  #       title: 猴子无限
+  #       logo: https://static.aside.fun/static/vines.svg
+  #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+  #       colors:
+  #         primary: "#52ad1f"
+  #   - appId: monkeys2
+  #     appUrl: http://localhost:3001
+  #     host: localhost:3001
+  #     customization:
+  #       title: 猴子无限
+  #       logo: https://static.aside.fun/static/vines.svg
+  #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+  #       colors:
+  #         primary: "#52ad1f"
+
+  auth:
+    enabled:
+      - password
+
+  # Example: Enable OIDC SSO
+  # auth:
+  #   enabled:
+  #     - oidc
+  #   oidc:
+  #     auto_signin: false
+  #     issuer: 
+  #     client_id: 
+  #     client_secret: 
+  #     scope: openid profile
+  #     button_text: 使用 OIDC 登录
+  #     id_token_signed_response_alg: RS256  
+
+
+  # Example: Enable SMS Auth
+  # auth:
+  #   enabled:
+  #     - phone
+  #   sms:
+  #     provider: dysms
+  #     config:
+  #       accessKeyId: 
+  #       accessKeySecret: 
+  #       signName: 
+  #       templateCode: 
+
+
+###################################
+# Monkeys Web
+###################################
+web:
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+  service:
+    port: 3000
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+###################################
+# Monkeys Admin
+###################################
+admin:
+  enabled: false
+  replicas: 1
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+  service:
+    port: 3000
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+  # For single tenant
+  site:
+    # Defaults to monkeys, will use as table name prefix and etc, you can change to your own.
+    appId: monkeys
+    # Change this to public visible url
+    appUrl: http://localhost:3000
+    auth:
+      enabled: true
+      defaultAdmin:
+        email: admin@example.com
+        password: monkeys123
+    customization:
+      title: 猴子无限
+      logo:
+        light: https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg
+        dark: https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg
+      favicon: https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg
+      colors:
+        primary: "#52ad1f"
+
+  # For multi tenant version
+  # sites:
+  #   - appId: monkeys
+  #     host: localhost:3000
+  #     auth:
+  #       enabled: true
+  #       defaultAdmin:
+  #         email: admin@example.com
+  #         password: monkeys123
+  #     customization:
+  #       title: 猴子无限
+  #       logo: https://static.aside.fun/static/vines.svg
+  #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+  #       colors:
+  #         primary: "#52ad1f"
+  #   - appId: monkeys2
+  #     host: localhost:3001
+  #     auth:
+  #       enabled: true
+  #       defaultAdmin:
+  #         email: admin@example.com
+  #         password: monkeys123
+  #     customization:
+  #       title: 猴子无限
+  #       logo: https://static.aside.fun/static/vines.svg
+  #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+  #       colors:
+  #         primary: "#52ad1f"
+
+###################################
+# OneAPI
+###################################
+oneapi:
+  enabled: true
+  rootUsername: root
+  rootPassword: "123456"
+
+###################################
+# External OneAPI
+###################################
+externalOneapi:
+  enabled: false
+  baseURL: http:127.0.0.1:3000
+  rootToken: "37383627c8daxxxxxxxx78ae3e453923c2"
+
+###################################
+# BuiltIn Tools
+###################################
+tools: []
+# tools:
+#   - name: knowledge-base
+#     manifestUrl: http://monkey-tools-knowledge-base:5000/manifest.json
+
+###################################
+# LLM Models
+###################################
+llmModels: []
+# llmModels:
+#   - model:
+#       - gpt-3.5-turbo
+#       - gpt-4-0613
+#     baseURL: https://api.openai.com/v1
+#     apiKey: sk-xxxxxxxxxxxxxxxxxxxx
+#     type:
+#       - chat_completions
+
+###################################
+# Conductor
+###################################
+conductor:
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+  service:
+    port: 8080
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+###################################
+# Clash
+###################################
+clash:
+  enabled: false
+  replicas: 1
+  resources: {}
+  annotations: {}
+
+  subscriptionUrl: ""
+  secret: ""
+
+
+###################################
+# GProductNavigator
+###################################
+GProductNavigator:
+  enabled: false
+  spec:
+    name: 流程编排
+    iconUrl: https://static.infmonkeys.com/favicon-gray.svg
+    localizedName:
+      zh-CN: 流程编排
+      en-US: Flow Choreography
+    url: https://ai.daocloud.cn/login
+    category: modelapplication
+    visible: true
+    order: 0
+    gproduct: monkeys
+
+
+###################################
+# BuiltIn postgres
+# - these configs are only used when `postgresql.enabled` is true
+###################################
+postgresql:
+  # If not enabled, will use sqlite as fallback.
+  enabled: true
+  image:
+    debug: true
+  auth:
+    postgresPassword: "monkeys123"
+    username: "monkeys"
+    password: "monkeys123"
+    monkeysDatabase: "monkeys"
+    conductorDatabase: "conductor"
+    oneapiDatabase: "oneapi"
+  primary:
+    initdb:
+      user: monkeys
+      password: monkeys123
+      scripts:
+        setup.sql: |
+          CREATE DATABASE monkeys;
+          CREATE DATABASE conductor;
+          CREATE DATABASE oneapi;
+
+###################################
+# External postgres
+# - these configs are only used when `externalPostgresql.enabled` is true
+###################################
+# For monkeys
+externalPostgresql:
+  enabled: false
+  host: 127.0.0.1
+  port: 5432
+  username: monkeys
+  password: monkeys123
+  database: monkeys
+
+# For conductor
+externalConductorPostgresql:
+  enabled: false
+  host: 127.0.0.1
+  port: 5432
+  username: monkeys
+  password: monkeys123
+  database: conductor
+
+# For OneAPI
+externalOneapiPostgresql:
+  enabled: false
+  host: 127.0.0.1
+  port: 5432
+  username: monkeys
+  password: monkeys123
+  database: oneapi
+
+###################################
+# BuiltIn elasticsearch
+# - these configs are only used when `elasticsearch.enabled` is true
+# See more at https://github.com/elastic/helm-charts/tree/main/elasticsearch#configuration
+###################################
+elasticsearch:
+  enabled: true
+  replicas: 1
+  image: docker.elastic.co/elasticsearch/elasticsearch
+  imageTag: 7.17.3
+  minimumMasterNodes: 1
+  esMajorVersion: 7
+  secret:
+    password: monkeys123
+
+  indexReplicasCount: 0
+  clusterHealthColor: yellow
+
+###################################
+# External elasticsearch 7
+# - these configs are only used when `externalElasticsearch.enabled` is true
+###################################
+externalElasticsearch:
+  enabled: false
+  indexReplicasCount: 0
+  clusterHealthColor: yellow
+  url: http://localhost:9200
+  username: elastic
+  password: monkeys123
+
+###################################
+# BuiltIn redis
+# - these configs are only used when `redis.enabled` is true
+###################################
+redis:
+  enabled: true
+  architecture: standalone
+  global:
+    redis:
+      password: monkeys123
+
+###################################
+# External redis
+# - these configs are only used when `externalRedis.enabled` is true
+###################################
+# standalone example
+externalRedis:
+  mode: standalone
+  enabled: false
+  url: redis://localhost:6379/0
+  # Set password like this
+  # url: redis://:password@localhost:6379/0
+
+# cluster example
+# externalRedis:
+#   enabled: true
+#   mode: cluster
+#   nodes:
+#     - host: 127.0.0.1
+#       port: 7001
+#     - host: 127.0.0.1
+#       port: 7002
+#     - host: 127.0.0.1
+#       port: 7003
+#     - host: 127.0.0.1
+#       port: 7004
+#     - host: 127.0.0.1
+#       port: 7005
+#     - host: 127.0.0.1
+#       port: 7006
+#   options:
+#     password: password
+
+# sentinel example
+# externalRedis:
+#   enabled: true
+#   mode: sentinel
+#   sentinels:
+#     - host: 127.0.0.1
+#       port: 7101
+#   sentinelName: mymaster
+#   options:
+#     password: password
+
+###################################
+# BuiltIn s3 storage
+# - these configs are only used when `minio.enabled` is true
+# - See more configuration at https://artifacthub.io/packages/helm/bitnami/minio
+###################################
+minio:
+  enabled: true
+  mode: standalone
+  defaultBuckets: monkeys-static
+  isPrivate: false
+  auth:
+    rootUser: minio
+    rootPassword: monkeys123
+
+  # By default use nodeport mode, so in browser user can access.
+  service:
+    type: NodePort
+    nodePorts:
+      # NodePort value should be between 30000-32767
+      # And if your server is behind a firewall, be sure to open those ports.
+      api: 31900
+      console: 31901
+
+  # This is the public accessible url of your minio, this will be use by frontend to display your staticfiles.
+  # **NOTE: this is the api port not console port**
+  # **NOTE: if you are using minikube, you need to port-foward minio service, see more at https://stackoverflow.com/a/55110218**
+  endpoint: http://127.0.0.1:31900
+
+###################################
+# External s3 storage
+# - these configs are only used when `externalRedis.enabled` is true
+###################################
+externalS3:
+  enabled: false
+  # If the bucket is private, set this to true
+  isPrivate: false
+  # If you are use minio, set this to true
+  forcePathStyle: false
+  endpoint: ""
+  accessKeyId: ""
+  secretAccessKey: ""
+  region: ""
+  bucket: ""
+  publicAccessUrl: ""
+
+###################################
+# Proxy SVC Config
+###################################
+# By default use ClusterIP Mode
+service:
+  type: ClusterIP
+  port: 80
+  clusterIP: ""
+
+  # Or you can use NodePort Mode
+  # type: NodePort
+  # port: 80
+  # nodePort: 30080
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    # nginx.ingress.kubernetes.io/proxy-body-size: 15m
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: monkeys-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10

--- a/charts/monkeys-core/monkeys-core/values.schema.json
+++ b/charts/monkeys-core/monkeys-core/values.schema.json
@@ -1,0 +1,1007 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "core": {
+            "type": "object",
+            "properties": {
+                "GProductNavigator": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "spec": {
+                            "type": "object",
+                            "properties": {
+                                "category": {
+                                    "type": "string"
+                                },
+                                "gproduct": {
+                                    "type": "string"
+                                },
+                                "iconUrl": {
+                                    "type": "string"
+                                },
+                                "localizedName": {
+                                    "type": "object",
+                                    "properties": {
+                                        "en-US": {
+                                            "type": "string"
+                                        },
+                                        "zh-CN": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "order": {
+                                    "type": "integer"
+                                },
+                                "url": {
+                                    "type": "string"
+                                },
+                                "visible": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "admin": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "site": {
+                            "type": "object",
+                            "properties": {
+                                "appId": {
+                                    "type": "string"
+                                },
+                                "appUrl": {
+                                    "type": "string"
+                                },
+                                "auth": {
+                                    "type": "object",
+                                    "properties": {
+                                        "defaultAdmin": {
+                                            "type": "object",
+                                            "properties": {
+                                                "email": {
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                "customization": {
+                                    "type": "object",
+                                    "properties": {
+                                        "colors": {
+                                            "type": "object",
+                                            "properties": {
+                                                "primary": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "favicon": {
+                                            "type": "string"
+                                        },
+                                        "logo": {
+                                            "type": "object",
+                                            "properties": {
+                                                "dark": {
+                                                    "type": "string"
+                                                },
+                                                "light": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "title": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxReplicas": {
+                            "type": "integer"
+                        },
+                        "minReplicas": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "clash": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "secret": {
+                            "type": "string"
+                        },
+                        "subscriptionUrl": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "conductor": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "elasticsearch": {
+                    "type": "object",
+                    "properties": {
+                        "clusterHealthColor": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "esMajorVersion": {
+                            "type": "integer"
+                        },
+                        "image": {
+                            "type": "string"
+                        },
+                        "imageTag": {
+                            "type": "string"
+                        },
+                        "indexReplicasCount": {
+                            "type": "integer"
+                        },
+                        "minimumMasterNodes": {
+                            "type": "integer"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "secret": {
+                            "type": "object",
+                            "properties": {
+                                "password": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalConductorPostgresql": {
+                    "type": "object",
+                    "properties": {
+                        "database": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalElasticsearch": {
+                    "type": "object",
+                    "properties": {
+                        "clusterHealthColor": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "indexReplicasCount": {
+                            "type": "integer"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalOneapi": {
+                    "type": "object",
+                    "properties": {
+                        "baseURL": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "rootToken": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalOneapiPostgresql": {
+                    "type": "object",
+                    "properties": {
+                        "database": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalPostgresql": {
+                    "type": "object",
+                    "properties": {
+                        "database": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalRedis": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "mode": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalS3": {
+                    "type": "object",
+                    "properties": {
+                        "accessKeyId": {
+                            "type": "string"
+                        },
+                        "bucket": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "forcePathStyle": {
+                            "type": "boolean"
+                        },
+                        "isPrivate": {
+                            "type": "boolean"
+                        },
+                        "publicAccessUrl": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "secretAccessKey": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "fullnameOverride": {
+                    "type": "null"
+                },
+                "images": {
+                    "type": "object",
+                    "properties": {
+                        "admin": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "busybox": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "clash": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "conductor": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "nginx": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "oneapi": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "web": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "pullSecrets": {
+                                    "type": "null"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "className": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {
+                                        "type": "string"
+                                    },
+                                    "paths": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                },
+                                                "pathType": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "llmModels": {
+                    "type": "array"
+                },
+                "minio": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "rootPassword": {
+                                    "type": "string"
+                                },
+                                "rootUser": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "defaultBuckets": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "isPrivate": {
+                            "type": "boolean"
+                        },
+                        "mode": {
+                            "type": "string"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "api": {
+                                            "type": "integer"
+                                        },
+                                        "console": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "oneapi": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "rootPassword": {
+                            "type": "string"
+                        },
+                        "rootUsername": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "conductorDatabase": {
+                                    "type": "string"
+                                },
+                                "monkeysDatabase": {
+                                    "type": "string"
+                                },
+                                "oneapiDatabase": {
+                                    "type": "string"
+                                },
+                                "password": {
+                                    "type": "string"
+                                },
+                                "postgresPassword": {
+                                    "type": "string"
+                                },
+                                "username": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "debug": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "primary": {
+                            "type": "object",
+                            "properties": {
+                                "initdb": {
+                                    "type": "object",
+                                    "properties": {
+                                        "password": {
+                                            "type": "string"
+                                        },
+                                        "scripts": {
+                                            "type": "object",
+                                            "properties": {
+                                                "setup.sql": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "user": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "proxy": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraEnv": {
+                            "type": "null"
+                        },
+                        "log": {
+                            "type": "object",
+                            "properties": {
+                                "persistence": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object",
+                                            "properties": {
+                                                "helm.sh/resource-policy": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "persistentVolumeClaim": {
+                                            "type": "object",
+                                            "properties": {
+                                                "accessModes": {
+                                                    "type": "string"
+                                                },
+                                                "existingClaim": {
+                                                    "type": "string"
+                                                },
+                                                "size": {
+                                                    "type": "string"
+                                                },
+                                                "storageClass": {
+                                                    "type": "null"
+                                                },
+                                                "subPath": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "redis": {
+                    "type": "object",
+                    "properties": {
+                        "architecture": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "global": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "object",
+                                    "properties": {
+                                        "password": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "site": {
+                            "type": "object",
+                            "properties": {
+                                "appId": {
+                                    "type": "string"
+                                },
+                                "appUrl": {
+                                    "type": "string"
+                                },
+                                "customization": {
+                                    "type": "object",
+                                    "properties": {
+                                        "colors": {
+                                            "type": "object",
+                                            "properties": {
+                                                "primary": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "favicon": {
+                                            "type": "string"
+                                        },
+                                        "logo": {
+                                            "type": "object",
+                                            "properties": {
+                                                "dark": {
+                                                    "type": "string"
+                                                },
+                                                "light": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "title": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tools": {
+                    "type": "array"
+                },
+                "web": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/monkeys-core/monkeys-core/values.yaml
+++ b/charts/monkeys-core/monkeys-core/values.yaml
@@ -1,0 +1,552 @@
+# child values
+core:
+  fullnameOverride:
+  ###################################
+  # Images
+  ###################################
+  images:
+    server:
+      registry: m.daocloud.io/docker.io
+      repository: infmonkeys/monkeys
+      # To use multi tenancy version
+      # repository: infmonkeys/monkeys-multi-tenancy
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    web:
+      registry: m.daocloud.io/docker.io
+      repository: infmonkeys/monkeys-ui
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    admin:
+      registry: m.daocloud.io/docker.io
+      repository: infmonkeys/monkeys-admin
+      # To use multi tenancy version
+      # repository: infmonkeys/monkeys-admin-multi-tenancy
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    conductor:
+      registry: m.daocloud.io/docker.io
+      repository: infmonkeys/conductor
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    oneapi:
+      registry: m.daocloud.io/docker.io
+      repository: justsong/one-api
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    busybox:
+      registry: m.daocloud.io/docker.io
+      repository: busybox
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    clash:
+      registry: m.daocloud.io/docker.io
+      repository: infmonkeys/clash
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+    nginx:
+      registry: m.daocloud.io/docker.io
+      repository: nginx
+      tag: latest
+      pullPolicy: IfNotPresent
+      pullSecrets:
+  ###################################
+  # Nginx reverse proxy
+  ###################################
+  proxy:
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2048M
+      requests:
+        cpu: 100m
+        memory: 125M
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    extraEnv:
+    # Apply your own Environment Variables if necessary
+    # - name: LANG
+    #   value: "C.UTF-8"
+    log:
+      persistence:
+        ## If true, create/use a Persistent Volume Claim for log
+        ## If false, flush logs to stdout & stderr
+        ##
+        enabled: false
+        mountPath: "/var/log/nginx"
+        annotations:
+          helm.sh/resource-policy: keep
+        persistentVolumeClaim:
+          existingClaim: ""
+          ## Nginx Logs Persistent Volume Storage Class
+          ## If defined, storageClassName: <storageClass>
+          ## If set to "-", storageClassName: "", which disables dynamic provisioning
+          ## If undefined (the default) or set to null, no storageClassName spec is
+          ##   set, choosing the default provisioner.
+          ## ReadWriteMany access mode required for nginx
+          ##
+          storageClass:
+          accessModes: ReadWriteMany
+          size: 1Gi
+          subPath: ""
+    service:
+      port: 80
+      annotations: {}
+      labels: {}
+      clusterIP: ""
+  ###################################
+  # Monkeys Server
+  ###################################
+  server:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2048M
+      requests:
+        cpu: 100m
+        memory: 125M
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    service:
+      port: 3000
+      annotations: {}
+      labels: {}
+      clusterIP: ""
+    # For single tenant
+    site:
+      # Defaults to monkeys, will use as table name prefix and etc, you can change to your own.
+      appId: monkeys
+      # Change this to public visible url
+      appUrl: http://localhost:3000
+      customization:
+        title: 猴子无限
+        logo:
+          light: https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg
+          dark: https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg
+        favicon: https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg
+        colors:
+          primary: "#52ad1f"
+    # For multi tenant
+    # sites:
+    #   - appId: monkeys
+    #     appUrl: http://localhost:3000
+    #     host: localhost:3000
+    #     customization:
+    #       title: 猴子无限
+    #       logo: https://static.aside.fun/static/vines.svg
+    #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+    #       colors:
+    #         primary: "#52ad1f"
+    #   - appId: monkeys2
+    #     appUrl: http://localhost:3001
+    #     host: localhost:3001
+    #     customization:
+    #       title: 猴子无限
+    #       logo: https://static.aside.fun/static/vines.svg
+    #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+    #       colors:
+    #         primary: "#52ad1f"
+    auth:
+      enabled:
+        - password
+        # Example: Enable OIDC SSO
+        # auth:
+        #   enabled:
+        #     - oidc
+        #   oidc:
+        #     auto_signin: false
+        #     issuer: 
+        #     client_id: 
+        #     client_secret: 
+        #     scope: openid profile
+        #     button_text: 使用 OIDC 登录
+        #     id_token_signed_response_alg: RS256  
+
+        # Example: Enable SMS Auth
+        # auth:
+        #   enabled:
+        #     - phone
+        #   sms:
+        #     provider: dysms
+        #     config:
+        #       accessKeyId: 
+        #       accessKeySecret: 
+        #       signName: 
+        #       templateCode: 
+  ###################################
+  # Monkeys Web
+  ###################################
+  web:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2048M
+      requests:
+        cpu: 100m
+        memory: 125M
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    service:
+      port: 3000
+      annotations: {}
+      labels: {}
+      clusterIP: ""
+  ###################################
+  # Monkeys Admin
+  ###################################
+  admin:
+    enabled: false
+    replicas: 1
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    service:
+      port: 3000
+      annotations: {}
+      labels: {}
+      clusterIP: ""
+    # For single tenant
+    site:
+      # Defaults to monkeys, will use as table name prefix and etc, you can change to your own.
+      appId: monkeys
+      # Change this to public visible url
+      appUrl: http://localhost:3000
+      auth:
+        enabled: true
+        defaultAdmin:
+          email: admin@example.com
+          password: monkeys123
+      customization:
+        title: 猴子无限
+        logo:
+          light: https://static.infmonkeys.com/logo/InfMonkeys-logo-light.svg
+          dark: https://static.infmonkeys.com/logo/InfMonkeys-logo-dark.svg
+        favicon: https://static.infmonkeys.com/logo/InfMonkeys-ICO.svg
+        colors:
+          primary: "#52ad1f"
+          # For multi tenant version
+          # sites:
+          #   - appId: monkeys
+          #     host: localhost:3000
+          #     auth:
+          #       enabled: true
+          #       defaultAdmin:
+          #         email: admin@example.com
+          #         password: monkeys123
+          #     customization:
+          #       title: 猴子无限
+          #       logo: https://static.aside.fun/static/vines.svg
+          #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+          #       colors:
+          #         primary: "#52ad1f"
+          #   - appId: monkeys2
+          #     host: localhost:3001
+          #     auth:
+          #       enabled: true
+          #       defaultAdmin:
+          #         email: admin@example.com
+          #         password: monkeys123
+          #     customization:
+          #       title: 猴子无限
+          #       logo: https://static.aside.fun/static/vines.svg
+          #       favicon: https://static.infmonkeys.com/upload/favicon.svg
+          #       colors:
+          #         primary: "#52ad1f"
+  ###################################
+  # OneAPI
+  ###################################
+  oneapi:
+    enabled: false
+    rootUsername: root
+    rootPassword: "123456"
+  ###################################
+  # External OneAPI
+  ###################################
+  externalOneapi:
+    enabled: false
+    baseURL: http:127.0.0.1:3000
+    rootToken: "37383627c8daxxxxxxxx78ae3e453923c2"
+  ###################################
+  # BuiltIn Tools
+  ###################################
+  tools: []
+  # tools:
+  #   - name: knowledge-base
+  #     manifestUrl: http://monkey-tools-knowledge-base:5000/manifest.json
+
+  ###################################
+  # LLM Models
+  ###################################
+  llmModels: []
+  # llmModels:
+  #   - model:
+  #       - gpt-3.5-turbo
+  #       - gpt-4-0613
+  #     baseURL: https://api.openai.com/v1
+  #     apiKey: sk-xxxxxxxxxxxxxxxxxxxx
+  #     type:
+  #       - chat_completions
+
+  ###################################
+  # Conductor
+  ###################################
+  conductor:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2048M
+      requests:
+        cpu: 100m
+        memory: 125M
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    service:
+      port: 8080
+      annotations: {}
+      labels: {}
+      clusterIP: ""
+  ###################################
+  # Clash
+  ###################################
+  clash:
+    enabled: false
+    replicas: 1
+    resources: {}
+    annotations: {}
+    subscriptionUrl: ""
+    secret: ""
+  ###################################
+  # GProductNavigator
+  ###################################
+  GProductNavigator:
+    enabled: true
+    spec:
+      name: 流程编排
+      iconUrl: https://static.infmonkeys.com/favicon-gray.svg
+      localizedName:
+        zh-CN: 流程编排
+        en-US: Flow Choreography
+      url: https://ai.daocloud.cn/login
+      category: modelapplication
+      visible: true
+      order: 0
+      gproduct: monkeys
+  ###################################
+  # BuiltIn postgres
+  # - these configs are only used when `postgresql.enabled` is true
+  ###################################
+  postgresql:
+    # If not enabled, will use sqlite as fallback.
+    enabled: false
+    image:
+      debug: true
+    auth:
+      postgresPassword: "monkeys123"
+      username: "monkeys"
+      password: "monkeys123"
+      monkeysDatabase: "monkeys"
+      conductorDatabase: "conductor"
+      oneapiDatabase: "oneapi"
+    primary:
+      initdb:
+        user: monkeys
+        password: monkeys123
+        scripts:
+          setup.sql: |
+            CREATE DATABASE monkeys;
+            CREATE DATABASE conductor;
+            CREATE DATABASE oneapi;
+  ###################################
+  # External postgres
+  # - these configs are only used when `externalPostgresql.enabled` is true
+  ###################################
+  # For monkeys
+  externalPostgresql:
+    enabled: true
+    host: pg-svc.infra-drun.svc
+    port: 5432
+    username: postgres
+    password: monkeys123
+    database: monkeys
+  # For conductor
+  externalConductorPostgresql:
+    enabled: true
+    host: pg-svc.infra-drun.svc
+    port: 5432
+    username: postgres
+    password: monkeys123
+    database: conductor
+  # For OneAPI
+  externalOneapiPostgresql:
+    enabled: false
+    host: 127.0.0.1
+    port: 5432
+    username: monkeys
+    password: monkeys123
+    database: oneapi
+  ###################################
+  # BuiltIn elasticsearch
+  # - these configs are only used when `elasticsearch.enabled` is true
+  # See more at https://github.com/elastic/helm-charts/tree/main/elasticsearch#configuration
+  ###################################
+  elasticsearch:
+    enabled: false
+    replicas: 1
+    image: docker.elastic.co/elasticsearch/elasticsearch
+    imageTag: 7.17.3
+    minimumMasterNodes: 1
+    esMajorVersion: 7
+    secret:
+      password: monkeys123
+    indexReplicasCount: 0
+    clusterHealthColor: yellow
+  ###################################
+  # External elasticsearch 7
+  # - these configs are only used when `externalElasticsearch.enabled` is true
+  ###################################
+  externalElasticsearch:
+    enabled: true
+    indexReplicasCount: 0
+    clusterHealthColor: yellow
+    url: http://mcamel-common-es-cluster-masters-es-http.mcamel-system.svc:9200
+    username: elastic
+    password: monkeys123
+  ###################################
+  # BuiltIn redis
+  # - these configs are only used when `redis.enabled` is true
+  ###################################
+  redis:
+    enabled: true
+    architecture: standalone
+    global:
+      redis:
+        password: monkeys123
+  ###################################
+  # External redis
+  # - these configs are only used when `externalRedis.enabled` is true
+  ###################################
+  # standalone example
+  externalRedis:
+    mode: standalone
+    enabled: false
+    url: redis://localhost:6379/0
+    # Set password like this
+    # url: redis://:password@localhost:6379/0
+  # cluster example
+  # externalRedis:
+  #   enabled: true
+  #   mode: cluster
+  #   nodes:
+  #     - host: 127.0.0.1
+  #       port: 7001
+  #     - host: 127.0.0.1
+  #       port: 7002
+  #     - host: 127.0.0.1
+  #       port: 7003
+  #     - host: 127.0.0.1
+  #       port: 7004
+  #     - host: 127.0.0.1
+  #       port: 7005
+  #     - host: 127.0.0.1
+  #       port: 7006
+  #   options:
+  #     password: password
+
+  # sentinel example
+  # externalRedis:
+  #   enabled: true
+  #   mode: sentinel
+  #   sentinels:
+  #     - host: 127.0.0.1
+  #       port: 7101
+  #   sentinelName: mymaster
+  #   options:
+  #     password: password
+
+  ###################################
+  # BuiltIn s3 storage
+  # - these configs are only used when `minio.enabled` is true
+  # - See more configuration at https://artifacthub.io/packages/helm/bitnami/minio
+  ###################################
+  minio:
+    enabled: false
+    mode: standalone
+    defaultBuckets: monkeys-static
+    isPrivate: false
+    auth:
+      rootUser: minio
+      rootPassword: monkeys123
+    # By default use nodeport mode, so in browser user can access.
+    service:
+      type: NodePort
+      nodePorts:
+        # NodePort value should be between 30000-32767
+        # And if your server is behind a firewall, be sure to open those ports.
+        api: 31900
+        console: 31901
+    # This is the public accessible url of your minio, this will be use by frontend to display your staticfiles.
+    # **NOTE: this is the api port not console port**
+    # **NOTE: if you are using minikube, you need to port-foward minio service, see more at https://stackoverflow.com/a/55110218**
+    endpoint: http://127.0.0.1:31900
+  ###################################
+  # External s3 storage
+  # - these configs are only used when `externalRedis.enabled` is true
+  ###################################
+  externalS3:
+    enabled: true
+    # If the bucket is private, set this to true
+    isPrivate: false
+    # If you are use minio, set this to true
+    forcePathStyle: false
+    endpoint: "https://minio-svc.infra-drun.svc"
+    accessKeyId: "minio"
+    secretAccessKey: ""
+    region: "us-east-1"
+    bucket: "monkeys"
+    publicAccessUrl: ""
+  ###################################
+  # Proxy SVC Config
+  ###################################
+  # By default use ClusterIP Mode
+  service:
+    type: ClusterIP
+    port: 80
+    clusterIP: ""
+    # Or you can use NodePort Mode
+    # type: NodePort
+    # port: 80
+    # nodePort: 30080
+  ingress:
+    enabled: false
+    className: nginx
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    # nginx.ingress.kubernetes.io/proxy-body-size: 15m
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    hosts:
+      - host: monkeys-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10

--- a/test/monkeys-core/install.sh
+++ b/test/monkeys-core/install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
+
+KIND_KUBECONFIG=$1
+
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+
+helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+#==================== notice , prometheus CRD has been deployed , so you no need to =============
+
+set -x
+
+# deploy the monkeys-core
+helm install monkeys-core chart-museum/monkeys-core  ${HELM_MUST_OPTION}   --namespace monkeys  --create-namespace \
+  --set instances.enabled=true \
+  
+kubectl get all -n metallb-system1 --kubeconfig ${KIND_KUBECONFIG}
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+  exit 0
+else
+  echo "error, faild to deploy $CHART_DIR"
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:
add monkeys chart
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #