### PR TITLE
feat: enable argocd metrics

### DIFF
--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -739,7 +739,7 @@ argo-cd:
     ## Application controller metrics configuration
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
       scrapeTimeout: ""
       applicationLabels:
@@ -762,7 +762,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor interval
         interval: 30s
         # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -780,7 +780,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # "monitoring"
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
       rules:
@@ -839,7 +840,7 @@ argo-cd:
     extraArgs: []
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       service:
         # -- Metrics service annotations
         annotations: {}
@@ -849,7 +850,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor interval
         interval: 30s
         # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -867,7 +868,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # "monitoring"
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
     ## Dex Pod Disruption Budget
@@ -1341,7 +1343,7 @@ argo-cd:
       labels: {}
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       # Redis metrics service configuration
       service:
         # -- Metrics service type
@@ -1358,7 +1360,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Interval at which metrics should be scraped
         interval: 30s
         # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -1376,7 +1378,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # "monitoring"
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
       image:
@@ -1954,7 +1957,7 @@ argo-cd:
     ## Server metrics service configuration
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       service:
         # -- Metrics service type
         type: ClusterIP
@@ -1970,7 +1973,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor interval
         interval: 30s
         # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -1990,7 +1993,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # monitoring
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
     # -- Automount API credentials for the Service Account into the pod.
@@ -2484,7 +2488,7 @@ argo-cd:
     ## Repo server metrics service configuration
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       service:
         # -- Metrics service type
         type: ClusterIP
@@ -2500,7 +2504,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor interval
         interval: 30s
         # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -2520,7 +2524,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # "monitoring"
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
     ## Enable Custom Rules for the Repo server's Cluster Role resource
@@ -2625,7 +2630,7 @@ argo-cd:
     ## Metrics service configuration
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       service:
         # -- Metrics service type
         type: ClusterIP
@@ -2641,7 +2646,7 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor interval
         interval: 30s
         # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -2661,7 +2666,8 @@ argo-cd:
         # -- Prometheus ServiceMonitor namespace
         namespace: "" # monitoring
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
     ## ApplicationSet service configuration
@@ -2988,7 +2994,7 @@ argo-cd:
     # For more information: https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/services/email/
     metrics:
       # -- Enables prometheus metrics server
-      enabled: false
+      enabled: true
       # -- Metrics port
       port: 9001
       service:
@@ -3004,12 +3010,13 @@ argo-cd:
         portName: http-metrics
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Prometheus ServiceMonitor selector
         selector: {}
         # prometheus: kube-prometheus
         # -- Prometheus ServiceMonitor labels
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Prometheus ServiceMonitor annotations
         annotations: {}
         # namespace: monitoring

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -80,6 +80,31 @@ yq -i '
   .argo-cd.redis-ha.exporter.image.repository = "oliver006/redis_exporter"
 ' values.yaml
 
+# default enable metrics
+yq -i '
+  .argo-cd.controller.metrics.enabled = true |
+  .argo-cd.controller.metrics.serviceMonitor.enabled = true |
+  .argo-cd.controller.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.dex.metrics.enabled = true |
+  .argo-cd.dex.metrics.serviceMonitor.enabled = true |
+  .argo-cd.dex.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.redis.metrics.enabled = true |
+  .argo-cd.redis.metrics.serviceMonitor.enabled = true |
+  .argo-cd.redis.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.server.metrics.enabled = true |
+  .argo-cd.server.metrics.serviceMonitor.enabled = true |
+  .argo-cd.server.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.repoServer.metrics.enabled = true |
+  .argo-cd.repoServer.metrics.serviceMonitor.enabled = true |
+  .argo-cd.repoServer.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.notifications.metrics.enabled = true |
+  .argo-cd.notifications.metrics.serviceMonitor.enabled = true |
+  .argo-cd.notifications.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight" |
+  .argo-cd.applicationSet.metrics.enabled = true |
+  .argo-cd.applicationSet.metrics.serviceMonitor.enabled = true |
+  .argo-cd.applicationSet.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight"
+' values.yaml
+
 
 # reset image to strut
 yq -i 'del(.exporter.image)' charts/argo-cd/charts/redis-ha/values.yaml


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #