### PR TITLE
fix: argocd image error

### DIFF
--- a/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
@@ -1467,7 +1467,7 @@ redisSecretInit:
     # -- Image pull policy for the Redis secret-init Job
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: "" # IfNotPresent
-    registry: quay.m.daocloud.io
+    registry: ""
   # -- Secrets with credentials to pull images from a private registry
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []

--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -1521,7 +1521,7 @@ argo-cd:
       # -- Image pull policy for the Redis secret-init Job
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: "" # IfNotPresent
-      registry: quay.m.daocloud.io
+      registry: ""
     # -- Secrets with credentials to pull images from a private registry
     # @default -- `[]` (defaults to global.imagePullSecrets)
     imagePullSecrets: []

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -78,7 +78,7 @@ yq -i '
   .argo-cd.redis-ha.sysctlImage.image.repository = "library/busybox" |
   .argo-cd.redis-ha.exporter.image.registry = "docker.m.daocloud.io" |
   .argo-cd.redis-ha.exporter.image.repository = "oliver006/redis_exporter" |
-  .argo-cd.redisSecretInit.image.registry = "quay.m.daocloud.io"
+  .argo-cd.redisSecretInit.image.registry = ""
 ' values.yaml
 
 
@@ -101,13 +101,13 @@ yq -i "
 
 
 yq -i "
-  .redisSecretInit.image.registry = \"quay.m.daocloud.io\" |
+  .redisSecretInit.image.registry = \"\" |
   .redisSecretInit.image.repository = \"argoproj/argocd\" |
   .redisSecretInit.image.tag = \"${globalImageTag}\"
 " charts/argo-cd/values.yaml
 
 yq -i "
-  .argo-cd.redisSecretInit.image.registry = \"quay.m.daocloud.io\" |
+  .argo-cd.redisSecretInit.image.registry = \"\" |
   .argo-cd.redisSecretInit.image.repository = \"argoproj/argocd\" |
   .argo-cd.redisSecretInit.image.tag = \"${globalImageTag}\"
 " values.yaml


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

fix argocd offline image error

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/879ec89d-cb91-462f-bf1c-acc8b200390a">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #