### PR TITLE
chore: update argocd to v2.12.1

### DIFF
--- a/charts/argo-cd/argo-cd/Chart.yaml
+++ b/charts/argo-cd/argo-cd/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed redis exporter NOAUTH error
+    - kind: changed
+      description: Bump argo-cd to v2.12.1
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v2.11.2
+appVersion: v2.12.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
@@ -22,8 +22,8 @@ name: argo-cd
 sources:
   - https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
   - https://github.com/argoproj/argo-cd
-version: 7.1.1
+version: 7.4.4
 dependencies:
   - name: argo-cd
-    version: "7.1.1"
+    version: "7.4.4"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-cd/argo-cd/README.md
+++ b/charts/argo-cd/argo-cd/README.md
@@ -278,6 +278,31 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 7.0.0
+
+We changed the type of `.Values.configs.clusterCredentials` from `list` to `object`.
+If you used the value, please migrate like below.
+
+```yaml
+# before
+configs:
+  clusterCredentials:
+    - mycluster:
+      server: https://mycluster.example.com
+      labels: {}
+      annotations: {}
+      # ...
+
+# after
+configs:
+  clusterCredentials:
+    mycluster:
+      server: https://mycluster.example.com
+      labels: {}
+      annotations: {}
+      # ...
+```
+
 ### 6.10.0
 
 This version introduces authentication for Redis to mitigate GHSA-9766-5277-j5hr.
@@ -622,7 +647,7 @@ server:
 
 ## Prerequisites
 
-- Kubernetes: `>=1.23.0-0`
+- Kubernetes: `>=1.25.0-0`
   - We align with [Amazon EKS calendar][EKS EoL] because there are many AWS users and it's a conservative approach.
   - Please check [Support Matrix of Argo CD][Kubernetes Compatibility Matrix] for official info.
 - Helm v3.0.0+
@@ -967,7 +992,7 @@ NAME: my-release
 | server.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | server.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
 | server.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
-| server.certificate.secretName | string | `"argocd-server-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
+| server.certificate.secretTemplateAnnotations | object | `{}` | Annotations that allow the certificate to be composed from data residing in existing Kubernetes Resources |
 | server.certificate.usages | list | `[]` | Usages for the certificate |
 | server.certificateSecret.annotations | object | `{}` | Annotations to be added to argocd-server-tls secret |
 | server.certificateSecret.crt | string | `""` | Certificate data |
@@ -1082,6 +1107,7 @@ NAME: my-release
 | server.service.externalIPs | list | `[]` | Server service external IPs |
 | server.service.externalTrafficPolicy | string | `"Cluster"` | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints |
 | server.service.labels | object | `{}` | Server service labels |
+| server.service.loadBalancerClass | string | `""` | The class of the load balancer implementation |
 | server.service.loadBalancerIP | string | `""` | LoadBalancer will get created with the IP specified in this field |
 | server.service.loadBalancerSourceRanges | list | `[]` | Source IP ranges to allow access to service from |
 | server.service.nodePortHttp | int | `30080` | Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort") |
@@ -1346,7 +1372,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain key `redis-password`). When it's set, the `externalRedis.password` parameter is ignored |
+| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials. When it's set, the `externalRedis.password` parameter is ignored |
 | externalRedis.host | string | `""` | External Redis server host |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |
@@ -1400,7 +1426,6 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | applicationSet.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
 | applicationSet.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
-| applicationSet.certificate.secretName | string | `"argocd-applicationset-controller-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
 | applicationSet.containerPorts.metrics | int | `8080` | Metrics container port |
 | applicationSet.containerPorts.probe | int | `8081` | Probe container port |
 | applicationSet.containerPorts.webhook | int | `7000` | Webhook container port |
@@ -1517,6 +1542,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the notifications controller |
 | notifications.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | notifications.initContainers | list | `[]` | Init containers to add to the notifications controller pod |
+| notifications.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for notifications controller Pods |
+| notifications.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| notifications.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| notifications.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| notifications.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| notifications.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | notifications.logFormat | string | `""` (defaults to global.logging.format) | Notifications controller log format. Either `text` or `json` |
 | notifications.logLevel | string | `""` (defaults to global.logging.level) | Notifications controller log level. One of: `debug`, `info`, `warn`, `error` |
 | notifications.metrics.enabled | bool | `false` | Enables prometheus metrics server |
@@ -1545,6 +1576,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.podAnnotations | object | `{}` | Annotations to be applied to the notifications controller Pods |
 | notifications.podLabels | object | `{}` | Labels to be applied to the notifications controller Pods |
 | notifications.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the notifications controller pods |
+| notifications.readinessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for notifications controller Pods |
+| notifications.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| notifications.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| notifications.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| notifications.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| notifications.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | notifications.resources | object | `{}` | Resource limits and requests for the notifications controller |
 | notifications.secret.annotations | object | `{}` | key:value pairs of annotations to be added to the secret |
 | notifications.secret.create | bool | `true` | Whether helm chart creates notifications controller secret |

--- a/charts/argo-cd/argo-cd/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed redis exporter NOAUTH error
+    - kind: changed
+      description: Bump argo-cd to v2.12.1
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
 apiVersion: v2
-appVersion: v2.11.2
+appVersion: v2.12.1
 dependencies:
 - condition: redis-ha.enabled
   name: redis-ha
@@ -20,7 +20,7 @@ keywords:
 - argoproj
 - argocd
 - gitops
-kubeVersion: '>=1.23.0-0'
+kubeVersion: '>=1.25.0-0'
 maintainers:
 - name: argoproj
   url: https://argoproj.github.io/
@@ -28,4 +28,4 @@ name: argo-cd
 sources:
 - https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
 - https://github.com/argoproj/argo-cd
-version: 7.1.1
+version: 7.4.4

--- a/charts/argo-cd/argo-cd/charts/argo-cd/README.md
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/README.md
@@ -278,6 +278,31 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 7.0.0
+
+We changed the type of `.Values.configs.clusterCredentials` from `list` to `object`.
+If you used the value, please migrate like below.
+
+```yaml
+# before
+configs:
+  clusterCredentials:
+    - mycluster:
+      server: https://mycluster.example.com
+      labels: {}
+      annotations: {}
+      # ...
+
+# after
+configs:
+  clusterCredentials:
+    mycluster:
+      server: https://mycluster.example.com
+      labels: {}
+      annotations: {}
+      # ...
+```
+
 ### 6.10.0
 
 This version introduces authentication for Redis to mitigate GHSA-9766-5277-j5hr.
@@ -622,7 +647,7 @@ server:
 
 ## Prerequisites
 
-- Kubernetes: `>=1.23.0-0`
+- Kubernetes: `>=1.25.0-0`
   - We align with [Amazon EKS calendar][EKS EoL] because there are many AWS users and it's a conservative approach.
   - Please check [Support Matrix of Argo CD][Kubernetes Compatibility Matrix] for official info.
 - Helm v3.0.0+
@@ -967,7 +992,7 @@ NAME: my-release
 | server.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | server.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
 | server.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
-| server.certificate.secretName | string | `"argocd-server-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
+| server.certificate.secretTemplateAnnotations | object | `{}` | Annotations that allow the certificate to be composed from data residing in existing Kubernetes Resources |
 | server.certificate.usages | list | `[]` | Usages for the certificate |
 | server.certificateSecret.annotations | object | `{}` | Annotations to be added to argocd-server-tls secret |
 | server.certificateSecret.crt | string | `""` | Certificate data |
@@ -1082,6 +1107,7 @@ NAME: my-release
 | server.service.externalIPs | list | `[]` | Server service external IPs |
 | server.service.externalTrafficPolicy | string | `"Cluster"` | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints |
 | server.service.labels | object | `{}` | Server service labels |
+| server.service.loadBalancerClass | string | `""` | The class of the load balancer implementation |
 | server.service.loadBalancerIP | string | `""` | LoadBalancer will get created with the IP specified in this field |
 | server.service.loadBalancerSourceRanges | list | `[]` | Source IP ranges to allow access to service from |
 | server.service.nodePortHttp | int | `30080` | Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort") |
@@ -1346,7 +1372,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain key `redis-password`). When it's set, the `externalRedis.password` parameter is ignored |
+| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials. When it's set, the `externalRedis.password` parameter is ignored |
 | externalRedis.host | string | `""` | External Redis server host |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |
@@ -1400,7 +1426,6 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | applicationSet.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
 | applicationSet.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
-| applicationSet.certificate.secretName | string | `"argocd-applicationset-controller-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
 | applicationSet.containerPorts.metrics | int | `8080` | Metrics container port |
 | applicationSet.containerPorts.probe | int | `8081` | Probe container port |
 | applicationSet.containerPorts.webhook | int | `7000` | Webhook container port |
@@ -1517,6 +1542,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the notifications controller |
 | notifications.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | notifications.initContainers | list | `[]` | Init containers to add to the notifications controller pod |
+| notifications.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for notifications controller Pods |
+| notifications.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| notifications.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| notifications.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| notifications.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| notifications.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | notifications.logFormat | string | `""` (defaults to global.logging.format) | Notifications controller log format. Either `text` or `json` |
 | notifications.logLevel | string | `""` (defaults to global.logging.level) | Notifications controller log level. One of: `debug`, `info`, `warn`, `error` |
 | notifications.metrics.enabled | bool | `false` | Enables prometheus metrics server |
@@ -1545,6 +1576,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.podAnnotations | object | `{}` | Annotations to be applied to the notifications controller Pods |
 | notifications.podLabels | object | `{}` | Labels to be applied to the notifications controller Pods |
 | notifications.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the notifications controller pods |
+| notifications.readinessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for notifications controller Pods |
+| notifications.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| notifications.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| notifications.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| notifications.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| notifications.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | notifications.resources | object | `{}` | Resource limits and requests for the notifications controller |
 | notifications.secret.annotations | object | `{}` | key:value pairs of annotations to be added to the secret |
 | notifications.secret.create | bool | `true` | Whether helm chart creates notifications controller secret |

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/NOTES.txt
@@ -1,6 +1,6 @@
 In order to access the server UI you have the following options:
 
-1. kubectl port-forward service/{{ include "argo-cd.fullname" . }}-server -n {{ .Release.Namespace }} 8080:443
+1. kubectl port-forward service/{{ include "argo-cd.fullname" . }}-server -n {{ include  "argo-cd.namespace" . }} 8080:443
 
     and then open the browser on http://localhost:8080 and accept the certificate
 
@@ -12,7 +12,7 @@ In order to access the server UI you have the following options:
 {{ if eq (toString (index .Values.configs.cm "admin.enabled")) "true" -}}
 After reaching the UI the first time you can login with username: admin and the random password generated during the installation. You can find the password by running:
 
-kubectl -n {{ .Release.Namespace }} get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+kubectl -n {{ include  "argo-cd.namespace" . }} get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
 
 (You should delete the initial secret afterwards as suggested by the Getting Started Guide: https://argo-cd.readthedocs.io/en/stable/getting_started/#4-login-using-the-cli)
 {{ else if or (index .Values.configs.cm "dex.config") (index .Values.configs.cm "oidc.config") -}}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/_helpers.tpl
@@ -99,7 +99,7 @@ Create the name of the Redis secret-init service account to use
 */}}
 {{- define "argo-cd.redisSecretInit.serviceAccountName" -}}
 {{- if .Values.redisSecretInit.serviceAccount.create -}}
-    {{ default (include "argo-cd.redisSecretInit.fullname" .) .Values.redis.serviceAccount.name }}
+    {{ default (include "argo-cd.redisSecretInit.fullname" .) .Values.redisSecretInit.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.redisSecretInit.serviceAccount.name }}
 {{- end -}}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -208,10 +208,22 @@ spec:
                 name: {{ default "argocd-redis" .Values.externalRedis.existingSecret }}
                 {{- if .Values.externalRedis.host }}
                 key: redis-password
-                optional: true
                 {{- else }}
                 key: auth
                 {{- end }}
+                optional: true
+          - name: REDIS_SENTINEL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-username
+                optional: true
+          - name: REDIS_SENTINEL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-password
+                optional: true
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
@@ -1,9 +1,9 @@
-{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.rules.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.controller.metrics.enabled .Values.controller.metrics.rules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.controller.metrics.rules.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.controller.metrics.rules.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     {{- if .Values.controller.metrics.rules.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -43,3 +43,17 @@ rules:
   - get
   - list
   - watch
+{{- if and (not .Values.createClusterRoles) .Values.controller.dynamicClusterDistribution }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - argocd-app-controller-shard-cm
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+{{- end }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.controller.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.controller.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     {{- with .Values.controller.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -211,6 +211,18 @@ spec:
                 {{- else }}
                 key: auth
                 {{- end }}
+          - name: REDIS_SENTINEL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-username
+                optional: true
+          - name: REDIS_SENTINEL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-password
+                optional: true
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 spec:
-  secretName: {{ .Values.applicationSet.certificate.secretName }}
+  secretName: argocd-applicationset-controller-tls
   commonName: {{ .Values.applicationSet.certificate.domain | default .Values.global.domain }}
   dnsNames:
     - {{ .Values.applicationSet.certificate.domain | default .Values.global.domain }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
@@ -35,6 +35,8 @@ rules:
     - appprojects
     verbs:
     - get
+    - list
+    - watch
   - apiGroups:
     - ""
     resources:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/role.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/role.yaml
@@ -34,6 +34,8 @@ rules:
     - appprojects
     verbs:
     - get
+    - list
+    - watch
   - apiGroups:
     - ""
     resources:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
     {{- with .Values.applicationSet.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "argo-cd.name" $ }}-cluster-{{ $cluster_key }}
-  namespace: {{ $.Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" $ | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
     {{- with $cluster_value.labels }}
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
+  {{- if $cluster_value.shard }}
+  shard: {{ $cluster_value.shard }}
+  {{- end }}
   name: {{ required "A valid .Values.configs.clusterCredentials.CLUSTERNAME.name entry is required!" $cluster_key }}
   server: {{ required "A valid .Values.configs.clusterCredentials.CLUSTERNAME.server entry is required!" $cluster_value.server }}
   {{- if $cluster_value.namespaces }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-repo-creds-{{ $repo_cred_key }}
-  namespace: {{ $.Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" $ | quote }}
   labels:
     argocd.argoproj.io/secret-type: repo-creds
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-repo-{{ $repo_key }}
-  namespace: {{ $.Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" $ | quote }}
   labels:
     argocd.argoproj.io/secret-type: repository
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -107,6 +107,26 @@ spec:
           - name: metrics
             containerPort: {{ .Values.notifications.containerPorts.metrics }}
             protocol: TCP
+          {{- if .Values.notifications.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: {{ .Values.notifications.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.notifications.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.notifications.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.notifications.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.notifications.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.notifications.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: {{ .Values.notifications.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.notifications.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.notifications.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.notifications.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.notifications.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}
           {{- with .Values.notifications.containerSecurityContext }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.notifications.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.notifications.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.notifications.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
     {{- with .Values.notifications.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -188,6 +188,18 @@ spec:
                 {{- else }}
                 key: auth
                 {{- end }}
+          - name: REDIS_SENTINEL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-username
+                optional: true
+          - name: REDIS_SENTINEL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-password
+                optional: true
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:
@@ -278,6 +290,12 @@ spec:
                 key: reposerver.revision.cache.lock.timeout
                 name: argocd-cmd-params-cm
                 optional: true
+          - name: ARGOCD_REPO_SERVER_INCLUDE_HIDDEN_DIRECTORIES
+            valueFrom:
+              configMapKeyRef:
+                key: reposerver.include.hidden.directories
+                name: argocd-cmd-params-cm
+                optional: true
           {{- if .Values.repoServer.useEphemeralHelmWorkingDir }}
           - name: HELM_CACHE_HOME
             value: /helm-working-dir
@@ -359,10 +377,8 @@ spec:
         image: {{ include "global.images.image" (dict "imageRoot" .Values.repoServer.image "global" .Values.global ) }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
         name: copyutil
-        {{- with .Values.repoServer.resources }}
         resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.repoServer.resources | nindent 10 }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.repoServer.metrics.serviceMonitor.namespace | default }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.repoServer.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
     {{- with .Values.repoServer.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -13,7 +13,14 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
-  secretName: {{ .Values.server.certificate.secretName }}
+  secretTemplate:
+    {{- with .Values.server.certificate.secretTemplateAnnotations }}
+    annotations:
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }} 
+  secretName: argocd-server-tls
   commonName: {{ .Values.server.certificate.domain | default .Values.global.domain }}
   dnsNames:
     - {{ .Values.server.certificate.domain | default .Values.global.domain }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -256,6 +256,18 @@ spec:
                 {{- else }}
                 key: auth
                 {{- end }}
+          - name: REDIS_SENTINEL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-username
+                optional: true
+          - name: REDIS_SENTINEL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+                key: redis-sentinel-password
+                optional: true
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/service.yaml
@@ -24,6 +24,9 @@ spec:
   externalTrafficPolicy: {{ .Values.server.service.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.server.service.type "LoadBalancer" }}
+  {{- with .Values.server.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
   {{- with .Values.server.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.server.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.server.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.server.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     {{- with .Values.server.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-application.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-application.yaml
@@ -39,20 +39,29 @@ spec:
       name: Revision
       priority: 10
       type: string
+    - jsonPath: .spec.project
+      name: Project
+      priority: 10
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Application is a definition of Application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -150,22 +159,21 @@ spec:
                       type: object
                     type: array
                   revision:
-                    description: Revision is the revision (Git) or chart version (Helm)
-                      which to sync the application to If omitted, will use the revision
-                      specified in app spec.
+                    description: |-
+                      Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                      If omitted, will use the revision specified in app spec.
                     type: string
                   revisions:
-                    description: Revisions is the list of revision (Git) or chart
-                      version (Helm) which to sync each source in sources field for
-                      the application to If omitted, will use the revision specified
-                      in app spec.
+                    description: |-
+                      Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                      If omitted, will use the revision specified in app spec.
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Source overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
                         description: Chart is a Helm chart name, and must be specified
@@ -486,18 +494,18 @@ spec:
                           Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the revision of the source
-                          to sync the application to. In case of Git, this can be
-                          commit, tag, or branch. If omitted, will equal to HEAD.
+                        description: |-
+                          TargetRevision defines the revision of the source to sync the application to.
+                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
                           In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
                   sources:
-                    description: Sources overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Sources overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     items:
                       description: ApplicationSource contains all required information
                         about the source of an application
@@ -825,11 +833,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -848,10 +855,10 @@ spec:
                           the sync.
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                       hook:
@@ -859,10 +866,10 @@ spec:
                           perform the sync. This is the default strategy
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                     type: object
@@ -883,9 +890,9 @@ spec:
                       not set.
                     type: string
                   namespace:
-                    description: Namespace specifies the target namespace for the
-                      application's resources. The namespace will only be set for
-                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    description: |-
+                      Namespace specifies the target namespace for the application's resources.
+                      The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
                     description: Server specifies the URL of the target cluster's
@@ -914,10 +921,9 @@ spec:
                     kind:
                       type: string
                     managedFieldsManagers:
-                      description: ManagedFieldsManagers is a list of trusted managers.
-                        Fields mutated by those managers will take precedence over
-                        the desired state defined in the SCM and won't be displayed
-                        in diffs
+                      description: |-
+                        ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                        desired state defined in the SCM and won't be displayed in diffs
                       items:
                         type: string
                       type: array
@@ -944,18 +950,17 @@ spec:
                   type: object
                 type: array
               project:
-                description: Project is a reference to the project this application
-                  belongs to. The empty string means that application belongs to the
-                  'default' project.
+                description: |-
+                  Project is a reference to the project this application belongs to.
+                  The empty string means that application belongs to the 'default' project.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit limits the number of items kept
-                  in the application's revision history, which is used for informational
-                  purposes as well as for rollbacks to previous versions. This should
-                  only be changed in exceptional circumstances. Setting to zero will
-                  store no history. This will reduce storage used. Increasing will
-                  increase the space used to store the history, so we do not recommend
-                  increasing it. Default is 10.
+                description: |-
+                  RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                  This should only be changed in exceptional circumstances.
+                  Setting to zero will store no history. This will reduce storage used.
+                  Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                  Default is 10.
                 format: int64
                 type: integer
               source:
@@ -1274,10 +1279,10 @@ spec:
                       that contains the application manifests
                     type: string
                   targetRevision:
-                    description: TargetRevision defines the revision of the source
-                      to sync the application to. In case of Git, this can be commit,
-                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
-                      this is a semver tag for the Chart's version.
+                    description: |-
+                      TargetRevision defines the revision of the source to sync the application to.
+                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                      In case of Helm, this is a semver tag for the Chart's version.
                     type: string
                 required:
                 - repoURL
@@ -1606,10 +1611,10 @@ spec:
                         that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the revision of the source
-                        to sync the application to. In case of Git, this can be commit,
-                        tag, or branch. If omitted, will equal to HEAD. In case of
-                        Helm, this is a semver tag for the Chart's version.
+                      description: |-
+                        TargetRevision defines the revision of the source to sync the application to.
+                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                        In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -2102,11 +2107,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -2448,11 +2452,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -2464,9 +2467,9 @@ spec:
                   type: object
                 type: array
               observedAt:
-                description: 'ObservedAt indicates when the application state was
-                  updated without querying latest git state Deprecated: controller
-                  no longer updates ObservedAt field'
+                description: |-
+                  ObservedAt indicates when the application state was updated without querying latest git state
+                  Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
               operationState:
@@ -2579,22 +2582,21 @@ spec:
                               type: object
                             type: array
                           revision:
-                            description: Revision is the revision (Git) or chart version
-                              (Helm) which to sync the application to If omitted,
-                              will use the revision specified in app spec.
+                            description: |-
+                              Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                              If omitted, will use the revision specified in app spec.
                             type: string
                           revisions:
-                            description: Revisions is the list of revision (Git) or
-                              chart version (Helm) which to sync each source in sources
-                              field for the application to If omitted, will use the
-                              revision specified in app spec.
+                            description: |-
+                              Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                              If omitted, will use the revision specified in app spec.
                             items:
                               type: string
                             type: array
                           source:
-                            description: Source overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Source overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             properties:
                               chart:
                                 description: Chart is a Helm chart name, and must
@@ -2937,19 +2939,18 @@ spec:
                                   (Git or Helm) that contains the application manifests
                                 type: string
                               targetRevision:
-                                description: TargetRevision defines the revision of
-                                  the source to sync the application to. In case of
-                                  Git, this can be commit, tag, or branch. If omitted,
-                                  will equal to HEAD. In case of Helm, this is a semver
-                                  tag for the Chart's version.
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
                                 type: string
                             required:
                             - repoURL
                             type: object
                           sources:
-                            description: Sources overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Sources overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             items:
                               description: ApplicationSource contains all required
                                 information about the source of an application
@@ -3300,11 +3301,10 @@ spec:
                                     (Git or Helm) that contains the application manifests
                                   type: string
                                 targetRevision:
-                                  description: TargetRevision defines the revision
-                                    of the source to sync the application to. In case
-                                    of Git, this can be commit, tag, or branch. If
-                                    omitted, will equal to HEAD. In case of Helm,
-                                    this is a semver tag for the Chart's version.
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
                                   type: string
                               required:
                               - repoURL
@@ -3325,11 +3325,10 @@ spec:
                                   to perform the sync.
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                               hook:
@@ -3337,11 +3336,10 @@ spec:
                                   to perform the sync. This is the default strategy
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                             type: object
@@ -3385,9 +3383,9 @@ spec:
                               description: Group specifies the API group of the resource
                               type: string
                             hookPhase:
-                              description: HookPhase contains the state of any operation
-                                associated with this resource OR hook This can also
-                                contain values for non-hook resources.
+                              description: |-
+                                HookPhase contains the state of any operation associated with this resource OR hook
+                                This can also contain values for non-hook resources.
                               type: string
                             hookType:
                               description: HookType specifies the type of the hook.
@@ -3772,11 +3770,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4127,11 +4124,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -4158,8 +4154,9 @@ spec:
                 description: Resources is a list of Kubernetes resources managed by
                   this application
                 items:
-                  description: 'ResourceStatus holds the current sync and health status
-                    of a resource TODO: describe members of this type'
+                  description: |-
+                    ResourceStatus holds the current sync and health status of a resource
+                    TODO: describe members of this type
                   properties:
                     group:
                       type: string
@@ -4242,10 +4239,9 @@ spec:
                               if Server is not set.
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
+                            description: |-
+                              Namespace specifies the target namespace for the application's resources.
+                              The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                             type: string
                           server:
                             description: Server specifies the URL of the target cluster's
@@ -4274,10 +4270,9 @@ spec:
                             kind:
                               type: string
                             managedFieldsManagers:
-                              description: ManagedFieldsManagers is a list of trusted
-                                managers. Fields mutated by those managers will take
-                                precedence over the desired state defined in the SCM
-                                and won't be displayed in diffs
+                              description: |-
+                                ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                desired state defined in the SCM and won't be displayed in diffs
                               items:
                                 type: string
                               type: array
@@ -4623,11 +4618,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4978,11 +4972,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-applicationset.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-applicationset.yaml
@@ -72,6 +72,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -668,6 +669,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         template:
                           properties:
                             metadata:
@@ -2430,6 +2432,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -3026,6 +3029,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -6891,6 +6895,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         template:
@@ -7487,6 +7492,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -8083,6 +8089,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -11948,6 +11955,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         mergeKeys:
@@ -14648,6 +14656,7 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               goTemplate:
@@ -15306,11 +15315,16 @@ spec:
                       type: string
                     step:
                       type: string
+                    targetRevisions:
+                      items:
+                        type: string
+                      type: array
                   required:
                   - application
                   - message
                   - status
                   - step
+                  - targetRevisions
                   type: object
                 type: array
               conditions:
@@ -15332,6 +15346,37 @@ spec:
                   - reason
                   - status
                   - type
+                  type: object
+                type: array
+              resources:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      properties:
+                        message:
+                          type: string
+                        status:
+                          type: string
+                      type: object
+                    hook:
+                      type: boolean
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    requiresPruning:
+                      type: boolean
+                    status:
+                      type: string
+                    syncWave:
+                      format: int64
+                      type: integer
+                    version:
+                      type: string
                   type: object
                 type: array
             type: object

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-project.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/crds/crd-project.yaml
@@ -31,22 +31,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'AppProject provides a logical grouping of applications, providing
-          controls for: * where the apps may deploy to (cluster whitelist) * what
-          may be deployed (repository whitelist, resource whitelist/blacklist) * who
-          can access these applications (roles, OIDC group claims bindings) * and
-          what they can do (RBAC policies) * automation access to these roles (JWT
-          tokens)'
+        description: |-
+          AppProject provides a logical grouping of applications, providing controls for:
+          * where the apps may deploy to (cluster whitelist)
+          * what may be deployed (repository whitelist, resource whitelist/blacklist)
+          * who can access these applications (roles, OIDC group claims bindings)
+          * and what they can do (RBAC policies)
+          * automation access to these roles (JWT tokens)
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -57,9 +63,9 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -74,9 +80,9 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -103,9 +109,9 @@ spec:
                         not set.
                       type: string
                     namespace:
-                      description: Namespace specifies the target namespace for the
-                        application's resources. The namespace will only be set for
-                        namespace-scoped resources that have not set a value for .metadata.namespace
+                      description: |-
+                        Namespace specifies the target namespace for the application's resources.
+                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                       type: string
                     server:
                       description: Server specifies the URL of the target cluster's
@@ -118,9 +124,9 @@ spec:
                 description: NamespaceResourceBlacklist contains list of blacklisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -135,9 +141,9 @@ spec:
                 description: NamespaceResourceWhitelist contains list of whitelisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.dex.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.dex.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.dex.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
     {{- with .Values.dex.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "argo-cd.redisSecretInit.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" . | quote }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -13,6 +13,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redisSecretInit.name "name" .Values.redisSecretInit.name) | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     metadata:
       labels:

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redisSecretInit.name "name" .Values.redisSecretInit.name) | nindent 4 }}
   name: {{ include "argo-cd.redisSecretInit.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" . | quote }}
 rules:
   - apiGroups:
       - ""

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redisSecretInit.name "name" .Values.redisSecretInit.name) | nindent 4 }}
   name: {{ include "argo-cd.redisSecretInit.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not .Values.externalRedis.host) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "argo-cd.redisSecretInit.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include  "argo-cd.namespace" . | quote }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis/servicemonitor.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/redis/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.redis.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.redis.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include  "argo-cd.namespace" .) .Values.redis.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
     {{- with .Values.redis.metrics.serviceMonitor.selector }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
@@ -405,6 +405,16 @@ configs:
   #     tlsClientConfig:
   #       insecure: false
   #       caData: "<base64 encoded certificate>"
+  # mycluster4-sharded:
+  #   shard: 1
+  #   server: https://mycluster4.example.com
+  #   labels: {}
+  #   annotations: {}
+  #   config:
+  #     bearerToken: "<authentication token>"
+  #     tlsClientConfig:
+  #       insecure: false
+  #       caData: "<base64 encoded certificate>"
 
   # -- Repository credentials to be used as Templates for other repos
   ## Creates a secret for each key/value specified below to create repository credentials
@@ -1437,7 +1447,7 @@ externalRedis:
   password: ""
   # -- External Redis server port
   port: 6379
-  # -- The name of an existing secret with Redis credentials (must contain key `redis-password`).
+  # -- The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials.
   # When it's set, the `externalRedis.password` parameter is ignored
   existingSecret: ""
   # -- External Redis Secret annotations
@@ -1453,7 +1463,7 @@ redisSecretInit:
     repository: "argoproj/argocd" # defaults to global.image.repository
     # -- Tag to use for the Redis secret-init Job
     # @default -- `""` (defaults to global.image.tag)
-    tag: "v2.11.2" # defaults to global.image.tag
+    tag: "v2.12.1" # defaults to global.image.tag
     # -- Image pull policy for the Redis secret-init Job
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: "" # IfNotPresent
@@ -1786,8 +1796,6 @@ server:
   certificate:
     # -- Deploy a Certificate resource (requires cert-manager)
     enabled: false
-    # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-    secretName: argocd-server-tls
     # -- Certificate primary domain (commonName)
     # @default -- `""` (defaults to global.domain)
     domain: ""
@@ -1825,6 +1833,8 @@ server:
     # -- Usages for the certificate
     ### Ref: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.KeyUsage
     usages: []
+    # -- Annotations that allow the certificate to be composed from data residing in existing Kubernetes Resources
+    secretTemplateAnnotations: {}
   # TLS certificate configuration via Secret
   ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server
   certificateSecret:
@@ -1861,6 +1871,8 @@ server:
     # -- Server service https port appProtocol
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
     servicePortHttpsAppProtocol: ""
+    # -- The class of the load balancer implementation
+    loadBalancerClass: ""
     # -- LoadBalancer will get created with the IP specified in this field
     loadBalancerIP: ""
     # -- Source IP ranges to allow access to service from
@@ -2707,8 +2719,6 @@ applicationSet:
   certificate:
     # -- Deploy a Certificate resource (requires cert-manager)
     enabled: false
-    # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-    secretName: argocd-applicationset-controller-tls
     # -- Certificate primary domain (commonName)
     # @default -- `""` (defaults to global.domain)
     domain: ""
@@ -2977,6 +2987,34 @@ notifications:
     capabilities:
       drop:
         - ALL
+  ## Probes for notifications controller Pods (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+  readinessProbe:
+    # -- Enable Kubernetes liveness probe for notifications controller Pods
+    enabled: false
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 3
+  livenessProbe:
+    # -- Enable Kubernetes liveness probe for notifications controller Pods
+    enabled: false
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 3
   # -- terminationGracePeriodSeconds for container lifecycle hook
   terminationGracePeriodSeconds: 30
   # -- [Node selector]

--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -52,7 +52,7 @@ argo-cd:
       # -- If defined, a repository applied to all Argo CD deployments
       repository: argoproj/argocd
       # -- Overrides the global Argo CD image tag whose default is the chart appVersion
-      tag: "v2.11.2"
+      tag: "v2.12.1"
       # -- If defined, a imagePullPolicy applied to all Argo CD deployments
       imagePullPolicy: IfNotPresent
       registry: quay.m.daocloud.io
@@ -408,6 +408,16 @@ argo-cd:
     #   labels: {}
     #   annotations: {}
     #   project: my-project1
+    #   config:
+    #     bearerToken: "<authentication token>"
+    #     tlsClientConfig:
+    #       insecure: false
+    #       caData: "<base64 encoded certificate>"
+    # mycluster4-sharded:
+    #   shard: 1
+    #   server: https://mycluster4.example.com
+    #   labels: {}
+    #   annotations: {}
     #   config:
     #     bearerToken: "<authentication token>"
     #     tlsClientConfig:
@@ -1491,7 +1501,7 @@ argo-cd:
     password: ""
     # -- External Redis server port
     port: 6379
-    # -- The name of an existing secret with Redis credentials (must contain key `redis-password`).
+    # -- The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials.
     # When it's set, the `externalRedis.password` parameter is ignored
     existingSecret: ""
     # -- External Redis Secret annotations
@@ -1507,7 +1517,7 @@ argo-cd:
       repository: "argoproj/argocd" # defaults to global.image.repository
       # -- Tag to use for the Redis secret-init Job
       # @default -- `""` (defaults to global.image.tag)
-      tag: "v2.11.2" # defaults to global.image.tag
+      tag: "v2.12.1" # defaults to global.image.tag
       # -- Image pull policy for the Redis secret-init Job
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: "" # IfNotPresent
@@ -1852,8 +1862,6 @@ argo-cd:
     certificate:
       # -- Deploy a Certificate resource (requires cert-manager)
       enabled: false
-      # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-      secretName: argocd-server-tls
       # -- Certificate primary domain (commonName)
       # @default -- `""` (defaults to global.domain)
       domain: ""
@@ -1891,6 +1899,8 @@ argo-cd:
       # -- Usages for the certificate
       ### Ref: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.KeyUsage
       usages: []
+      # -- Annotations that allow the certificate to be composed from data residing in existing Kubernetes Resources
+      secretTemplateAnnotations: {}
     # TLS certificate configuration via Secret
     ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server
     certificateSecret:
@@ -1927,6 +1937,8 @@ argo-cd:
       # -- Server service https port appProtocol
       ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
       servicePortHttpsAppProtocol: ""
+      # -- The class of the load balancer implementation
+      loadBalancerClass: ""
       # -- LoadBalancer will get created with the IP specified in this field
       loadBalancerIP: ""
       # -- Source IP ranges to allow access to service from
@@ -2785,8 +2797,6 @@ argo-cd:
     certificate:
       # -- Deploy a Certificate resource (requires cert-manager)
       enabled: false
-      # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-      secretName: argocd-applicationset-controller-tls
       # -- Certificate primary domain (commonName)
       # @default -- `""` (defaults to global.domain)
       domain: ""
@@ -3061,6 +3071,34 @@ argo-cd:
       capabilities:
         drop:
           - ALL
+    ## Probes for notifications controller Pods (optional)
+    ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+    readinessProbe:
+      # -- Enable Kubernetes liveness probe for notifications controller Pods
+      enabled: false
+      # -- Number of seconds after the container has started before [probe] is initiated
+      initialDelaySeconds: 10
+      # -- How often (in seconds) to perform the [probe]
+      periodSeconds: 10
+      # -- Number of seconds after which the [probe] times out
+      timeoutSeconds: 1
+      # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+      successThreshold: 1
+      # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+      failureThreshold: 3
+    livenessProbe:
+      # -- Enable Kubernetes liveness probe for notifications controller Pods
+      enabled: false
+      # -- Number of seconds after the container has started before [probe] is initiated
+      initialDelaySeconds: 10
+      # -- How often (in seconds) to perform the [probe]
+      periodSeconds: 10
+      # -- Number of seconds after which the [probe] times out
+      timeoutSeconds: 1
+      # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+      successThreshold: 1
+      # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+      failureThreshold: 3
     # -- terminationGracePeriodSeconds for container lifecycle hook
     terminationGracePeriodSeconds: 30
     # -- [Node selector]

--- a/charts/argo-cd/config
+++ b/charts/argo-cd/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-cd
 export CHART_NAME=argo-cd
-export VERSION=7.1.1
+export VERSION=7.4.4
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -51,6 +51,8 @@ redisNewTag=${redisTag//-alpine/}
 
 redisHaProxyTag=${haproxyImageTag//-alpine/}
 
+yq -i '.kubeVersion=">=1.23.0-0"' Chart.yaml
+
 yq -i '
   .argo-cd.global.image.registry = "quay.m.daocloud.io" |
   .argo-cd.global.image.repository = "argoproj/argocd" |


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #