### PR TITLE
bump argocd to 8.1.0

### DIFF
--- a/charts/argo-cd/argo-cd/.relok8s-images.yaml
+++ b/charts/argo-cd/argo-cd/.relok8s-images.yaml
@@ -7,3 +7,4 @@
 - "{{ .argo-cd.redis-ha.haproxy.image.registry }}/{{ .argo-cd.redis-ha.haproxy.image.repository }}:{{ .argo-cd.redis-ha.haproxy.image.tag }}"
 - "{{ .argo-cd.redis-ha.sysctlImage.image.registry }}/{{ .argo-cd.redis-ha.sysctlImage.image.repository }}:{{ .argo-cd.redis-ha.sysctlImage.image.tag }}"
 - "{{ .argo-cd.redis-ha.exporter.image.registry }}/{{ .argo-cd.redis-ha.exporter.image.repository }}:{{ .argo-cd.redis-ha.exporter.image.tag }}"
+- "{{ .argo-cd.redisSecretInit.image.registry }}/{{ .argo-cd.redisSecretInit.image.repository }}:{{ .argo-cd.redisSecretInit.image.tag }}"

--- a/charts/argo-cd/argo-cd/Chart.yaml
+++ b/charts/argo-cd/argo-cd/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.0.6
+    - kind: added
+      description: trafficDistribution to repo server service
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
@@ -22,8 +22,8 @@ name: argo-cd
 sources:
   - https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
   - https://github.com/argoproj/argo-cd
-version: 8.0.17
+version: 8.1.0
 dependencies:
   - name: argo-cd
-    version: "8.0.17"
+    version: "8.1.0"
     repository: "https://argoproj.github.io/argo-helm"

--- a/charts/argo-cd/argo-cd/README.md
+++ b/charts/argo-cd/argo-cd/README.md
@@ -1013,6 +1013,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | repoServer.service.labels | object | `{}` | Repo server service labels |
 | repoServer.service.port | int | `8081` | Repo server service port |
 | repoServer.service.portName | string | `"tcp-repo-server"` | Repo server service port name |
+| repoServer.service.trafficDistribution | string | `""` | Traffic distribution preference for the repo server service. If the field is not set, the implementation will apply its default routing strategy. |
 | repoServer.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | repoServer.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | repoServer.serviceAccount.create | bool | `true` | Create repo server service account |

--- a/charts/argo-cd/argo-cd/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.0.6
+    - kind: added
+      description: trafficDistribution to repo server service
   artifacthub.io/signKey: |
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
@@ -28,4 +28,4 @@ name: argo-cd
 sources:
 - https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
 - https://github.com/argoproj/argo-cd
-version: 8.0.17
+version: 8.1.0

--- a/charts/argo-cd/argo-cd/charts/argo-cd/README.md
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/README.md
@@ -1013,6 +1013,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | repoServer.service.labels | object | `{}` | Repo server service labels |
 | repoServer.service.port | int | `8081` | Repo server service port |
 | repoServer.service.portName | string | `"tcp-repo-server"` | Repo server service port name |
+| repoServer.service.trafficDistribution | string | `""` | Traffic distribution preference for the repo server service. If the field is not set, the implementation will apply its default routing strategy. |
 | repoServer.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | repoServer.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | repoServer.serviceAccount.create | bool | `true` | Create repo server service account |

--- a/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/service.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/templates/argocd-repo-server/service.yaml
@@ -23,3 +23,6 @@ spec:
     targetPort: repo-server
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.repoServer.name) | nindent 4 }}
+  {{- if .Values.repoServer.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.repoServer.service.trafficDistribution }}
+  {{- end }}

--- a/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/charts/argo-cd/values.yaml
@@ -1637,16 +1637,6 @@ redisSecretInit:
   enabled: true
   # -- Redis secret-init name
   name: redis-secret-init
-  image:
-    # -- Repository to use for the Redis secret-init Job
-    # @default -- `""` (defaults to global.image.repository)
-    repository: "argoproj/argocd" # defaults to global.image.repository
-    # -- Tag to use for the Redis secret-init Job
-    # @default -- `""` (defaults to global.image.tag)
-    tag: "v3.0.6" # defaults to global.image.tag
-    # -- Image pull policy for the Redis secret-init Job
-    # @default -- `""` (defaults to global.image.imagePullPolicy)
-    imagePullPolicy: "" # IfNotPresent
   # -- Secrets with credentials to pull images from a private registry
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []
@@ -1698,6 +1688,11 @@ redisSecretInit:
   # -- Tolerations to be added to the Redis secret-init Job
   # @default -- `[]` (defaults to global.tolerations)
   tolerations: []
+  image:
+    registry: quay.m.daocloud.io
+    repository: argoproj/argocd
+    tag: v3.0.6
+    imagePullPolicy: ""
 ## Server
 server:
   # -- Argo CD server name
@@ -2601,6 +2596,8 @@ repoServer:
     port: 8081
     # -- Repo server service port name
     portName: tcp-repo-server
+    # -- Traffic distribution preference for the repo server service. If the field is not set, the implementation will apply its default routing strategy.
+    trafficDistribution: ""
   ## Repo server metrics service configuration
   metrics:
     # -- Deploy metrics service

--- a/charts/argo-cd/argo-cd/values.schema.json
+++ b/charts/argo-cd/argo-cd/values.schema.json
@@ -3033,6 +3033,9 @@
                                 "imagePullPolicy": {
                                     "type": "string"
                                 },
+                                "registry": {
+                                    "type": "string"
+                                },
                                 "repository": {
                                     "type": "string"
                                 },
@@ -3484,6 +3487,9 @@
                                     "type": "integer"
                                 },
                                 "portName": {
+                                    "type": "string"
+                                },
+                                "trafficDistribution": {
                                     "type": "string"
                                 }
                             }

--- a/charts/argo-cd/argo-cd/values.yaml
+++ b/charts/argo-cd/argo-cd/values.yaml
@@ -1697,6 +1697,7 @@ argo-cd:
       # -- Image pull policy for the Redis secret-init Job
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: "" # IfNotPresent
+      registry: quay.m.daocloud.io
     # -- Secrets with credentials to pull images from a private registry
     # @default -- `[]` (defaults to global.imagePullSecrets)
     imagePullSecrets: []
@@ -2669,6 +2670,8 @@ argo-cd:
       port: 8081
       # -- Repo server service port name
       portName: tcp-repo-server
+      # -- Traffic distribution preference for the repo server service. If the field is not set, the implementation will apply its default routing strategy.
+      trafficDistribution: ""
     ## Repo server metrics service configuration
     metrics:
       # -- Deploy metrics service

--- a/charts/argo-cd/config
+++ b/charts/argo-cd/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://argoproj.github.io/argo-helm
 export REPO_NAME=argo-cd
 export CHART_NAME=argo-cd
-export VERSION=8.0.17
+export VERSION=8.1.0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/argo-cd/custom.sh
+++ b/charts/argo-cd/custom.sh
@@ -100,14 +100,20 @@ yq -i "
 " charts/argo-cd/values.yaml
 
 
+yq -i 'del(.redisSecretInit.image)' charts/argo-cd/values.yaml
 yq -i "
+  .redisSecretInit.image.registry = \"quay.m.daocloud.io\" |
   .redisSecretInit.image.repository = \"argoproj/argocd\" |
-  .redisSecretInit.image.tag = \"${globalImageTag}\"
+  .redisSecretInit.image.tag = \"${globalImageTag}\" |
+  .redisSecretInit.image.imagePullPolicy=\"\"
 " charts/argo-cd/values.yaml
 
+yq -i 'del(.argo-cd.redisSecretInit.image)' charts/argo-cd/values.yaml
 yq -i "
+  .argo-cd.redisSecretInit.image.registry = \"quay.m.daocloud.io\" |
   .argo-cd.redisSecretInit.image.repository = \"argoproj/argocd\" |
-  .argo-cd.redisSecretInit.image.tag = \"${globalImageTag}\"
+  .argo-cd.redisSecretInit.image.tag = \"${globalImageTag}\" |
+  .argo-cd.redisSecretInit.image.imagePullPolicy=\"\"
 " values.yaml
 
 

--- a/charts/argo-cd/parent/.relok8s-images.yaml
+++ b/charts/argo-cd/parent/.relok8s-images.yaml
@@ -7,3 +7,4 @@
 - "{{ .argo-cd.redis-ha.haproxy.image.registry }}/{{ .argo-cd.redis-ha.haproxy.image.repository }}:{{ .argo-cd.redis-ha.haproxy.image.tag }}"
 - "{{ .argo-cd.redis-ha.sysctlImage.image.registry }}/{{ .argo-cd.redis-ha.sysctlImage.image.repository }}:{{ .argo-cd.redis-ha.sysctlImage.image.tag }}"
 - "{{ .argo-cd.redis-ha.exporter.image.registry }}/{{ .argo-cd.redis-ha.exporter.image.repository }}:{{ .argo-cd.redis-ha.exporter.image.tag }}"
+- "{{ .argo-cd.redisSecretInit.image.registry }}/{{ .argo-cd.redisSecretInit.image.repository }}:{{ .argo-cd.redisSecretInit.image.tag }}"

--- a/charts/argo-cd/parent/values.schema.json
+++ b/charts/argo-cd/parent/values.schema.json
@@ -3033,6 +3033,9 @@
                                 "imagePullPolicy": {
                                     "type": "string"
                                 },
+                                "registry": {
+                                    "type": "string"
+                                },
                                 "repository": {
                                     "type": "string"
                                 },
@@ -3484,6 +3487,9 @@
                                     "type": "integer"
                                 },
                                 "portName": {
+                                    "type": "string"
+                                },
+                                "trafficDistribution": {
                                     "type": "string"
                                 }
                             }


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #