### PR TITLE
fix: argocd offline image error

### DIFF
--- a/charts/argo-cd/argo-cd/.relok8s-images.yaml
+++ b/charts/argo-cd/argo-cd/.relok8s-images.yaml
@@ -7,4 +7,3 @@
 - "{{ .argo-cd.redis-ha.haproxy.image.registry }}/{{ .argo-cd.redis-ha.haproxy.image.repository }}:{{ .argo-cd.redis-ha.haproxy.image.tag }}"
 - "{{ .argo-cd.redis-ha.sysctlImage.image.registry }}/{{ .argo-cd.redis-ha.sysctlImage.image.repository }}:{{ .argo-cd.redis-ha.sysctlImage.image.tag }}"
 - "{{ .argo-cd.redis-ha.exporter.image.registry }}/{{ .argo-cd.redis-ha.exporter.image.repository }}:{{ .argo-cd.redis-ha.exporter.image.tag }}"
-- "{{ .argo-cd.redisSecretInit.image.registry }}/{{ .argo-cd.redisSecretInit.image.repository }}:{{ .argo-cd.redisSecretInit.image.tag }}"

--- a/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
@@ -1467,7 +1467,6 @@ redisSecretInit:
     # -- Image pull policy for the Redis secret-init Job
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: "" # IfNotPresent
-    registry: ""
   # -- Secrets with credentials to pull images from a private registry
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []

--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -1521,7 +1521,6 @@ argo-cd:
       # -- Image pull policy for the Redis secret-init Job
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: "" # IfNotPresent
-      registry: ""
     # -- Secrets with credentials to pull images from a private registry
     # @default -- `[]` (defaults to global.imagePullSecrets)
     imagePullSecrets: []

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -77,8 +77,7 @@ yq -i '
   .argo-cd.redis-ha.sysctlImage.image.registry = "docker.m.daocloud.io" |
   .argo-cd.redis-ha.sysctlImage.image.repository = "library/busybox" |
   .argo-cd.redis-ha.exporter.image.registry = "docker.m.daocloud.io" |
-  .argo-cd.redis-ha.exporter.image.repository = "oliver006/redis_exporter" |
-  .argo-cd.redisSecretInit.image.registry = ""
+  .argo-cd.redis-ha.exporter.image.repository = "oliver006/redis_exporter"
 ' values.yaml
 
 
@@ -101,13 +100,11 @@ yq -i "
 
 
 yq -i "
-  .redisSecretInit.image.registry = \"\" |
   .redisSecretInit.image.repository = \"argoproj/argocd\" |
   .redisSecretInit.image.tag = \"${globalImageTag}\"
 " charts/argo-cd/values.yaml
 
 yq -i "
-  .argo-cd.redisSecretInit.image.registry = \"\" |
   .argo-cd.redisSecretInit.image.repository = \"argoproj/argocd\" |
   .argo-cd.redisSecretInit.image.tag = \"${globalImageTag}\"
 " values.yaml

--- a/charts/argo-cd/parent/.relok8s-images.yaml
+++ b/charts/argo-cd/parent/.relok8s-images.yaml
@@ -7,4 +7,3 @@
 - "{{ .argo-cd.redis-ha.haproxy.image.registry }}/{{ .argo-cd.redis-ha.haproxy.image.repository }}:{{ .argo-cd.redis-ha.haproxy.image.tag }}"
 - "{{ .argo-cd.redis-ha.sysctlImage.image.registry }}/{{ .argo-cd.redis-ha.sysctlImage.image.repository }}:{{ .argo-cd.redis-ha.sysctlImage.image.tag }}"
 - "{{ .argo-cd.redis-ha.exporter.image.registry }}/{{ .argo-cd.redis-ha.exporter.image.repository }}:{{ .argo-cd.redis-ha.exporter.image.tag }}"
-- "{{ .argo-cd.redisSecretInit.image.registry }}/{{ .argo-cd.redisSecretInit.image.repository }}:{{ .argo-cd.redisSecretInit.image.tag }}"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

fix argocd offline image prase error:

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/2cc831e2-b4f6-4779-859b-4a364dfa26d4">


relock k8s：

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/c9a2445c-b3dd-40b5-96da-1da66165214b">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #