### PR TITLE
Robot Upgrade: argo-rollouts chart upgrade from 2.35.3 to 2.36.2

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Support revisionHistoryLimit
+    - kind: changed
+      description: Add subscriptions into notifications-configmap
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.6
+appVersion: v1.7.0
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,8 +19,8 @@ maintainers:
 name: argo-rollouts
 sources:
   - https://github.com/argoproj/argo-rollouts
-version: 2.35.3
+version: 2.36.2
 dependencies:
   - name: argo-rollouts
-    version: "2.35.3"
+    version: "2.36.2"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-rollouts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/README.md
@@ -58,8 +58,10 @@ For full list of changes please check ArtifactHub [changelog].
 | kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
 | nameOverride | string | `nil` | String to partially override "argo-rollouts.fullname" template |
 | notifications.notifiers | object | `{}` | Configures notification services |
+| notifications.secret.annotations | object | `{}` | Annotations to be added to the notifications secret |
 | notifications.secret.create | bool | `false` | Whether to create notifications secret |
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
+| notifications.subscriptions | object | `{}` | The subscriptions define the subscriptions to the triggers in a general way for all rollouts |
 | notifications.templates | object | `{}` | Notification templates |
 | notifications.triggers | object | `{}` | The trigger defines the condition when the notification should be sent |
 | providerRBAC.additionalRules | list | `[]` | Additional RBAC rules for others providers |
@@ -79,7 +81,7 @@ For full list of changes please check ArtifactHub [changelog].
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext | object | `{}` | Security Context to set on container level |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context to set on container level |
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
 | controller.containerPorts.healthz | int | `8080` | Healthz container port |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Support revisionHistoryLimit
+    - kind: changed
+      description: Add subscriptions into notifications-configmap
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v1.6.6
+appVersion: v1.7.0
 description: A Helm chart for Argo Rollouts
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
@@ -19,4 +19,4 @@ maintainers:
 name: argo-rollouts
 sources:
 - https://github.com/argoproj/argo-rollouts
-version: 2.35.3
+version: 2.36.2

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/README.md
@@ -58,8 +58,10 @@ For full list of changes please check ArtifactHub [changelog].
 | kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
 | nameOverride | string | `nil` | String to partially override "argo-rollouts.fullname" template |
 | notifications.notifiers | object | `{}` | Configures notification services |
+| notifications.secret.annotations | object | `{}` | Annotations to be added to the notifications secret |
 | notifications.secret.create | bool | `false` | Whether to create notifications secret |
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
+| notifications.subscriptions | object | `{}` | The subscriptions define the subscriptions to the triggers in a general way for all rollouts |
 | notifications.templates | object | `{}` | Notification templates |
 | notifications.triggers | object | `{}` | The trigger defines the condition when the notification should be sent |
 | providerRBAC.additionalRules | list | `[]` | Additional RBAC rules for others providers |
@@ -79,7 +81,7 @@ For full list of changes please check ArtifactHub [changelog].
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext | object | `{}` | Security Context to set on container level |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context to set on container level |
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
 | controller.containerPorts.healthz | int | `8080` | Healthz container port |

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       app.kubernetes.io/component: {{ .Values.controller.component }}
       {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
   replicas: {{ .Values.controller.replicas }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   template:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
@@ -16,3 +16,7 @@ data:
   {{- with .Values.notifications.triggers }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.notifications.subscriptions }}
+  subscriptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifications-secret.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/controller/notifications-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: argo-rollouts-notification-secret
   namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.notifications.secret.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -188,6 +188,19 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            aggregator:
+                              default: last
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
                             apiVersion:
                               default: v1
                               enum:
@@ -241,6 +254,9 @@ spec:
                                 backoffLimit:
                                   format: int32
                                   type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
                                 completionMode:
                                   type: string
                                 completions:
@@ -248,6 +264,9 @@ spec:
                                   type: integer
                                 manualSelector:
                                   type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
                                 parallelism:
                                   format: int32
                                   type: integer
@@ -289,13 +308,14 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         required:
                                         - action
-                                        - onPodConditions
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   required:
                                   - rules
                                   type: object
+                                podReplacementPolicy:
+                                  type: string
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -467,6 +487,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -535,6 +565,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -601,6 +641,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -669,6 +719,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -848,6 +908,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -897,6 +965,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1094,13 +1170,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -1453,6 +1556,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -1502,6 +1613,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1699,13 +1818,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2065,6 +2211,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -2114,6 +2268,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -2311,13 +2473,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2543,12 +2732,43 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              source:
+                                                properties:
+                                                  resourceClaimName:
+                                                    type: string
+                                                  resourceClaimTemplateName:
+                                                    type: string
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
                                           type: string
                                         schedulerName:
                                           type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
                                             fsGroup:
@@ -2945,11 +3165,26 @@ spec:
                 type: array
               terminate:
                 type: boolean
+              ttlStrategy:
+                properties:
+                  secondsAfterCompletion:
+                    format: int32
+                    type: integer
+                  secondsAfterFailure:
+                    format: int32
+                    type: integer
+                  secondsAfterSuccess:
+                    format: int32
+                    type: integer
+                type: object
             required:
             - metrics
             type: object
           status:
             properties:
+              completedAt:
+                format: date-time
+                type: string
               dryRunSummary:
                 properties:
                   count:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -184,6 +184,19 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            aggregator:
+                              default: last
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
                             apiVersion:
                               default: v1
                               enum:
@@ -237,6 +250,9 @@ spec:
                                 backoffLimit:
                                   format: int32
                                   type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
                                 completionMode:
                                   type: string
                                 completions:
@@ -244,6 +260,9 @@ spec:
                                   type: integer
                                 manualSelector:
                                   type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
                                 parallelism:
                                   format: int32
                                   type: integer
@@ -285,13 +304,14 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         required:
                                         - action
-                                        - onPodConditions
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   required:
                                   - rules
                                   type: object
+                                podReplacementPolicy:
+                                  type: string
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -463,6 +483,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -531,6 +561,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -597,6 +637,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -665,6 +715,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -844,6 +904,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -893,6 +961,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1090,13 +1166,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -1449,6 +1552,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -1498,6 +1609,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1695,13 +1814,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2061,6 +2207,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -2110,6 +2264,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -2307,13 +2469,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2539,12 +2728,43 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              source:
+                                                properties:
+                                                  resourceClaimName:
+                                                    type: string
+                                                  resourceClaimTemplateName:
+                                                    type: string
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
                                           type: string
                                         schedulerName:
                                           type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
                                             fsGroup:
@@ -2939,8 +3159,15 @@ spec:
                   - provider
                   type: object
                 type: array
-            required:
-            - metrics
+              templates:
+                items:
+                  properties:
+                    clusterScope:
+                      type: boolean
+                    templateName:
+                      type: string
+                  type: object
+                type: array
             type: object
         required:
         - spec

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -184,6 +184,19 @@ spec:
                           type: object
                         datadog:
                           properties:
+                            aggregator:
+                              default: last
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
                             apiVersion:
                               default: v1
                               enum:
@@ -237,6 +250,9 @@ spec:
                                 backoffLimit:
                                   format: int32
                                   type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
                                 completionMode:
                                   type: string
                                 completions:
@@ -244,6 +260,9 @@ spec:
                                   type: integer
                                 manualSelector:
                                   type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
                                 parallelism:
                                   format: int32
                                   type: integer
@@ -285,13 +304,14 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         required:
                                         - action
-                                        - onPodConditions
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   required:
                                   - rules
                                   type: object
+                                podReplacementPolicy:
+                                  type: string
                                 selector:
                                   properties:
                                     matchExpressions:
@@ -463,6 +483,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -531,6 +561,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -597,6 +637,16 @@ spec:
                                                                 type: object
                                                             type: object
                                                             x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
                                                           namespaceSelector:
                                                             properties:
                                                               matchExpressions:
@@ -665,6 +715,16 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -844,6 +904,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -893,6 +961,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1090,13 +1166,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -1449,6 +1552,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -1498,6 +1609,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -1695,13 +1814,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2061,6 +2207,14 @@ spec:
                                                         required:
                                                         - port
                                                         type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
                                                       tcpSocket:
                                                         properties:
                                                           host:
@@ -2110,6 +2264,14 @@ spec:
                                                             type: string
                                                         required:
                                                         - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
                                                         type: object
                                                       tcpSocket:
                                                         properties:
@@ -2307,13 +2469,40 @@ spec:
                                                     format: int32
                                                     type: integer
                                                 type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                   requests:
                                                     x-kubernetes-preserve-unknown-fields: true
                                                 type: object
+                                              restartPolicy:
+                                                type: string
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
@@ -2539,12 +2728,43 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              source:
+                                                properties:
+                                                  resourceClaimName:
+                                                    type: string
+                                                  resourceClaimTemplateName:
+                                                    type: string
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
                                           type: string
                                         schedulerName:
                                           type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
                                             fsGroup:
@@ -2939,8 +3159,15 @@ spec:
                   - provider
                   type: object
                 type: array
-            required:
-            - metrics
+              templates:
+                items:
+                  properties:
+                    clusterScope:
+                      type: boolean
+                    templateName:
+                      type: string
+                  type: object
+                type: array
             type: object
         required:
         - spec

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -94,6 +94,17 @@ spec:
                   - templateName
                   type: object
                 type: array
+              analysisRunMetadata:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               dryRun:
                 items:
                   properties:
@@ -309,6 +320,16 @@ spec:
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               namespaceSelector:
                                                 properties:
                                                   matchExpressions:
@@ -377,6 +398,16 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -443,6 +474,16 @@ spec:
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               namespaceSelector:
                                                 properties:
                                                   matchExpressions:
@@ -511,6 +552,16 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -690,6 +741,14 @@ spec:
                                             required:
                                             - port
                                             type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
@@ -739,6 +798,14 @@ spec:
                                                 type: string
                                             required:
                                             - port
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
                                             type: object
                                           tcpSocket:
                                             properties:
@@ -936,13 +1003,40 @@ spec:
                                         format: int32
                                         type: integer
                                     type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   resources:
                                     properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
                                       limits:
                                         x-kubernetes-preserve-unknown-fields: true
                                       requests:
                                         x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                                  restartPolicy:
+                                    type: string
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1295,6 +1389,14 @@ spec:
                                             required:
                                             - port
                                             type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
@@ -1344,6 +1446,14 @@ spec:
                                                 type: string
                                             required:
                                             - port
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
                                             type: object
                                           tcpSocket:
                                             properties:
@@ -1541,13 +1651,40 @@ spec:
                                         format: int32
                                         type: integer
                                     type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   resources:
                                     properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
                                       limits:
                                         x-kubernetes-preserve-unknown-fields: true
                                       requests:
                                         x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                                  restartPolicy:
+                                    type: string
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1907,6 +2044,14 @@ spec:
                                             required:
                                             - port
                                             type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
@@ -1956,6 +2101,14 @@ spec:
                                                 type: string
                                             required:
                                             - port
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
                                             type: object
                                           tcpSocket:
                                             properties:
@@ -2153,13 +2306,40 @@ spec:
                                         format: int32
                                         type: integer
                                     type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   resources:
                                     properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
                                       limits:
                                         x-kubernetes-preserve-unknown-fields: true
                                       requests:
                                         x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                                  restartPolicy:
+                                    type: string
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -2385,12 +2565,43 @@ spec:
                                 - conditionType
                                 type: object
                               type: array
+                            resourceClaims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  source:
+                                    properties:
+                                      resourceClaimName:
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        type: string
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             restartPolicy:
                               type: string
                             runtimeClassName:
                               type: string
                             schedulerName:
                               type: string
+                            schedulingGates:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             securityContext:
                               properties:
                                 fsGroup:

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -581,6 +581,26 @@ spec:
                                     - templateName
                                     type: object
                                   type: array
+                                analysisRunMetadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                dryRun:
+                                  items:
+                                    properties:
+                                      metricName:
+                                        type: string
+                                    required:
+                                    - metricName
+                                    type: object
+                                  type: array
                                 duration:
                                   type: string
                                 templates:
@@ -913,6 +933,9 @@ spec:
                               - name
                               type: object
                             type: array
+                          maxTrafficWeight:
+                            format: int32
+                            type: integer
                           nginx:
                             properties:
                               additionalIngressAnnotations:
@@ -1093,6 +1116,16 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -1161,6 +1194,16 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -1227,6 +1270,16 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -1295,6 +1348,16 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -1474,6 +1537,14 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       properties:
                                         host:
@@ -1523,6 +1594,14 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       properties:
@@ -1720,13 +1799,40 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   x-kubernetes-preserve-unknown-fields: true
                                 requests:
                                   x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            restartPolicy:
+                              type: string
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -2079,6 +2185,14 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       properties:
                                         host:
@@ -2128,6 +2242,14 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       properties:
@@ -2325,13 +2447,40 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   x-kubernetes-preserve-unknown-fields: true
                                 requests:
                                   x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            restartPolicy:
+                              type: string
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -2691,6 +2840,14 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       properties:
                                         host:
@@ -2740,6 +2897,14 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       properties:
@@ -2937,13 +3102,40 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   x-kubernetes-preserve-unknown-fields: true
                                 requests:
                                   x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            restartPolicy:
+                              type: string
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -3169,12 +3361,43 @@ spec:
                           - conditionType
                           type: object
                         type: array
+                      resourceClaims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            source:
+                              properties:
+                                resourceClaimName:
+                                  type: string
+                                resourceClaimTemplateName:
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       restartPolicy:
                         type: string
                       runtimeClassName:
                         type: string
                       schedulerName:
                         type: string
+                      schedulingGates:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       securityContext:
                         properties:
                           fsGroup:
@@ -3339,6 +3562,8 @@ spec:
                   kind:
                     type: string
                   name:
+                    type: string
+                  scaleDown:
                     type: string
                 type: object
             type: object

--- a/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/charts/argo-rollouts/values.yaml
@@ -240,13 +240,14 @@ podSecurityContext:
   runAsNonRoot: true
 
 # -- Security Context to set on container level
-containerSecurityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Annotations to be added to the Rollout service
 serviceAnnotations: {}
@@ -453,6 +454,8 @@ notifications:
     # -- Generic key:value pairs to be inserted into the notifications secret
     items: {}
       # slack-token:
+    # -- Annotations to be added to the notifications secret
+    annotations: {}
 
   # -- Configures notification services
   notifiers: {}
@@ -476,3 +479,11 @@ notifications:
     # trigger.on-purple: |
     #   - send: [my-purple-template]
     #     when: rollout.spec.template.spec.containers[0].image == 'argoproj/rollouts-demo:purple'
+
+  # -- The subscriptions define the subscriptions to the triggers in a general way for all rollouts
+  subscriptions: {}
+    # subscriptions:
+    #   recipients:
+    #     - slack:<channel>
+    #   triggers:
+    #     - on-rollout-completed

--- a/charts/argo-rollouts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/values.yaml
@@ -42,7 +42,7 @@ argo-rollouts:
     revisionHistoryLimit: 10
     imageRegistry: quay.m.daocloud.io
     repository: argoproj/argo-rollouts
-    tag: v1.6.6
+    tag: v1.7.0
   controller:
     # -- Value of label `app.kubernetes.io/component`
     component: rollouts-controller
@@ -85,7 +85,7 @@ argo-rollouts:
       # -- Repository to use
       repository: argoproj/argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.6"
+      tag: "v1.7.0"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-controller.  A list of flags.
@@ -222,14 +222,14 @@ argo-rollouts:
   podSecurityContext:
     runAsNonRoot: true
   # -- Security Context to set on container level
-  containerSecurityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   # -- Annotations to be added to the Rollout service
   serviceAnnotations: {}
   # -- Labels to be added to the Rollout pods
@@ -311,7 +311,7 @@ argo-rollouts:
       # --  Repository to use
       repository: argoproj/kubectl-argo-rollouts
       # -- Overrides the image tag (default is the chart appVersion)
-      tag: "v1.6.6"
+      tag: "v1.7.0"
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Additional command line arguments to pass to rollouts-dashboard. A list of flags.
@@ -423,6 +423,8 @@ argo-rollouts:
       # -- Generic key:value pairs to be inserted into the notifications secret
       items: {}
       # slack-token:
+      # -- Annotations to be added to the notifications secret
+      annotations: {}
     # -- Configures notification services
     notifiers: {}
     # service.slack: |
@@ -445,3 +447,11 @@ argo-rollouts:
     # trigger.on-purple: |
     #   - send: [my-purple-template]
     #     when: rollout.spec.template.spec.containers[0].image == 'argoproj/rollouts-demo:purple'
+
+    # -- The subscriptions define the subscriptions to the triggers in a general way for all rollouts
+    subscriptions: {}
+    # subscriptions:
+    #   recipients:
+    #     - slack:<channel>
+    #   triggers:
+    #     - on-rollout-completed

--- a/charts/argo-rollouts/config
+++ b/charts/argo-rollouts/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-rollouts
 export CHART_NAME=argo-rollouts
-export VERSION=2.35.3
+export VERSION=2.36.2
 
 # pr, issue, none
 export UPGRADE_METHOD=pr


### PR DESCRIPTION
I am robot, upgrade: project argo-rollouts chart upgrade from 2.35.3 to 2.36.2