### PR TITLE
upgrade harbor-operator

### DIFF
--- a/charts/harbor-operator/config
+++ b/charts/harbor-operator/config
@@ -3,7 +3,7 @@ export REPO_URL=https://github.com/goharbor/harbor-operator.git
 export REPO_NAME=harbor-operator
 export CHART_NAME=harbor-operator
 export VERSION=v1.4.0-rc1
-export HARBOR_VERSION=v2.6.3
+export HARBOR_VERSION=v2.7.1
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/harbor-operator/harbor-operator/values.yaml
+++ b/charts/harbor-operator/harbor-operator/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v1.4.0-rc1"
+  tag: "v1.4.1"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true
@@ -268,7 +268,7 @@ postgres-operator:
     secret_name_template: "{username}.{cluster}.credentials"
 
 harbor:
-  tag: v2.6.3
+  tag: v2.7.1
   core:
     repository: goharbor/harbor-core
   nginx:

--- a/charts/harbor-operator/update.sh
+++ b/charts/harbor-operator/update.sh
@@ -119,6 +119,12 @@ elif [ $os == "Darwin" ];then
     sed -i "" "s/installCRDs: false/installCRDs: true/g" harbor-operator/values.yaml
 fi
 
+if [ $os == "Linux" ];then
+    sed -i "s/tag: \"v1.4.0-rc1\"/tag: \"v1.4.1\"/g" harbor-operator/values.yaml
+elif [ $os == "Darwin" ];then
+    sed -i "" "s/tag: \"v1.4.0-rc1\"/tag: \"v1.4.1\"/g" harbor-operator/values.yaml
+fi
+
 # replace values.schema.json
 cp ./parent/values.schema.json ./harbor-operator/values.schema.json
 


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


更新harbor-operator image version 到1.4.1

Fixes #