### PR TITLE
feat: add kubevela metrics

### DIFF
--- a/charts/vela-core/vela-core/charts/vela-core/templates/controller-service-monitor.yaml
+++ b/charts/vela-core/vela-core/charts/vela-core/templates/controller-service-monitor.yaml
@@ -1,0 +1,22 @@
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.multicluster.metrics.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: amamba-kubevela
+  namespace: {{ .Release.Namespace }}
+  labels:
+      operator.insight.io/managed-by: insight
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 10s
+      path: /metrics
+      port: metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      component: kubevela-controller
+{{- end -}}

--- a/charts/vela-core/vela-core/charts/vela-core/templates/controller-service.yaml
+++ b/charts/vela-core/vela-core/charts/vela-core/templates/controller-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevela-controller-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: kubevela-controller
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
+    - name: metrics
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    {{- include "kubevela.selectorLabels" . | nindent 6 }}

--- a/charts/vela-core/vela-core/values.yaml
+++ b/charts/vela-core/vela-core/values.yaml
@@ -142,7 +142,7 @@ vela-core:
   multicluster:
     enabled: true
     metrics:
-      enabled: false
+      enabled: true
     clusterGateway:
       direct: true
       replicaCount: 1


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #