### PR TITLE
Robot Upgrade: opentelemetry-demo-lite chart upgrade from 1.1.10 to 1.1.11

### DIFF
--- a/charts/opentelemetry-demo-lite/config
+++ b/charts/opentelemetry-demo-lite/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://openinsight-proj.github.io/openinsight-helm-charts
 export REPO_NAME=open-insight
 export CHART_NAME=opentelemetry-demo-lite
-export VERSION=1.1.10
+export VERSION=1.1.11
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/Chart.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/Chart.yaml
@@ -12,8 +12,8 @@ name: opentelemetry-demo-lite
 sources:
   - https://github.com/openinsight-proj/openinsight-helm-charts
 type: application
-version: 1.1.10
+version: 1.1.11
 dependencies:
   - name: opentelemetry-demo-lite
-    version: "1.1.10"
+    version: "1.1.11"
     repository: "https://openinsight-proj.github.io/openinsight-helm-charts"

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/Chart.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/Chart.yaml
@@ -18,4 +18,4 @@ name: opentelemetry-demo-lite
 sources:
 - https://github.com/openinsight-proj/openinsight-helm-charts
 type: application
-version: 1.1.10
+version: 1.1.11

--- a/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.yaml
+++ b/charts/opentelemetry-demo-lite/opentelemetry-demo-lite/charts/opentelemetry-demo-lite/values.yaml
@@ -122,7 +122,7 @@ extensions:
     image:
       registry: ghcr.io
       repository: openinsight-proj/demo
-      tag: "db802043e29ceb4205af968a6d6f324c8929d543-adservice-v2"
+      tag: "980e0a4bb9308609df24b64468a9f8ff6cf4aafe-adservice-v2"
       pullPolicy: Always
     servcie:
       type: ClusterIP


### PR DESCRIPTION
I am robot, upgrade: project opentelemetry-demo-lite chart upgrade from 1.1.10 to 1.1.11