### PR TITLE
prometheus-adapter-chart-upgrade-from-4.2.0-to-4.10.0

### DIFF
--- a/charts/prometheus-adapter/config
+++ b/charts/prometheus-adapter/config
@@ -2,9 +2,9 @@ export USE_OPENSOURCE_CHART=false
 
 # must
 export REPO_URL=https://prometheus-community.github.io/helm-charts
-export REPO_NAME=kube-state-metrics
+export REPO_NAME=prometheus-adapter
 export CHART_NAME=prometheus-adapter
-export VERSION=4.2.0
+export VERSION=4.10.0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/prometheus-adapter/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.10.0
+appVersion: v0.11.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:
@@ -17,8 +17,8 @@ name: prometheus-adapter
 sources:
   - https://github.com/kubernetes/charts
   - https://github.com/kubernetes-sigs/prometheus-adapter
-version: 4.2.0
+version: 4.10.0
 dependencies:
   - name: prometheus-adapter
-    version: "4.2.0"
+    version: "4.10.0"
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.10.0
+appVersion: v0.11.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:
@@ -17,4 +17,4 @@ name: prometheus-adapter
 sources:
 - https://github.com/kubernetes/charts
 - https://github.com/kubernetes-sigs/prometheus-adapter
-version: 4.2.0
+version: 4.10.0

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-auth-reader.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/cluster-role-binding-auth-reader.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.rbac.create (not .Values.rbac.useAuthReaderClusterRole) -}}
+{{- if and .Values.rbac.create .Values.rbac.useAuthReaderClusterRole -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   {{- if .Values.customAnnotations }}
   annotations:
@@ -9,10 +9,9 @@ metadata:
   labels:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
   name: {{ template "k8s-prometheus-adapter.name" . }}-auth-reader
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
@@ -12,6 +12,6 @@ metadata:
 rules:
 - apiGroups:
   - custom.metrics.k8s.io
-  resources: ["*"]
+  resources: {{ toYaml .Values.rbac.customMetrics.resources | nindent 2 }}
   verbs: ["*"]
 {{- end -}}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/deployment.yaml
@@ -44,9 +44,13 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end}}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.env }}
         env:
@@ -60,7 +64,6 @@ spec:
         - --tls-private-key-file=/var/run/serving-cert/tls.key
         {{- end }}
         - --cert-dir=/tmp/cert
-        - --logtostderr=true
         - --prometheus-url={{ tpl .Values.prometheus.url . }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}{{ .Values.prometheus.path }}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
         - --v={{ .Values.logLevel }}
@@ -79,13 +82,13 @@ spec:
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- if .Values.resources }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        {{- end }}
-        {{- with .Values.dnsConfig }}
-        dnsConfig:
-        {{ toYaml . | indent 8 }}
         {{- end }}
         {{- with .Values.securityContext }}
         securityContext:
@@ -105,13 +108,18 @@ spec:
           name: volume-serving-cert
           readOnly: true
         {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       topologySpreadConstraints:
         {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -12,8 +12,7 @@ metadata:
 rules:
 - apiGroups:
   - "external.metrics.k8s.io"
-  resources:
-  - "*"
+  resources: {{ toYaml .Values.rbac.externalMetrics.resources | nindent 2 }}
   verbs:
   - list
   - get

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/psp.yaml
@@ -4,9 +4,9 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
-  {{- if .Values.customAnnotations }}
+  {{- with (merge .Values.customAnnotations .Values.psp.annotations) }}
   annotations:
-  {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/service.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/templates/service.yaml
@@ -15,8 +15,13 @@ metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
   namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
 spec:
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}
   ports:
   - port: {{ .Values.service.port }}
+    name: https
     protocol: TCP
     targetPort: https
   selector:

--- a/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/charts/prometheus-adapter/values.yaml
@@ -4,7 +4,8 @@ topologySpreadConstraints: []
 
 image:
   repository: registry.k8s.io/prometheus-adapter/prometheus-adapter
-  tag: v0.10.0
+  # if not set appVersion field from Chart.yaml is used
+  tag: ""
   pullPolicy: IfNotPresent
 
 logLevel: 4
@@ -47,7 +48,7 @@ podSecurityContext:
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
-    drop: ["all"]
+    drop: ["ALL"]
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 10001
@@ -57,10 +58,21 @@ securityContext:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # Specifies if a Cluster Role should be used for the Auth Reader
+  useAuthReaderClusterRole: false
+  externalMetrics:
+    resources: ["*"]
+  customMetrics:
+    resources: ["*"]
 
 psp:
   # Specifies whether PSP resources should be created
   create: false
+  # Annotations added to the pod security policy
+  annotations: {}
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -111,6 +123,10 @@ readinessProbe:
     scheme: HTTPS
   initialDelaySeconds: 30
   timeoutSeconds: 5
+
+# Configure startup probe
+# Use if prometheus-adapter takes a long time to finish startup e.g. polling a lot of API versions in cluster
+startupProbe: {}
 
 rules:
   default: true
@@ -183,7 +199,10 @@ service:
   port: 443
   type: ClusterIP
   # clusterIP: 1.2.3.4
-
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"
 tls:
   enable: false
   ca: |-
@@ -208,6 +227,9 @@ env: []
 extraArguments: []
   # - --tls-private-key-file=/etc/tls/tls.key
   # - --tls-cert-file=/etc/tls/tls.crt
+
+# Additional containers to add to the pod
+extraContainers: []
 
 # Any extra volumes
 extraVolumes: []
@@ -266,5 +288,5 @@ podDisruptionBudget:
 
 certManager:
   enabled: false
-  caCertDuration: 43800h
-  certDuration: 8760h
+  caCertDuration: 43800h0m0s
+  certDuration: 8760h0m0s

--- a/charts/prometheus-adapter/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/prometheus-adapter/values.yaml
@@ -4,7 +4,8 @@ prometheus-adapter:
   topologySpreadConstraints: []
   image:
     repository: prometheus-adapter/prometheus-adapter
-    tag: v0.10.0
+    # if not set appVersion field from Chart.yaml is used
+    tag: "v0.11.2"
     pullPolicy: IfNotPresent
     registry: k8s.m.daocloud.io
   logLevel: 4
@@ -38,7 +39,7 @@ prometheus-adapter:
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
-      drop: ["all"]
+      drop: ["ALL"]
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10001
@@ -47,9 +48,20 @@ prometheus-adapter:
   rbac:
     # Specifies whether RBAC resources should be created
     create: true
+    # Specifies if a Cluster Role should be used for the Auth Reader
+    useAuthReaderClusterRole: false
+    externalMetrics:
+      resources: ["*"]
+    customMetrics:
+      resources: ["*"]
   psp:
     # Specifies whether PSP resources should be created
     create: false
+    # Annotations added to the pod security policy
+    annotations: {}
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -72,14 +84,13 @@ prometheus-adapter:
   #     value: "2"
   #   - name: edns0
 
-  resources: 
+  resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: "1"
+      memory: 1Gi
     limits:
-      cpu: 100m
-      memory: 128Mi
-
+      cpu: "1"
+      memory: 1Gi
   # Configure liveness probe
   # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
   livenessProbe:
@@ -97,6 +108,9 @@ prometheus-adapter:
       scheme: HTTPS
     initialDelaySeconds: 30
     timeoutSeconds: 5
+  # Configure startup probe
+  # Use if prometheus-adapter takes a long time to finish startup e.g. polling a lot of API versions in cluster
+  startupProbe: {}
   rules:
     default: true
     custom: []
@@ -157,6 +171,10 @@ prometheus-adapter:
     port: 443
     type: ClusterIP
     # clusterIP: 1.2.3.4
+    ipDualStack:
+      enabled: false
+      ipFamilies: ["IPv6", "IPv4"]
+      ipFamilyPolicy: "PreferDualStack"
   tls:
     enable: false
     ca: |-
@@ -181,6 +199,8 @@ prometheus-adapter:
   # - --tls-private-key-file=/etc/tls/tls.key
   # - --tls-cert-file=/etc/tls/tls.crt
 
+  # Additional containers to add to the pod
+  extraContainers: []
   # Any extra volumes
   extraVolumes: []
   # - name: example-name
@@ -231,5 +251,5 @@ prometheus-adapter:
     maxUnavailable: 1
   certManager:
     enabled: false
-    caCertDuration: 43800h
-    certDuration: 8760h
+    caCertDuration: 43800h0m0s
+    certDuration: 8760h0m0s

--- a/test/Makefile
+++ b/test/Makefile
@@ -188,13 +188,13 @@ checkBin:
 
 .PHONY: install-relok8s
 install-relok8s:
-	VERSION=0.5.1 ;\
+	VERSION=0.5.4 ;\
 	curl -OL https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/releases/download/v$${VERSION}/relok8s_$${VERSION}_linux_x86_64.tar.gz  ;\
 	tar -zvxf relok8s_$${VERSION}_linux_x86_64.tar.gz && mv relok8s /usr/local/bin/relok8s && rm -rf README.md relok8s*.tar.gz
 
 .PHONY: install-charts-syncer
 install-charts-syncer:
-	VERSION=0.0.15 ; \
+	VERSION=0.0.23 ; \
 	curl -OL https://github.com/DaoCloud/charts-syncer/releases/download/v$${VERSION}/charts-syncer_$${VERSION}_linux_x86_64.tar.gz ; \
 	tar -zvxf charts-syncer_$${VERSION}_linux_x86_64.tar.gz && mv charts-syncer /usr/local/bin/charts-syncer && rm -rf README.md charts-syncer*.tar.gz
 


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #