### PR TITLE
Update ingress nginx to 4.7.2

### DIFF
--- a/charts/ingress-nginx/config
+++ b/charts/ingress-nginx/config
@@ -3,7 +3,7 @@ export DAOCLOUD_REPO_PROJECT=addon
 export REPO_URL=https://kubernetes.github.io/ingress-nginx
 export REPO_NAME=ingress-nginx
 export CHART_NAME=ingress-nginx
-export VERSION=4.7.1
+export VERSION=4.7.2
 
 export UPGRADE_METHOD=pr
 export UPGRADE_REVIWER=lou-lan

--- a/charts/ingress-nginx/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/ingress-nginx/Chart.yaml
@@ -1,12 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - "Added a doc line to the missing helm value service.internal.loadBalancerIP (#9406)"
-    - "feat(helm): Add loadBalancerClass (#9562)"
-    - "added helmshowvalues example (#10019)"
-    - "Update Ingress-Nginx version controller-v1.8.1"
+    - "Update Ingress-Nginx version controller-v1.8.2"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.8.1
+appVersion: 1.8.2
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -22,8 +19,8 @@ maintainers:
 name: ingress-nginx
 sources:
   - https://github.com/kubernetes/ingress-nginx
-version: 4.7.1
+version: 4.7.2
 dependencies:
   - name: ingress-nginx
-    version: "4.7.1"
+    version: "4.7.2"
     repository: "https://kubernetes.github.io/ingress-nginx"

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/Chart.yaml
@@ -1,12 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - "Added a doc line to the missing helm value service.internal.loadBalancerIP (#9406)"
-    - "feat(helm): Add loadBalancerClass (#9562)"
-    - "added helmshowvalues example (#10019)"
-    - "Update Ingress-Nginx version controller-v1.8.1"
+    - "Update Ingress-Nginx version controller-v1.8.2"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.8.1
+appVersion: 1.8.2
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -22,4 +19,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.7.1
+version: 4.7.2

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.7.1](https://img.shields.io/badge/Version-4.7.1-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 4.7.2](https://img.shields.io/badge/Version-4.7.2-informational?style=flat-square) ![AppVersion: 1.8.2](https://img.shields.io/badge/AppVersion-1.8.2-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -294,8 +294,9 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.dnsConfig | object | `{}` | Optionally customize the pod dnsConfig. |
 | controller.dnsPolicy | string | `"ClusterFirst"` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet. |
 | controller.electionID | string | `""` | Election ID to use for status update, by default it uses the controller name combined with a suffix of 'leader' |
+| controller.enableAnnotationValidations | bool | `false` |  |
 | controller.enableMimalloc | bool | `true` | Enable mimalloc as a drop-in replacement for malloc. # ref: https://github.com/microsoft/mimalloc # |
-| controller.enableTopologyAwareRouting | bool | `false` | This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-aware-hints="auto" Defaults to false |
+| controller.enableTopologyAwareRouting | bool | `false` | This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto" Defaults to false |
 | controller.existingPsp | string | `""` | Use an existing PSP instead of creating one |
 | controller.extraArgs | object | `{}` | Additional command line arguments to pass to Ingress-Nginx Controller E.g. to specify the default SSL certificate you can use |
 | controller.extraContainers | list | `[]` | Additional containers to be added to the controller pod. See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example. |
@@ -306,6 +307,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.extraVolumes | list | `[]` | Additional volumes to the controller pod. |
 | controller.healthCheckHost | string | `""` | Address to bind the health check endpoint. It is better to set this option to the internal node address if the Ingress-Nginx Controller is running in the `hostNetwork: true` mode. |
 | controller.healthCheckPath | string | `"/healthz"` | Path of the health check endpoint. All requests received on the port defined by the healthz-port parameter are forwarded internally to this path. |
+| controller.hostAliases | object | `{}` | Optionally customize the pod hostAliases. |
 | controller.hostNetwork | bool | `false` | Required for use with CNI based kubernetes installations (such as ones set up by kubeadm), since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920 is merged |
 | controller.hostPort.enabled | bool | `false` | Enable 'hostPort' or not |
 | controller.hostPort.ports.http | int | `80` | 'hostPort' http port |
@@ -313,13 +315,13 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `true` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:e5c4824e7375fcf2a393e1c03c293b69759af37a9ca6abdb91b13d78a93da8bd"` |  |
-| controller.image.digestChroot | string | `"sha256:e0d4121e3c5e39de9122e55e331a32d5ebf8d4d257227cb93ab54a1b912a7627"` |  |
+| controller.image.digest | string | `"sha256:74834d3d25b336b62cabeb8bf7f1d788706e2cf1cfd64022de4137ade8881ff2"` |  |
+| controller.image.digestChroot | string | `"sha256:1317a563219f755a6094d990057c78e5c4dcea5e31f4ce1db8641e732a7d6133"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.registry | string | `"registry.k8s.io"` |  |
 | controller.image.runAsUser | int | `101` |  |
-| controller.image.tag | string | `"v1.8.1"` |  |
+| controller.image.tag | string | `"v1.8.2"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` | Controller-value of the controller that is processing this ingressClass |
@@ -375,7 +377,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for controller pod assignment # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ # |
 | controller.opentelemetry.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | controller.opentelemetry.enabled | bool | `false` |  |
-| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0"` |  |
+| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230721-3e2062ee5@sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472"` |  |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods # |
 | controller.podLabels | object | `{}` | Labels to add to the pod container metadata |
 | controller.podSecurityContext | object | `{}` | Security Context policies for controller pods |
@@ -399,14 +401,14 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.scope.enabled | bool | `false` | Enable 'scope' or not |
 | controller.scope.namespace | string | `""` | Namespace to limit the controller to; defaults to $(POD_NAMESPACE) |
 | controller.scope.namespaceSelector | string | `""` | When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces. |
-| controller.service.annotations | object | `{}` |  |
+| controller.service.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine. |
 | controller.service.appProtocol | bool | `true` | If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http It allows choosing the protocol for each backend specified in the Kubernetes service. See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244 Will be ignored for Kubernetes versions older than 1.20 # |
 | controller.service.enableHttp | bool | `true` |  |
 | controller.service.enableHttps | bool | `true` |  |
 | controller.service.enabled | bool | `true` |  |
 | controller.service.external.enabled | bool | `true` |  |
 | controller.service.externalIPs | list | `[]` | List of IP addresses at which the controller services are available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
-| controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. |
+| controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine. |
 | controller.service.internal.enabled | bool | `false` | Enables an additional internal load balancer (besides the external one). |
 | controller.service.internal.loadBalancerIP | string | `""` | Used by cloud providers to connect the resulting internal LoadBalancer to a pre-existing static IP. Make sure to add to the service the needed annotation to specify the subnet which the static IP belongs to. For instance, `networking.gke.io/internal-load-balancer-subnet` for GCP and `service.beta.kubernetes.io/aws-load-balancer-subnets` for AWS. |
 | controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0. |

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/changelog/Changelog-4.7.2.md
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/changelog/Changelog-4.7.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.7.2
+
+* Update Ingress-Nginx version controller-v1.8.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.7.1...helm-chart-4.7.2

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/_params.tpl
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/_params.tpl
@@ -1,5 +1,8 @@
 {{- define "ingress-nginx.params" -}}
 - /nginx-ingress-controller
+{{- if .Values.controller.enableAnnotationValidations }}
+- --enable-annotation-validation=true
+{{- end }}
 {{- if .Values.defaultBackend.enabled }}
 - --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
 {{- end }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: controller
-  {{- if not .Values.controller.autoscaling.enabled }}
+  {{- if not (or .Values.controller.autoscaling.enabled .Values.controller.keda.enabled) }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -48,6 +48,9 @@ spec:
     spec:
     {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{ toYaml .Values.controller.dnsConfig | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.hostAliases }}
+      hostAliases: {{ tpl (toYaml .Values.controller.hostAliases) $ | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.hostname }}
       hostname: {{ toYaml .Values.controller.hostname | nindent 8 }}
@@ -190,7 +193,7 @@ spec:
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}
           {{ $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" false) | nindent 8}}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" true) | nindent 8}}
       {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   annotations:
   {{- range $key, $value := .Values.controller.service.internal.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   annotations:
   {{- range $key, $value := .Values.controller.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -11,8 +11,7 @@ metadata:
   name: {{ template "ingress-nginx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
-  annotations:
-  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 {{- if .Values.controller.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.controller.metrics.serviceMonitor.namespace | quote }}
+{{- else }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/ingress-nginx/charts/ingress-nginx/values.yaml
@@ -15,6 +15,7 @@ commonLabels: {}
 
 controller:
   name: controller
+  enableAnnotationValidations: false
   image:
     ## Keep false as default for now!
     chroot: false
@@ -23,9 +24,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.8.1"
-    digest: sha256:e5c4824e7375fcf2a393e1c03c293b69759af37a9ca6abdb91b13d78a93da8bd
-    digestChroot: sha256:e0d4121e3c5e39de9122e55e331a32d5ebf8d4d257227cb93ab54a1b912a7627
+    tag: "v1.8.2"
+    digest: sha256:74834d3d25b336b62cabeb8bf7f1d788706e2cf1cfd64022de4137ade8881ff2
+    digestChroot: sha256:1317a563219f755a6094d990057c78e5c4dcea5e31f4ce1db8641e732a7d6133
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -48,6 +49,8 @@ controller:
   addHeaders: {}
   # -- Optionally customize the pod dnsConfig.
   dnsConfig: {}
+  # -- Optionally customize the pod hostAliases.
+  hostAliases: {}
   # -- Optionally customize the pod hostname.
   hostname: {}
   # -- Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
@@ -63,7 +66,7 @@ controller:
   watchIngressWithoutClass: false
   # -- Process IngressClass per name (additionally as per spec.controller).
   ingressClassByName: false
-  # -- This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-aware-hints="auto"
+  # -- This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto"
   # Defaults to false
   enableTopologyAwareRouting: false
   # -- This configuration defines if Ingress Controller should allow users to set
@@ -415,6 +418,7 @@ controller:
     # Will be ignored for Kubernetes versions older than 1.20
     ##
     appProtocol: true
+    # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
     annotations: {}
     labels: {}
     # clusterIP: ""
@@ -476,7 +480,7 @@ controller:
     internal:
       # -- Enables an additional internal load balancer (besides the external one).
       enabled: false
-      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
       annotations: {}
       # -- Used by cloud providers to connect the resulting internal LoadBalancer to a pre-existing static IP. Make sure to add to the service the needed annotation to specify the subnet which the static IP belongs to. For instance, `networking.gke.io/internal-load-balancer-subnet` for GCP and `service.beta.kubernetes.io/aws-load-balancer-subnets` for AWS.
       loadBalancerIP: ""
@@ -552,7 +556,7 @@ controller:
 
   opentelemetry:
     enabled: false
-    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0
+    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230721-3e2062ee5@sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472
     containerSecurityContext:
       allowPrivilegeEscalation: false
   admissionWebhooks:

--- a/charts/ingress-nginx/ingress-nginx/templates/PrometheusRule.yaml
+++ b/charts/ingress-nginx/ingress-nginx/templates/PrometheusRule.yaml
@@ -18,28 +18,28 @@ spec:
             message_zh: "无法抓取 ingress-nginx-controller-metrics 的指标"
           labels:
             severity: critical
-    - alert: NginxHighHttp4xxErrorRate
-      expr: sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}
-      for: 1m
-      labels:
-        severity: critical
-      annotations:
-        message: "Too many HTTP requests with status 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "HTTP 请求 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-    - alert: NginxHighHttp5xxErrorRate
-      expr: sum(rate(nginx_http_requests_total{status=~"^5.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}
-      for: 1m
-      labels:
-        severity: critical
-      annotations:
-        message: "Too many HTTP requests with status 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "HTTP 请求 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-    - alert: NginxLatencyHigh
-      expr: histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node)) > {{ .Values.alert.prometheusRule.nginxLatencySecond }}
-      for: 2m
-      labels:
-        severity: warning
-      annotations:
-        message: "Nginx p99 latency is higher than {{ .Values.alert.prometheusRule.nginxLatencySecond }} seconds\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "Nginx p99 延迟超过 {{ .Values.alert.prometheusRule.nginxLatencySecond }} 秒\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxHighHttp4xxErrorRate
+          expr: sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            message: "Too many HTTP requests with status 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "HTTP 请求 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxHighHttp5xxErrorRate
+          expr: sum(rate(nginx_http_requests_total{status=~"^5.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            message: "Too many HTTP requests with status 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "HTTP 请求 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxLatencyHigh
+          expr: histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node)) > {{ .Values.alert.prometheusRule.nginxLatencySecond }}
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            message: "Nginx p99 latency is higher than {{ .Values.alert.prometheusRule.nginxLatencySecond }} seconds\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "Nginx p99 延迟超过 {{ .Values.alert.prometheusRule.nginxLatencySecond }} 秒\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
 {{ end }}

--- a/charts/ingress-nginx/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/ingress-nginx/values.yaml
@@ -17,6 +17,7 @@ ingress-nginx:
 
   controller:
     name: controller
+    enableAnnotationValidations: false
     image:
       ## Keep false as default for now!
       chroot: false
@@ -25,7 +26,7 @@ ingress-nginx:
       ## for backwards compatibility consider setting the full image url via the repository value below
       ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
       ## repository:
-      tag: "v1.8.1"
+      tag: "v1.8.2"
       digest: ""
       digestChroot: ""
       pullPolicy: IfNotPresent
@@ -50,6 +51,8 @@ ingress-nginx:
     addHeaders: {}
     # -- Optionally customize the pod dnsConfig.
     dnsConfig: {}
+    # -- Optionally customize the pod hostAliases.
+    hostAliases: {}
     # -- Optionally customize the pod hostname.
     hostname: {}
     # -- Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
@@ -65,7 +68,7 @@ ingress-nginx:
     watchIngressWithoutClass: false
     # -- Process IngressClass per name (additionally as per spec.controller).
     ingressClassByName: false
-    # -- This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-aware-hints="auto"
+    # -- This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto"
     # Defaults to false
     enableTopologyAwareRouting: false
     # -- This configuration defines if Ingress Controller should allow users to set
@@ -427,6 +430,7 @@ ingress-nginx:
       # Will be ignored for Kubernetes versions older than 1.20
       ##
       appProtocol: true
+      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
       annotations: {}
       labels: {}
       # clusterIP: ""
@@ -488,7 +492,7 @@ ingress-nginx:
       internal:
         # -- Enables an additional internal load balancer (besides the external one).
         enabled: false
-        # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+        # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
         annotations: {}
         # -- Used by cloud providers to connect the resulting internal LoadBalancer to a pre-existing static IP. Make sure to add to the service the needed annotation to specify the subnet which the static IP belongs to. For instance, `networking.gke.io/internal-load-balancer-subnet` for GCP and `service.beta.kubernetes.io/aws-load-balancer-subnets` for AWS.
         loadBalancerIP: ""
@@ -566,7 +570,7 @@ ingress-nginx:
 
     opentelemetry:
       enabled: false
-      image: registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0
+      image: registry.k8s.io/ingress-nginx/opentelemetry:v20230721-3e2062ee5@sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472
       containerSecurityContext:
         allowPrivilegeEscalation: false
     admissionWebhooks:

--- a/charts/ingress-nginx/parent/templates/PrometheusRule.yaml
+++ b/charts/ingress-nginx/parent/templates/PrometheusRule.yaml
@@ -18,28 +18,28 @@ spec:
             message_zh: "无法抓取 ingress-nginx-controller-metrics 的指标"
           labels:
             severity: critical
-    - alert: NginxHighHttp4xxErrorRate
-      expr: sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}
-      for: 1m
-      labels:
-        severity: critical
-      annotations:
-        message: "Too many HTTP requests with status 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "HTTP 请求 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-    - alert: NginxHighHttp5xxErrorRate
-      expr: sum(rate(nginx_http_requests_total{status=~"^5.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}
-      for: 1m
-      labels:
-        severity: critical
-      annotations:
-        message: "Too many HTTP requests with status 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "HTTP 请求 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-    - alert: NginxLatencyHigh
-      expr: histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node)) > {{ .Values.alert.prometheusRule.nginxLatencySecond }}
-      for: 2m
-      labels:
-        severity: warning
-      annotations:
-        message: "Nginx p99 latency is higher than {{ .Values.alert.prometheusRule.nginxLatencySecond }} seconds\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
-        message_zh: "Nginx p99 延迟超过 {{ .Values.alert.prometheusRule.nginxLatencySecond }} 秒\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxHighHttp4xxErrorRate
+          expr: sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            message: "Too many HTTP requests with status 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "HTTP 请求 4xx (> {{ .Values.alert.prometheusRule.nginxHighHttp4xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxHighHttp5xxErrorRate
+          expr: sum(rate(nginx_http_requests_total{status=~"^5.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            message: "Too many HTTP requests with status 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "HTTP 请求 5xx (> {{ .Values.alert.prometheusRule.nginxHighHttp5xxErrorRate }}%)\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+        - alert: NginxLatencyHigh
+          expr: histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node)) > {{ .Values.alert.prometheusRule.nginxLatencySecond }}
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            message: "Nginx p99 latency is higher than {{ .Values.alert.prometheusRule.nginxLatencySecond }} seconds\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
+            message_zh: "Nginx p99 延迟超过 {{ .Values.alert.prometheusRule.nginxLatencySecond }} 秒\n  VALUE = {{"{{ $value }}"}}\n  LABELS = {{"{{ $labels }}"}}"
 {{ end }}


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

Update ingress nginx to 4.7.2

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix https://github.com/DaoCloud/dce-charts-repackage/issues/2860