### PR TITLE
revert cert manager arm64 change

### DIFF
--- a/charts/cert-manager/cert-manager/.relok8s-images.yaml
+++ b/charts/cert-manager/cert-manager/.relok8s-images.yaml
@@ -1,6 +1,3 @@
-- "{{ .cert-manager.image.repository }}-arm64:{{ .cert-manager.image.tag }}"
-- "{{ .cert-manager.webhook.image.repository }}-arm64:{{ .cert-manager.webhook.image.tag }}"
-- "{{ .cert-manager.cainjector.image.repository }}-arm64:{{ .cert-manager.cainjector.image.tag }}"
 - "{{ .cert-manager.image.repository }}:{{ .cert-manager.image.tag }}"
 - "{{ .cert-manager.webhook.image.repository }}:{{ .cert-manager.webhook.image.tag }}"
 - "{{ .cert-manager.cainjector.image.repository }}:{{ .cert-manager.cainjector.image.tag }}"

--- a/charts/cert-manager/parent/.relok8s-images.yaml
+++ b/charts/cert-manager/parent/.relok8s-images.yaml
@@ -1,6 +1,3 @@
-- "{{ .cert-manager.image.repository }}-arm64:{{ .cert-manager.image.tag }}"
-- "{{ .cert-manager.webhook.image.repository }}-arm64:{{ .cert-manager.webhook.image.tag }}"
-- "{{ .cert-manager.cainjector.image.repository }}-arm64:{{ .cert-manager.cainjector.image.tag }}"
 - "{{ .cert-manager.image.repository }}:{{ .cert-manager.image.tag }}"
 - "{{ .cert-manager.webhook.image.repository }}:{{ .cert-manager.webhook.image.tag }}"
 - "{{ .cert-manager.cainjector.image.repository }}:{{ .cert-manager.cainjector.image.tag }}"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #