### PR TITLE
add topohub chart

### DIFF
--- a/charts/topohub/config
+++ b/charts/topohub/config
@@ -1,0 +1,20 @@
+export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://infrastructure-io.github.io/topohub
+export REPO_NAME=topohub
+export CHART_NAME=topohub
+export VERSION=0.4.3
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=JiaweiGithub
+export TEST_ASSIGNER=JiaweiGithub
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+export NO_TRIVY=true

--- a/charts/topohub/custom.sh
+++ b/charts/topohub/custom.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+set -o errexit
+set -o nounset
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if ! which yq &>/dev/null; then
+    echo " 'yq' no found, try to install..."
+    YQ_VERSION=v4.30.6
+    YQ_BINARY="yq_$(uname | tr 'A-Z' 'a-z')_amd64"
+    wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz -O /tmp/yq.tar.gz &&
+        tar -xzf /tmp/yq.tar.gz -C /tmp &&
+        mv /tmp/${YQ_BINARY} /usr/bin/yq
+fi
+
+OS=$(uname -s | tr 'A-Z' 'a-z')
+SED_COMMAND="sed"
+if [ "${OS}" == "darwin" ]; then
+    SED_COMMAND="gsed"
+fi
+
+#==============================
+echo "insert custom resources"
+
+FILEBROWSER_IMAGE_TAG=$(yq e '.fileBrowser.image.tag' $CHART_DIRECTORY/charts/topohub/values.yaml | tr -d '\n' | tr -d '\r')
+TOPOHUB_IMAGE_TAG=$(cat $CHART_DIRECTORY/Chart.yaml | grep appVersion | awk '{print $2}')
+
+
+yq -i "
+  .topohub.image.tag = \"v$TOPOHUB_IMAGE_TAG\" |
+  .topohub.fileBrowser.image.tag = \"$FILEBROWSER_IMAGE_TAG\" 
+" values.yaml
+
+
+yq -i '
+  .topohub.image.registry = "ghcr.m.daocloud.io" |
+  .topohub.image.repository = "infrastructure-io/topohub" |
+  .topohub.fileBrowser.enabled = true |
+  .topohub.fileBrowser.image.registry = "docker.m.daocloud.io" |
+  .topohub.fileBrowser.image.repository = "filebrowser/filebrowser" |
+  .topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="topohub.io/deployment" |
+  .topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator="In" |
+  .topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]="true"
+' values.yaml
+
+exit 0

--- a/charts/topohub/parent/.relok8s-images.yaml
+++ b/charts/topohub/parent/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .topohub.image.registry }}/{{ .topohub.image.repository }}:{{ .topohub.image.tag }}"
+- "{{ .topohub.fileBrowser.image.registry}}/{{ .topohub.fileBrowser.image.repository }}:{{ .topohub.fileBrowser.image.tag }}"

--- a/charts/topohub/parent/README.md
+++ b/charts/topohub/parent/README.md
@@ -1,0 +1,99 @@
+# topohub
+
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+
+Topohub is a set of Kubernetes components for managing infrastructure, including hosts, switches, and more.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://infrastructure-io.github.io/topohub | topohub | 0.4.2 |
+
+## Values
+
+| Key                                      | Type   | Default       | Description                                                        |
+|------------------------------------------|--------|---------------|--------------------------------------------------------------------|
+| topohub.replicaCount                     | int    | `1`           | Number of replicas for topohub                                      |
+| topohub.registryOverride                 | string | `""`          | Registry override for topohub                                      |
+| topohub.imagePullSecrets                 | list   | `[]`          | List of image pull secrets                                          |
+| topohub.nameOverride                     | string | `""`          | Override for the topohub name                                      |
+| topohub.fullnameOverride                 | string | `""`          | Override for the full name of topohub                              |
+| topohub.image.registry                   | string | `"ghcr.m.daocloud.io"` | Image registry address                                           |
+| topohub.image.repository                 | string | `"infrastructure-io/topohub"` | Image repository name                                            |
+| topohub.image.pullPolicy                 | string | `"IfNotPresent"` | Image pull policy                                                |
+| topohub.image.tag                        | string | `"v0.4.2"`    | Image tag, overridden by version from Chart.yaml                  |
+| topohub.resources.limits.cpu             | string | `"500m"`      | CPU limit for topohub                                             |
+| topohub.resources.limits.memory          | string | `"512Mi"`     | Memory limit for topohub                                          |
+| topohub.resources.requests.cpu            | string | `"100m"`      | CPU request for topohub                                           |
+| topohub.resources.requests.memory         | string | `"128Mi"`     | Memory request for topohub                                        |
+| topohub.defaultConfig.redfish.port       | int    | `443`         | Port for the Redfish endpoint                                      |
+| topohub.defaultConfig.redfish.https      | bool   | `true`        | Enable HTTPS for Redfish                                           |
+| topohub.defaultConfig.redfish.username    | string | `"admin"`     | Username for Redfish authentication                                 |
+| topohub.defaultConfig.redfish.password    | string | `"secret"`    | Password for Redfish authentication                                 |
+| topohub.defaultConfig.redfish.hostStatusUpdateInterval | int | `60`   | Status update interval in seconds for Redfish                     |
+| topohub.defaultConfig.dhcpServer.interface | string | `""`         | Host network interface for DHCP server                             |
+| topohub.defaultConfig.dhcpServer.expireTime | string | `"1d"`       | Expiration time for DHCP leases in the format of 1 day           |
+| topohub.defaultConfig.httpServer.enabled   | bool   | `true`       | Enable HTTP server for ISO and ZTP in DHCP subnet                 |
+| topohub.defaultConfig.httpServer.port      | int    | `80`         | Port for the HTTP server                                           |
+| topohub.storage.type                      | string | `"hostPath"`  | Storage type for lease and config files                            |
+| topohub.storage.pvc.storageClass          | string | `""`          | Storage class for PVCs                                            |
+| topohub.storage.pvc.size                  | string | `"10Gi"`     | Storage size for new PVCs                                         |
+| topohub.storage.pvc.accessModes           | list   | `["ReadWriteOnce"]` | Access modes for PVC                                       |
+| topohub.storage.hostPath.path             | string | `"/var/lib/topohub"` | Path on the host for HostPath storage                  |
+| topohub.logLevel                         | string | `"info"`      | Log level configuration                                            |
+| topohub.metricsPort                      | int    | `8083`        | Port for the metrics server                                        |
+| topohub.healthProbePort                  | int    | `8081`        | Port for health probes                                             |
+| topohub.webhook.webhookPort              | int    | `8082`        | Port for the webhook server                                        |
+| topohub.webhook.timeoutSeconds            | int    | `5`           | Timeout for webhook calls in seconds                              |
+| topohub.webhook.failurePolicy             | string | `"Fail"`      | Failure policy for webhook                                         |
+| topohub.webhook.certificate.validityDays | int    | `36500`       | Validity duration of the webhook certificate in days              |
+| topohub.serviceAccount.create             | bool   | `true`        | Specifies whether to create a service account                      |
+| topohub.serviceAccount.name               | string | `""`          | Name of the service account, generated if not set                 |
+| topohub.podAnnotations                    | object | `{}`          | Annotations to add to the pod                                      |
+----------------------------------------------
+
+## Configuration and installation details
+
+### Quick Install
+
+```bash
+helm repo add topohub https://infrastructure-io.github.io/topohub
+helm repo update
+
+# Create configuration file
+cat << EOF > values.yaml
+replicaCount: 1
+
+# For users in China, you can use the following Chinese mirror source
+#image:
+#  registry: "ghcr.m.daocloud.io"
+
+defaultConfig:
+  redfish:
+    # Default username to connect to the host BMC
+    username: "<<BmcDefaultUsername>>"
+    # Default password to connect to the host BMC
+    password: "<<BmcDefaultPassword>>"
+  dhcpServer:
+    # The network interface name that can access all management device networks on the node, which is connected to the switch in trunk mode
+    interface: "eth1"
+
+storage:
+  # Use hostPath for POC scenarios; please use PVC in production environments
+  type: "hostPath"
+
+fileBrowser:
+  # Enable filebrowser service, which provides a web UI to manage configuration files and ISO files
+  enabled: true
+
+  # For users in China, you can use the following Chinese mirror source
+  #image:
+  #  registry: "docker.m.daocloud.io"
+EOF
+
+# Install Topohub components
+helm install topohub topohub/topohub \
+    --namespace topohub  --create-namespace  --wait \
+    -f values.yaml
+```

--- a/charts/topohub/parent/values.schema.json
+++ b/charts/topohub/parent/values.schema.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"type": "object",
+	"properties": {
+	 "topohub": {
+	  "type": "object",
+	  "title": "Topohub Settings",
+	  "properties": {
+	   "defaultConfig": {
+	    "type": "object",
+	    "title": "Base Config",
+	    "properties": {
+	     "redfish": {
+		"type": "object",
+		"title": "BMC",
+		"description": "BMC is a component for managing and monitoring server hardware",
+		"properties": {
+		 "username": {
+		  "type": "string",
+		  "title": "Username"
+		 },
+		 "password": {
+		  "type": "string",
+		  "title": "Password"
+		 }
+		}
+	     },
+	     "dhcpServer": {
+		"type": "object",
+		"title": "DHCP Server",
+		"description": "DHCP server is a component for assigning IP addresses to network devices",
+		"required": [
+		 "interface"
+		],
+		"properties": {
+		 "interface": {
+		  "type": "string",
+		  "title": "Interface",
+		  "description": "Topohub component looking for the node's network interface to connect to the switch in trunk mode"
+		 }
+		}
+	     }
+	    }
+	   },
+	   "fileBrowser": {
+	    "type": "object",
+	    "title": "File Browser Configuration",
+	    "description": "File management application that allows users to upload ISO images through a web UI",
+	    "properties": {
+	     "enabled": {
+		"type": "boolean",
+		"default": true,
+		"title": "Enable File Browser"
+	     }
+	    }
+	   },
+	   "nodeName": {
+	    "type": "string",
+	    "title": "Topohub working node",
+	    "description": "Specify the node name where topohub will run. Only single-node deployment is supported."
+	   }
+	  },
+	  "required": [
+	   "nodeName"
+	  ]
+	 }
+	}
+}

--- a/charts/topohub/topohub/.relok8s-images.yaml
+++ b/charts/topohub/topohub/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .topohub.image.registry }}/{{ .topohub.image.repository }}:{{ .topohub.image.tag }}"
+- "{{ .topohub.fileBrowser.image.registry}}/{{ .topohub.fileBrowser.image.repository }}:{{ .topohub.fileBrowser.image.tag }}"

--- a/charts/topohub/topohub/Chart.yaml
+++ b/charts/topohub/topohub/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+appVersion: 0.4.3
+description: A Helm chart for Topohub
+keywords:
+  - kubernetes
+  - bmc
+  - server
+  - infrastructure
+  - switch
+  - network
+maintainers:
+  - name: infrastructure-io
+    url: https://github.com/infrastructure-io/topohub
+name: topohub
+type: application
+version: 0.4.3
+dependencies:
+  - name: topohub
+    version: "0.4.3"
+    repository: "https://infrastructure-io.github.io/topohub"

--- a/charts/topohub/topohub/README.md
+++ b/charts/topohub/topohub/README.md
@@ -1,0 +1,99 @@
+# topohub
+
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+
+Topohub is a set of Kubernetes components for managing infrastructure, including hosts, switches, and more.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://infrastructure-io.github.io/topohub | topohub | 0.4.2 |
+
+## Values
+
+| Key                                      | Type   | Default       | Description                                                        |
+|------------------------------------------|--------|---------------|--------------------------------------------------------------------|
+| topohub.replicaCount                     | int    | `1`           | Number of replicas for topohub                                      |
+| topohub.registryOverride                 | string | `""`          | Registry override for topohub                                      |
+| topohub.imagePullSecrets                 | list   | `[]`          | List of image pull secrets                                          |
+| topohub.nameOverride                     | string | `""`          | Override for the topohub name                                      |
+| topohub.fullnameOverride                 | string | `""`          | Override for the full name of topohub                              |
+| topohub.image.registry                   | string | `"ghcr.m.daocloud.io"` | Image registry address                                           |
+| topohub.image.repository                 | string | `"infrastructure-io/topohub"` | Image repository name                                            |
+| topohub.image.pullPolicy                 | string | `"IfNotPresent"` | Image pull policy                                                |
+| topohub.image.tag                        | string | `"v0.4.2"`    | Image tag, overridden by version from Chart.yaml                  |
+| topohub.resources.limits.cpu             | string | `"500m"`      | CPU limit for topohub                                             |
+| topohub.resources.limits.memory          | string | `"512Mi"`     | Memory limit for topohub                                          |
+| topohub.resources.requests.cpu            | string | `"100m"`      | CPU request for topohub                                           |
+| topohub.resources.requests.memory         | string | `"128Mi"`     | Memory request for topohub                                        |
+| topohub.defaultConfig.redfish.port       | int    | `443`         | Port for the Redfish endpoint                                      |
+| topohub.defaultConfig.redfish.https      | bool   | `true`        | Enable HTTPS for Redfish                                           |
+| topohub.defaultConfig.redfish.username    | string | `"admin"`     | Username for Redfish authentication                                 |
+| topohub.defaultConfig.redfish.password    | string | `"secret"`    | Password for Redfish authentication                                 |
+| topohub.defaultConfig.redfish.hostStatusUpdateInterval | int | `60`   | Status update interval in seconds for Redfish                     |
+| topohub.defaultConfig.dhcpServer.interface | string | `""`         | Host network interface for DHCP server                             |
+| topohub.defaultConfig.dhcpServer.expireTime | string | `"1d"`       | Expiration time for DHCP leases in the format of 1 day           |
+| topohub.defaultConfig.httpServer.enabled   | bool   | `true`       | Enable HTTP server for ISO and ZTP in DHCP subnet                 |
+| topohub.defaultConfig.httpServer.port      | int    | `80`         | Port for the HTTP server                                           |
+| topohub.storage.type                      | string | `"hostPath"`  | Storage type for lease and config files                            |
+| topohub.storage.pvc.storageClass          | string | `""`          | Storage class for PVCs                                            |
+| topohub.storage.pvc.size                  | string | `"10Gi"`     | Storage size for new PVCs                                         |
+| topohub.storage.pvc.accessModes           | list   | `["ReadWriteOnce"]` | Access modes for PVC                                       |
+| topohub.storage.hostPath.path             | string | `"/var/lib/topohub"` | Path on the host for HostPath storage                  |
+| topohub.logLevel                         | string | `"info"`      | Log level configuration                                            |
+| topohub.metricsPort                      | int    | `8083`        | Port for the metrics server                                        |
+| topohub.healthProbePort                  | int    | `8081`        | Port for health probes                                             |
+| topohub.webhook.webhookPort              | int    | `8082`        | Port for the webhook server                                        |
+| topohub.webhook.timeoutSeconds            | int    | `5`           | Timeout for webhook calls in seconds                              |
+| topohub.webhook.failurePolicy             | string | `"Fail"`      | Failure policy for webhook                                         |
+| topohub.webhook.certificate.validityDays | int    | `36500`       | Validity duration of the webhook certificate in days              |
+| topohub.serviceAccount.create             | bool   | `true`        | Specifies whether to create a service account                      |
+| topohub.serviceAccount.name               | string | `""`          | Name of the service account, generated if not set                 |
+| topohub.podAnnotations                    | object | `{}`          | Annotations to add to the pod                                      |
+----------------------------------------------
+
+## Configuration and installation details
+
+### Quick Install
+
+```bash
+helm repo add topohub https://infrastructure-io.github.io/topohub
+helm repo update
+
+# Create configuration file
+cat << EOF > values.yaml
+replicaCount: 1
+
+# For users in China, you can use the following Chinese mirror source
+#image:
+#  registry: "ghcr.m.daocloud.io"
+
+defaultConfig:
+  redfish:
+    # Default username to connect to the host BMC
+    username: "<<BmcDefaultUsername>>"
+    # Default password to connect to the host BMC
+    password: "<<BmcDefaultPassword>>"
+  dhcpServer:
+    # The network interface name that can access all management device networks on the node, which is connected to the switch in trunk mode
+    interface: "eth1"
+
+storage:
+  # Use hostPath for POC scenarios; please use PVC in production environments
+  type: "hostPath"
+
+fileBrowser:
+  # Enable filebrowser service, which provides a web UI to manage configuration files and ISO files
+  enabled: true
+
+  # For users in China, you can use the following Chinese mirror source
+  #image:
+  #  registry: "docker.m.daocloud.io"
+EOF
+
+# Install Topohub components
+helm install topohub topohub/topohub \
+    --namespace topohub  --create-namespace  --wait \
+    -f values.yaml
+```

--- a/charts/topohub/topohub/charts/topohub/Chart.yaml
+++ b/charts/topohub/topohub/charts/topohub/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+appVersion: 0.4.3
+description: A Helm chart for Topohub
+keywords:
+- kubernetes
+- bmc
+- server
+- infrastructure
+- switch
+- network
+maintainers:
+- name: infrastructure-io
+  url: https://github.com/infrastructure-io/topohub
+name: topohub
+type: application
+version: 0.4.3

--- a/charts/topohub/topohub/charts/topohub/README.md
+++ b/charts/topohub/topohub/charts/topohub/README.md
@@ -1,0 +1,2 @@
+# Helm Chart for Topohub
+

--- a/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_bindingips.yaml
+++ b/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_bindingips.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: bindingips.topohub.infrastructure.io
+spec:
+  group: topohub.infrastructure.io
+  names:
+    kind: BindingIp
+    listKind: BindingIpList
+    plural: bindingips
+    singular: bindingip
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.subnet
+      name: SUBNET
+      type: string
+    - jsonPath: .spec.ipAddr
+      name: IPADDR
+      type: string
+    - jsonPath: .spec.macAddr
+      name: MACADDR
+      type: string
+    - jsonPath: .status.valid
+      name: VALID
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              ipAddr:
+                description: IP address (required)
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+                type: string
+              macAddr:
+                description: Mac address (required)
+                pattern: ^([0-9a-fA-F]{2}:){5}([0-9a-fA-F]{2})$
+                type: string
+              subnet:
+                description: subnet name (required)
+                type: string
+            required:
+            - ipAddr
+            - macAddr
+            - subnet
+            type: object
+          status:
+            properties:
+              valid:
+                description: taking effect
+                type: boolean
+            required:
+            - valid
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hostendpoints.yaml
+++ b/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hostendpoints.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: hostendpoints.topohub.infrastructure.io
+spec:
+  group: topohub.infrastructure.io
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterName
+      name: CLUSTERNAME
+      type: string
+    - jsonPath: .spec.ipAddr
+      name: HOSTIP
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostEndpoint is the Schema for the hostendpoints API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec defines the desired state of HostEndpoint
+            properties:
+              clusterName:
+                description: ClusterName specifies which clusterName this hostEndpoint
+                  belongs to
+                type: string
+              https:
+                default: true
+                description: HTTPS specifies whether to use HTTPS for communication
+                type: boolean
+              ipAddr:
+                description: IPAddr is the IP address of the host endpoint
+                type: string
+              port:
+                default: 443
+                description: Port specifies the port number for communication
+                format: int32
+                type: integer
+              secretName:
+                description: SecretName is the name of the secret containing credentials
+                type: string
+              secretNamespace:
+                description: SecretNamespace is the namespace of the secret containing
+                  credentials
+                type: string
+            required:
+            - ipAddr
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hostoperations.yaml
+++ b/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hostoperations.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: hostoperations.topohub.infrastructure.io
+spec:
+  group: topohub.infrastructure.io
+  names:
+    kind: HostOperation
+    listKind: HostOperationList
+    plural: hostoperations
+    singular: hostoperation
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.action
+      name: ACTION
+      type: string
+    - jsonPath: .status.status
+      name: STATUS
+      type: string
+    - jsonPath: .status.clusterName
+      name: CLUSTERNAME
+      type: string
+    - jsonPath: .status.ipAddr
+      name: HOSTIP
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              action:
+                enum:
+                - ForceOn
+                - "On"
+                - ForceOff
+                - GracefulShutdown
+                - ForceRestart
+                - GracefulRestart
+                - PxeReboot
+                type: string
+              hostStatusName:
+                type: string
+            required:
+            - action
+            - hostStatusName
+            type: object
+          status:
+            properties:
+              clusterName:
+                type: string
+              ipAddr:
+                type: string
+              lastUpdateTime:
+                type: string
+              message:
+                type: string
+              status:
+                enum:
+                - pending
+                - success
+                - failure
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hoststatuses.yaml
+++ b/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_hoststatuses.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: hoststatuses.topohub.infrastructure.io
+spec:
+  group: topohub.infrastructure.io
+  names:
+    kind: HostStatus
+    listKind: HostStatusList
+    plural: hoststatuses
+    singular: hoststatus
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.basic.clusterName
+      name: CLUSTERNAME
+      type: string
+    - jsonPath: .status.healthy
+      name: HEALTHY
+      type: boolean
+    - jsonPath: .status.basic.ipAddr
+      name: IPADDR
+      type: string
+    - jsonPath: .status.basic.type
+      name: TYPE
+      type: string
+    - jsonPath: .status.log.warningLogAccount
+      name: WARNING
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            properties:
+              basic:
+                properties:
+                  activeDhcpClient:
+                    description: ActiveDhcpClient specifies this host is an active
+                      dhcp client when type is dhcp
+                    type: boolean
+                  clusterName:
+                    type: string
+                  dhcpExpireTime:
+                    type: string
+                  hostname:
+                    type: string
+                  https:
+                    type: boolean
+                  ipAddr:
+                    type: string
+                  mac:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                  secretName:
+                    type: string
+                  secretNamespace:
+                    type: string
+                  subnetName:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - clusterName
+                - https
+                - ipAddr
+                - port
+                - secretName
+                - secretNamespace
+                - type
+                type: object
+              healthy:
+                type: boolean
+              info:
+                additionalProperties:
+                  type: string
+                type: object
+              lastUpdateTime:
+                type: string
+              log:
+                properties:
+                  lastestLog:
+                    properties:
+                      message:
+                        type: string
+                      time:
+                        type: string
+                    required:
+                    - message
+                    - time
+                    type: object
+                  lastestWarningLog:
+                    properties:
+                      message:
+                        type: string
+                      time:
+                        type: string
+                    required:
+                    - message
+                    - time
+                    type: object
+                  totalLogAccount:
+                    format: int32
+                    type: integer
+                  warningLogAccount:
+                    format: int32
+                    type: integer
+                required:
+                - totalLogAccount
+                - warningLogAccount
+                type: object
+            required:
+            - basic
+            - healthy
+            - info
+            - lastUpdateTime
+            - log
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_subnets.yaml
+++ b/charts/topohub/topohub/charts/topohub/crds/topohub.infrastructure.io_subnets.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: subnets.topohub.infrastructure.io
+spec:
+  group: topohub.infrastructure.io
+  names:
+    kind: Subnet
+    listKind: SubnetList
+    plural: subnets
+    singular: subnet
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipv4Subnet.subnet
+      name: SUBNET
+      type: string
+    - jsonPath: .spec.interface.ipv4
+      name: SERVER_IP
+      type: string
+    - jsonPath: .status.dhcpStatus.dhcpIpTotalAmount
+      name: IP_TOTAL
+      type: integer
+    - jsonPath: .status.dhcpStatus.dhcpIpAvailableAmount
+      name: IP_AVAILABLE
+      type: integer
+    - jsonPath: .status.dhcpStatus.dhcpIpBindAmount
+      name: IP_RESERVED
+      type: integer
+    - jsonPath: .spec.feature.syncHoststatus.enabled
+      name: SYNC_HOSTSTATUS
+      type: boolean
+    - jsonPath: .spec.feature.enablePxe
+      name: PXE
+      type: boolean
+    - jsonPath: .spec.feature.enableZtp
+      name: ZTP
+      type: boolean
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Subnet is the Schema for the subnets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SubnetSpec defines the desired state of Subnet
+            properties:
+              feature:
+                description: Feature configuration
+                properties:
+                  enablePxe:
+                    default: false
+                    description: Enable PXE boot support
+                    type: boolean
+                  enableZtp:
+                    default: false
+                    description: Enable ZTP configuration for switch
+                    type: boolean
+                  syncHoststatus:
+                    description: SyncHoststatus configuration
+                    properties:
+                      defaultClusterName:
+                        description: Default cluster name
+                        type: string
+                      enableBindDhcpIP:
+                        default: true
+                        description: Enable bind dhcp ip
+                        type: boolean
+                      enabled:
+                        default: false
+                        description: Enable automatically create the hoststatus object
+                          for the dhcp client. Notice, it will not be deleted automatically
+                        type: boolean
+                    required:
+                    - enableBindDhcpIP
+                    - enabled
+                    type: object
+                required:
+                - enablePxe
+                - enableZtp
+                - syncHoststatus
+                type: object
+              interface:
+                description: Interface configuration
+                properties:
+                  interface:
+                    description: DHCP server interface (required)
+                    type: string
+                  ipv4:
+                    description: Self IP for DHCP server (required)
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$
+                    type: string
+                  vlanId:
+                    description: VLAN ID (optional, 0-4094)
+                    format: int32
+                    maximum: 4094
+                    minimum: 0
+                    type: integer
+                required:
+                - interface
+                - ipv4
+                type: object
+              ipv4Subnet:
+                description: IPv4Subnet configuration
+                properties:
+                  dns:
+                    description: DNS server (optional)
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+                    type: string
+                  gateway:
+                    description: Gateway for DHCP server (optional)
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+                    type: string
+                  ipRange:
+                    description: IPRange for DHCP server (required)
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}-([0-9]{1,3}\.){3}[0-9]{1,3}(,([0-9]{1,3}\.){3}[0-9]{1,3}-([0-9]{1,3}\.){3}[0-9]{1,3})*$
+                    type: string
+                  subnet:
+                    description: Subnet for DHCP server (required)
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$
+                    type: string
+                required:
+                - ipRange
+                - subnet
+                type: object
+            required:
+            - interface
+            - ipv4Subnet
+            type: object
+          status:
+            description: SubnetStatus defines the observed state of Subnet
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              dhcpClientDetails:
+                description: Dhcp client details
+                type: string
+              dhcpStatus:
+                description: Dhcp ip status
+                properties:
+                  dhcpIpActiveAmount:
+                    description: Number of assigned IP addresses which is in use in
+                      the lease file
+                    format: int64
+                    type: integer
+                  dhcpIpAvailableAmount:
+                    description: Number of available IP addresses
+                    format: int64
+                    type: integer
+                  dhcpIpBindAmount:
+                    description: Number of reserved IP addresses which is bond to
+                      MAC address
+                    format: int64
+                    type: integer
+                  dhcpIpTotalAmount:
+                    description: Total number of IP addresses in the subnet
+                    format: int64
+                    type: integer
+                required:
+                - dhcpIpActiveAmount
+                - dhcpIpAvailableAmount
+                - dhcpIpBindAmount
+                - dhcpIpTotalAmount
+                type: object
+              hostNode:
+                description: the name of the node who hosts the subnet
+                type: string
+            required:
+            - dhcpClientDetails
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/topohub/topohub/charts/topohub/templates/_helpers.tpl
+++ b/charts/topohub/topohub/charts/topohub/templates/_helpers.tpl
@@ -1,0 +1,98 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "topohub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "topohub.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "topohub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "topohub.labels" -}}
+helm.sh/chart: {{ include "topohub.chart" . }}
+{{ include "topohub.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "topohub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "topohub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "topohub.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "topohub.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+return the image
+*/}}
+{{- define "topohub.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- if .Values.registryOverride }}
+{{- $registryName = .Values.registryOverride }}
+{{- end }}
+{{- $repositoryName := .Values.image.repository -}}
+{{- printf "%s/%s" $registryName $repositoryName -}}
+{{- if .Values.image.digest }}
+    {{- print "@" .Values.image.digest -}}
+{{- else if .Values.image.tag -}}
+    {{- printf ":%s" (toString .Values.image.tag) -}}
+{{- else -}}
+    {{- printf ":v%s" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+return the image
+*/}}
+{{- define "fileBrowser.image" -}}
+{{- $registryName := .Values.fileBrowser.image.registry -}}
+{{- if .Values.registryOverride }}
+{{- $registryName = .Values.registryOverride }}
+{{- end }}
+{{- $repositoryName := .Values.fileBrowser.image.repository -}}
+{{- printf "%s/%s" $registryName $repositoryName -}}
+{{- if .Values.fileBrowser.image.digest }}
+    {{- print "@" .Values.fileBrowser.image.digest -}}
+{{- else if .Values.fileBrowser.image.tag -}}
+    {{- printf ":%s" (toString .Values.fileBrowser.image.tag) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/topohub/topohub/charts/topohub/templates/configmap-dhcp.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/configmap-dhcp.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "topohub.fullname" . }}-dhcp
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+data:
+  dnsmasq.conf.tmpl: |
+    # Basic DHCP configuration
+    dhcp-authoritative
+    dhcp-leasefile={{ "{{ .LeaseFile }}" }}
+    log-facility={{ "{{ .LogFile }}" }}
+    log-dhcp
+    bind-interfaces
+    interface={{ "{{ .Interface }}" }}
+    listen-address={{ "{{ .SelfIP }}" }}
+
+    # DHCP range configuration
+    # format: <start_ip>,<end_ip>,<lease_time>  or <start_ip>,<end_ip>
+    {{ "{{ range .IPRanges }}" }}
+    dhcp-range={{ "{{ . }}" }},{{ .Values.defaultConfig.dhcpServer.expireTime }}
+    {{ "{{ end }}" }}
+
+    # Gateway configuration
+    {{ "{{ if .Gateway }}" }}
+    dhcp-option=3,{{ "{{ .Gateway }}" }}  # Default gateway
+    {{ "{{ end }}" }}
+
+    # DNS configuration
+    {{ "{{ if .DNS }}" }}
+    dhcp-option=6,{{ "{{ .DNS }}" }}  # DNS server
+    {{ "{{ end }}" }}
+
+    # PXE boot configuration
+    {{ "{{ if .EnablePxe }}" }}
+    # Enable TFTP server
+    enable-tftp
+    tftp-root={{ "{{ .TftpServerDir }}" }}
+    
+    # PXE boot menu
+    dhcp-match=set:efi-x86_64,option:client-arch,7
+    dhcp-boot=tag:efi-x86_64,{{ "{{ .PxeEfiInTftpServerDir }}" }}/core.efi
+    {{ "{{ end }}" }}
+
+    
+    {{ "{{ if .EnableZtp }}" }}
+    # DHCP options for ZTP
+    dhcp-option=67,http://{{ "{{ .SelfIP }}" }}/ztp/ztp.json
+    {{ "{{ end }}" }}
+
+    conf-file={{ "{{ .HostIpBindingsConfigPath }}" }}
+
+    # Additional options
+    # Disable DNS server functionality
+    port=0
+    # Disable re-use of the DHCP servername and filename fields as extra option space
+    dhcp-no-override
+    # Don't read /etc/hosts
+    no-hosts
+
+    # Logging configuration
+    log-queries
+    log-dhcp
+    quiet-dhcp6
+
+    # Performance tuning
+    # cache-size=150
+    no-resolv
+    no-poll

--- a/charts/topohub/topohub/charts/topohub/templates/configmap-feature.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/configmap-feature.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "topohub.fullname" . }}-feature
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+data:
+  redfishPort: {{ .Values.defaultConfig.redfish.port | quote }}
+  redfishHttps: {{ .Values.defaultConfig.redfish.https | quote }}
+  redfishSecretname: {{ include "topohub.fullname" . }}-redfish-auth
+  redfishSecretNamespace: {{ .Release.Namespace }}
+  redfishHostStatusUpdateInterval: {{ .Values.defaultConfig.redfish.hostStatusUpdateInterval | quote }}
+  dhcpServerInterface: {{ .Values.defaultConfig.dhcpServer.interface | quote }}
+  httpServerPort: {{ .Values.defaultConfig.httpServer.port | quote }}
+  httpServerEnabled: {{ .Values.defaultConfig.httpServer.enabled | quote }}
+

--- a/charts/topohub/topohub/charts/topohub/templates/deployment.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/deployment.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "topohub.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "topohub.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "topohub.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "topohub.serviceAccountName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeName }}
+      nodeName: {{ .Values.nodeName }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                {{- include "topohub.selectorLabels" . | nindent 16 }}
+            topologyKey: kubernetes.io/hostname
+        {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      hostNetwork: true
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ include "topohub.image" . | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        command: ["topohub"]
+        args:
+        - --metrics-port={{ .Values.metricsPort }}
+        - --health-probe-port={{ .Values.healthProbePort }}
+        - --webhook-port={{ .Values.webhook.webhookPort }}
+        {{- with .Values.extraArgs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LOG_LEVEL
+          value: {{ .Values.logLevel | default "info" | quote }}
+        - name: STORAGE_PATH
+          value: /var/lib/topohub
+        - name: WEBHOOK_CERT_DIR
+          value: /tmp/k8s-webhook-server/serving-certs  
+        - name: FEATURE_CONFIG_PATH
+          value: /var/lib/feature
+        - name: DHCP_CONFIG_TEMPLATE_PATH
+          value: /var/lib/dhcp
+        ports:
+        - name: webhook
+          containerPort: {{ .Values.webhook.webhookPort }}
+          protocol: TCP
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          protocol: TCP
+        - name: health-probe
+          containerPort: {{ .Values.healthProbePort }}
+          protocol: TCP
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        - name: storage-data
+          mountPath: /var/lib/topohub
+        - name: feature-config
+          mountPath: /var/lib/feature  
+        - name: dhcp-config
+          mountPath: /var/lib/dhcp
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.healthProbePort }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .Values.healthProbePort }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.fileBrowser.enabled }}
+      - name: http-server
+        image:  {{ include "fileBrowser.image" . | quote }}
+        imagePullPolicy: {{ .Values.fileBrowser.image.pullPolicy }}
+        command: ["/filebrowser"]
+        args:
+        - --port={{ .Values.fileBrowser.port }}
+        - --root=/var/lib/topohub
+        - --database=/var/lib/topohub/filebrowser/filebrowser.db
+        ports:
+        - name: http
+          containerPort: {{ .Values.fileBrowser.port }}
+          protocol: TCP
+        volumeMounts:
+        - name: storage-data
+          mountPath: /var/lib/topohub
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.fileBrowser.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.fileBrowser.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.fileBrowser.resources | nindent 12 }}
+      {{- end }}
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: {{ include "topohub.fullname" . }}-webhook-server-cert
+      - name: dhcp-config
+        configMap:
+          name: {{ include "topohub.fullname" . }}-dhcp
+      - name: feature-config
+        configMap:
+          name: {{ include "topohub.fullname" . }}-feature
+      - name: storage-data
+      {{- if eq .Values.storage.type "pvc" }}
+        persistentVolumeClaim:
+          claimName: {{ include "topohub.fullname" . }}-data
+      {{- else }}
+        hostPath:
+          path: {{ .Values.storage.hostPath.path }}
+          type: DirectoryOrCreate
+      {{- end }}

--- a/charts/topohub/topohub/charts/topohub/templates/pvc.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if eq .Values.storage.type "pvc" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "topohub.fullname" . }}-data
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.storage.pvc.storageClass }}
+  storageClassName: {{ .Values.storage.pvc.storageClass }}
+  {{- end }}
+  accessModes:
+  {{- range .Values.storage.pvc.accessModes }}
+    - {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.pvc.size }}
+{{- end }}

--- a/charts/topohub/topohub/charts/topohub/templates/rbac.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/rbac.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "topohub.fullname" . }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - topohub.infrastructure.io
+  resources:
+  - hostendpoints
+  - hostendpoints/status
+  - hoststatuses
+  - hoststatuses/status
+  - hostoperations
+  - hostoperations/status
+  - subnets
+  - subnets/status
+  - bindingips
+  - bindingips/status
+  verbs:
+  - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "topohub.fullname" . }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "topohub.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "topohub.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/topohub/topohub/charts/topohub/templates/secret.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "topohub.fullname" . }}-redfish-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+type: Opaque
+data:
+  username: {{ .Values.defaultConfig.redfish.username | b64enc | quote }}
+  password: {{ .Values.defaultConfig.redfish.password | b64enc | quote }}

--- a/charts/topohub/topohub/charts/topohub/templates/service.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "topohub.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.webhook.webhookPort }}
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
+  selector:
+    {{- include "topohub.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "topohub.fullname" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "topohub.selectorLabels" . | nindent 4 }}

--- a/charts/topohub/topohub/charts/topohub/templates/serviceaccount.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "topohub.serviceAccountName" . }}
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/topohub/topohub/charts/topohub/templates/webhook.yaml
+++ b/charts/topohub/topohub/charts/topohub/templates/webhook.yaml
@@ -1,0 +1,214 @@
+{{- $validityDays := int .Values.webhook.certificate.validityDays }}
+{{- $ca := genCA "topohub-ca" $validityDays }}
+{{- $cn := include "topohub.fullname" . }}
+{{- $altNames := list (printf "%s-webhook-service.%s.svc" $cn .Release.Namespace) (printf "%s-webhook-service.%s.svc.cluster.local" $cn .Release.Namespace) }}
+{{- $cert := genSignedCert $cn nil $altNames $validityDays $ca }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "topohub.fullname" . }}-webhook-server-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "topohub.fullname" . }}-webhook
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "topohub.fullname" . }}-validating-webhook-configuration
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+webhooks:
+- name: subnet.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-topohub-infrastructure-io-v1beta1-subnet
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["subnets"]
+    scope: "Cluster"
+- name: hostendpoint.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-topohub-infrastructure-io-v1beta1-hostendpoint
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hostendpoints"]
+    scope: "Cluster"
+- name: hostoperation.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-topohub-infrastructure-io-v1beta1-hostoperation
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hostoperations"]
+    scope: "Cluster"
+- name: hoststatus.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-topohub-infrastructure-io-v1beta1-hoststatus
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hoststatuses"]
+    scope: "Cluster"
+- name: bindingip.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-topohub-infrastructure-io-v1beta1-bindingip
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["bindingips"]
+    scope: "Cluster"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "topohub.fullname" . }}-mutating-webhook-configuration
+  labels:
+    {{- include "topohub.labels" . | nindent 4 }}
+webhooks:
+- name: hostendpoint.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-topohub-infrastructure-io-v1beta1-hostendpoint
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hostendpoints"]
+    scope: "Cluster"
+- name: hostoperation.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-topohub-infrastructure-io-v1beta1-hostoperation
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hostoperations"]
+    scope: "Cluster"
+- name: subnet.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-topohub-infrastructure-io-v1beta1-subnet
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["subnets"]
+    scope: "Cluster"
+- name: hoststatus.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-topohub-infrastructure-io-v1beta1-hoststatus
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["hoststatuses"]
+    scope: "Cluster"
+- name: bindingip.topohub.infrastructure.io
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "topohub.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-topohub-infrastructure-io-v1beta1-bindingip
+      port: {{ .Values.webhook.webhookPort }}
+    caBundle: {{ $ca.Cert | b64enc }}
+  rules:
+  - apiGroups: ["topohub.infrastructure.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["bindingips"]
+    scope: "Cluster"

--- a/charts/topohub/topohub/charts/topohub/values.yaml
+++ b/charts/topohub/topohub/charts/topohub/values.yaml
@@ -1,0 +1,146 @@
+replicaCount: 1
+
+registryOverride: ""
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: "ghcr.io"
+  repository: "infrastructure-io/topohub"
+  pullPolicy: IfNotPresent
+  # tag will be overridden by version from Chart.yaml
+  tag: ""
+  # Optional: image digest
+  digest: ""
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+defaultConfig:
+  redfish:
+    # Port for the endpoint (default: 443)
+    port: 443
+    # Enable HTTPS (default: true)
+    https: true
+    # Optional: Authentication credentials
+    username: "admin"
+    password: "secret"
+    # 状态更新间隔，它决定了多久向主机发送一次redfish请求，来更新 hostStatus 对象中的信息，默认 60 秒
+    hostStatusUpdateInterval: 60
+
+  dhcpServer:
+    # 宿主机网卡名，最好是 trunk 模式接入网络，从而接入到各种子网中
+    interface: ""
+    # 1 day
+    expireTime: "1d"
+
+  # for iso and ztp in dchp subnet
+  httpServer:
+    enabled: true
+    # Port for the endpoint (default: 10080)
+    port: 80
+
+# Storage configuration for DHCP lease files、DHCP configuration files、sftp storage、http storage（ISO）
+storage:
+  # Storage type: "pvc" or "hostPath"
+  type: "hostPath"
+
+  # PVC configuration (used when type is "pvc")
+  # this should be used when production environment
+  pvc:
+    # Storage class for new PVC
+    storageClass: ""
+    # Storage size for new PVC, it is used to store config files and ISO files
+    size: "10Gi"
+    # Access modes for PVC
+    accessModes:
+      - ReadWriteOnce
+
+  # HostPath configuration (used when type is "hostPath")
+  # this should be used only when POC environment, and it should designate the node name
+  hostPath:
+    # Path on the host
+    path: "/var/lib/topohub"
+
+# Log level configuration
+# Available values: debug, info, error
+logLevel: "info"
+
+# Port for metrics server
+metricsPort: 8083
+
+# Health probe port
+healthProbePort: 8081
+
+# Webhook configuration
+webhook:
+  # Port for webhook server to listen on and service to expose
+  webhookPort: 8082
+  # Timeout in seconds for webhook calls
+  timeoutSeconds: 5
+  # Failure policy for webhook
+  failurePolicy: Fail
+  # Certificate configuration
+  certificate:
+    # Validity duration in days
+    validityDays: 36500
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+
+nodeSelector: {}
+
+# Specify a specific node by name
+nodeName: ""
+
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: infrastructure.io/deploy
+        operator: In
+        values:
+        - "true"
+
+## @param topohub.extraArgs the additional arguments of topohub container
+extraArgs: []
+
+## @skip spiderpoolAgent.tolerations
+tolerations:
+  - operator: Exists
+
+## this is used to manage the files for the administrator
+fileBrowser:
+  enabled: false
+  
+  image:
+    registry: "docker.io"
+    repository: "filebrowser/filebrowser"
+    pullPolicy: IfNotPresent
+    # tag will be overridden by version from Chart.yaml
+    tag: "v2.32.0"
+    # Optional: image digest
+    digest: ""
+
+  port: 8080
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/charts/topohub/topohub/values.schema.json
+++ b/charts/topohub/topohub/values.schema.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"type": "object",
+	"properties": {
+	 "topohub": {
+	  "type": "object",
+	  "title": "Topohub Settings",
+	  "properties": {
+	   "defaultConfig": {
+	    "type": "object",
+	    "title": "Base Config",
+	    "properties": {
+	     "redfish": {
+		"type": "object",
+		"title": "BMC",
+		"description": "BMC is a component for managing and monitoring server hardware",
+		"properties": {
+		 "username": {
+		  "type": "string",
+		  "title": "Username"
+		 },
+		 "password": {
+		  "type": "string",
+		  "title": "Password"
+		 }
+		}
+	     },
+	     "dhcpServer": {
+		"type": "object",
+		"title": "DHCP Server",
+		"description": "DHCP server is a component for assigning IP addresses to network devices",
+		"required": [
+		 "interface"
+		],
+		"properties": {
+		 "interface": {
+		  "type": "string",
+		  "title": "Interface",
+		  "description": "Topohub component looking for the node's network interface to connect to the switch in trunk mode"
+		 }
+		}
+	     }
+	    }
+	   },
+	   "fileBrowser": {
+	    "type": "object",
+	    "title": "File Browser Configuration",
+	    "description": "File management application that allows users to upload ISO images through a web UI",
+	    "properties": {
+	     "enabled": {
+		"type": "boolean",
+		"default": true,
+		"title": "Enable File Browser"
+	     }
+	    }
+	   },
+	   "nodeName": {
+	    "type": "string",
+	    "title": "Topohub working node",
+	    "description": "Specify the node name where topohub will run. Only single-node deployment is supported."
+	   }
+	  },
+	  "required": [
+	   "nodeName"
+	  ]
+	 }
+	}
+}

--- a/charts/topohub/topohub/values.yaml
+++ b/charts/topohub/topohub/values.yaml
@@ -1,0 +1,124 @@
+# child values
+topohub:
+  replicaCount: 1
+  registryOverride: ""
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+  image:
+    registry: "ghcr.m.daocloud.io"
+    repository: "infrastructure-io/topohub"
+    pullPolicy: IfNotPresent
+    # tag will be overridden by version from Chart.yaml
+    tag: "v0.4.3"
+    # Optional: image digest
+    digest: ""
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  defaultConfig:
+    redfish:
+      # Port for the endpoint (default: 443)
+      port: 443
+      # Enable HTTPS (default: true)
+      https: true
+      # Optional: Authentication credentials
+      username: "admin"
+      password: "secret"
+      # 状态更新间隔，它决定了多久向主机发送一次redfish请求，来更新 hostStatus 对象中的信息，默认 60 秒
+      hostStatusUpdateInterval: 60
+    dhcpServer:
+      # 宿主机网卡名，最好是 trunk 模式接入网络，从而接入到各种子网中
+      interface: ""
+      # 1 day
+      expireTime: "1d"
+    # for iso and ztp in dchp subnet
+    httpServer:
+      enabled: true
+      # Port for the endpoint (default: 10080)
+      port: 80
+  # Storage configuration for DHCP lease files、DHCP configuration files、sftp storage、http storage（ISO）
+  storage:
+    # Storage type: "pvc" or "hostPath"
+    type: "hostPath"
+    # PVC configuration (used when type is "pvc")
+    # this should be used when production environment
+    pvc:
+      # Storage class for new PVC
+      storageClass: ""
+      # Storage size for new PVC, it is used to store config files and ISO files
+      size: "10Gi"
+      # Access modes for PVC
+      accessModes:
+        - ReadWriteOnce
+    # HostPath configuration (used when type is "hostPath")
+    # this should be used only when POC environment, and it should designate the node name
+    hostPath:
+      # Path on the host
+      path: "/var/lib/topohub"
+  # Log level configuration
+  # Available values: debug, info, error
+  logLevel: "info"
+  # Port for metrics server
+  metricsPort: 8083
+  # Health probe port
+  healthProbePort: 8081
+  # Webhook configuration
+  webhook:
+    # Port for webhook server to listen on and service to expose
+    webhookPort: 8082
+    # Timeout in seconds for webhook calls
+    timeoutSeconds: 5
+    # Failure policy for webhook
+    failurePolicy: Fail
+    # Certificate configuration
+    certificate:
+      # Validity duration in days
+      validityDays: 36500
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    annotations: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  # Specify a specific node by name
+  nodeName: ""
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topohub.io/deployment
+              operator: In
+              values:
+                - "true"
+  ## @param topohub.extraArgs the additional arguments of topohub container
+  extraArgs: []
+  ## @skip spiderpoolAgent.tolerations
+  tolerations:
+    - operator: Exists
+  ## this is used to manage the files for the administrator
+  fileBrowser:
+    enabled: true
+    image:
+      registry: "docker.m.daocloud.io"
+      repository: "filebrowser/filebrowser"
+      pullPolicy: IfNotPresent
+      # tag will be overridden by version from Chart.yaml
+      tag: "v2.32.0"
+      # Optional: image digest
+      digest: ""
+    port: 8080
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi

--- a/test/topohub/install.sh
+++ b/test/topohub/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
+
+KIND_KUBECONFIG=$1
+CHART_VERSION=$3
+
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+[ -n "$CHART_VERSION" ] || { echo "error, failed to find chart version $CHART_VERSION " ; exit 1 ; }
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+echo "CHART_VERSION: $CHART_VERSION"
+
+helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --version ${CHART_VERSION} --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+#==================== notice , prometheus CRD has been deployed , so you no need to =============
+
+set -x
+
+helm install topohub chart-museum/topohub ${HELM_MUST_OPTION}  --namespace topohub --create-namespace \
+  --set topohub.defaultConfig.dhcpServer.interface="eth0" \
+  --set topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=beta.kubernetes.io/os \
+  --set topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
+  --set topohub.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=linux
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+  exit 0
+else
+  echo "error, faild to deploy $CHART_DIR"
+    kubectl --kubeconfig ${KIND_KUBECONFIG} get pod -o wide -A
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #