### PR TITLE
rollback resourcesInjector from v1.6.0 to v1.5

### DIFF
--- a/charts/spiderpool/custom.sh
+++ b/charts/spiderpool/custom.sh
@@ -69,7 +69,8 @@ yq -i '
     .spiderpool.spiderpoolController.podResourceInject.namespacesExclude= ["insight-system","mcamel-system","amamba-system","argocd","baize-system","ghippo-system","gpu-operator","dowl-system","hwameistor","insight-system","kairship-system","kangaroo-system","kant-system","kcollie-system","kcoral-system","kolm-system","kpanda-system","kubean-system","local-path-storage","metax","mspider-system","nvidia-gpu-operator","skoala-system","spidernet-system","virtnest-system","ipavo-system"] + .spiderpool.spiderpoolController.podResourceInject.namespacesExclude | 
     .spiderpool.spiderpoolInit.image.registry="ghcr.m.daocloud.io" | 
     .spiderpool.plugins.image.registry="ghcr.m.daocloud.io" |
-    .spiderpool.rdma.rdmaSharedDevicePlugin.image.registry="ghcr.m.daocloud.io" 
+    .spiderpool.rdma.rdmaSharedDevicePlugin.image.registry="ghcr.m.daocloud.io" |
+    .spiderpool.sriov.image.resourcesInjector.tag="v1.5"
 ' ${CHART_DIRECTORY}/values.yaml
 
 if ! grep "keywords:" ${CHART_DIRECTORY}/Chart.yaml &>/dev/null ; then

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -729,7 +729,7 @@ spiderpool:
         ## @param sriov.image.resourcesInjector.repository the image repository
         repository: k8snetworkplumbingwg/network-resources-injector
         ## @param sriov.image.resourcesInjector.tag the image tag
-        tag: v1.6.0
+        tag: v1.5
       webhook:
         ## @param sriov.image.webhook.repository the image repository
         repository: k8snetworkplumbingwg/sriov-network-operator-webhook


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

由于 resourcesInjector v1.6.0 暂时没有 arm64 版本，所以导致离线打包 CI 失败，此 PR 暂时将其版本会退为 v1.5，待https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/158 解决，再回复其tag。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #