### PR TITLE
Robot Upgrade: contour chart upgrade from 21.0.2 to 21.0.5

### DIFF
--- a/charts/contour/config
+++ b/charts/contour/config
@@ -3,7 +3,7 @@ export DAOCLOUD_REPO_PROJECT=addon
 export REPO_URL=https://charts.bitnami.com/bitnami
 export REPO_NAME=contour
 export CHART_NAME=contour
-export VERSION=21.0.2
+export VERSION=21.0.5
 
 export UPGRADE_METHOD=pr
 export UPGRADE_REVIWER=lou-lan

--- a/charts/contour/contour/Chart.yaml
+++ b/charts/contour/contour/Chart.yaml
@@ -2,9 +2,9 @@ annotations:
   category: Infrastructure
   images: |
     - name: contour
-      image: docker.io/bitnami/contour:1.32.0-debian-12-r0
+      image: docker.io/bitnami/contour:1.32.0-debian-12-r4
     - name: envoy
-      image: docker.io/bitnami/envoy:1.34.1-debian-12-r1
+      image: docker.io/bitnami/envoy:1.34.1-debian-12-r2
     - name: nginx
       image: docker.io/bitnami/nginx:1.28.0-debian-12-r3
   licenses: Apache-2.0
@@ -25,8 +25,8 @@ maintainers:
 name: contour
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 21.0.2
+version: 21.0.5
 dependencies:
   - name: contour
-    version: "21.0.2"
+    version: "21.0.5"
     repository: "https://charts.bitnami.com/bitnami"

--- a/charts/contour/contour/charts/contour/Chart.yaml
+++ b/charts/contour/contour/charts/contour/Chart.yaml
@@ -2,9 +2,9 @@ annotations:
   category: Infrastructure
   images: |
     - name: contour
-      image: docker.io/bitnami/contour:1.32.0-debian-12-r0
+      image: docker.io/bitnami/contour:1.32.0-debian-12-r4
     - name: envoy
-      image: docker.io/bitnami/envoy:1.34.1-debian-12-r1
+      image: docker.io/bitnami/envoy:1.34.1-debian-12-r2
     - name: nginx
       image: docker.io/bitnami/nginx:1.28.0-debian-12-r3
   licenses: Apache-2.0
@@ -31,4 +31,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 21.0.2
+version: 21.0.5

--- a/charts/contour/contour/charts/contour/values.yaml
+++ b/charts/contour/contour/charts/contour/values.yaml
@@ -108,7 +108,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.32.0-debian-12-r0
+    tag: 1.32.0-debian-12-r4
     digest: ""
     ## Specify a imagePullPolicy
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -668,7 +668,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.34.1-debian-12-r1
+    tag: 1.34.1-debian-12-r2
     digest: ""
     ## Specify a imagePullPolicy
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images

--- a/charts/contour/contour/values.yaml
+++ b/charts/contour/contour/values.yaml
@@ -110,7 +110,7 @@ contour:
     image:
       registry: docker.m.daocloud.io
       repository: bitnami/contour
-      tag: 1.32.0-debian-12-r0
+      tag: 1.32.0-debian-12-r4
       digest: ""
       ## Specify a imagePullPolicy
       ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -674,7 +674,7 @@ contour:
     image:
       registry: docker.m.daocloud.io
       repository: bitnami/envoy
-      tag: 1.34.1-debian-12-r1
+      tag: 1.34.1-debian-12-r2
       digest: ""
       ## Specify a imagePullPolicy
       ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images


### PR DESCRIPTION
I am robot, upgrade: project contour chart upgrade from 21.0.2 to 21.0.5