### PR TITLE
feat: add rollout metrics

### DIFF
--- a/charts/argo-rollouts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/argo-rollouts/values.yaml
@@ -128,7 +128,7 @@ argo-rollouts:
       healthz: 8080
     metrics:
       # -- Deploy metrics service
-      enabled: false
+      enabled: true
       service:
         # -- Metrics service port name
         portName: metrics
@@ -138,11 +138,12 @@ argo-rollouts:
         annotations: {}
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
-        enabled: false
+        enabled: true
         # -- Namespace to be used for the ServiceMonitor
         namespace: ""
         # -- Labels to be added to the ServiceMonitor
-        additionalLabels: {}
+        additionalLabels:
+          operator.insight.io/managed-by: insight
         # -- Annotations to be added to the ServiceMonitor
         additionalAnnotations: {}
         # -- RelabelConfigs to apply to samples before scraping

--- a/charts/argo-rollouts/custom.sh
+++ b/charts/argo-rollouts/custom.sh
@@ -43,6 +43,12 @@ yq -i "
 #==============================
 os=$(uname)
 
+yq -i '
+  .argo-rollouts.controller.metrics.enabled = true |
+  .argo-rollouts.controller.metrics.serviceMonitor.enabled = true |
+  .argo-rollouts.controller.metrics.serviceMonitor.additionalLabels."operator.insight.io/managed-by" = "insight"
+' values.yaml
+
 
 echo '
 {{- define "global.images.image" -}}


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #