### PR TITLE
fix: update sonarqube bitnami images

### DIFF
--- a/charts/sonarqube/custom.sh
+++ b/charts/sonarqube/custom.sh
@@ -27,45 +27,51 @@ if ! which yq &>/dev/null ; then
     mv /tmp/${YQ_BINARY} /usr/bin/yq
 fi
 
+BUSYBOX_VERSION="1.32"
+CURL_VERSION="8.2.0"
+SONARQUBE_VERSION="10.2.0-community"
+
+# We set postgres image tag force cause the default is missing in bitnamilegacy repo
+# ref: https://github.com/bitnami/charts/issues/35164
 yq -i '
   .sonarqube.image.registry = "docker.m.daocloud.io" |
   .sonarqube.image.repository = "library/sonarqube" |
-  .sonarqube.image.tag = "10.2.0-community" |
+  .sonarqube.image.tag = "'$SONARQUBE_VERSION'" |
   .sonarqube.initContainers.registry = "docker.m.daocloud.io" |
   .sonarqube.initContainers.repository = "library/busybox" |
-  .sonarqube.initContainers.tag = "1.32" |
+  .sonarqube.initContainers.tag = "'$BUSYBOX_VERSION'" |
   .sonarqube.initSysctl.registry = "docker.m.daocloud.io" |
   .sonarqube.initSysctl.repository = "library/busybox" |
-  .sonarqube.initSysctl.tag = "1.32" |
+  .sonarqube.initSysctl.tag = "'$BUSYBOX_VERSION'" |
   .sonarqube.initFs.registry = "docker.m.daocloud.io" |
   .sonarqube.initFs.repository = "library/busybox" |
-  .sonarqube.initFs.tag = "1.32" |
+  .sonarqube.initFs.tag = "'$BUSYBOX_VERSION'" |
   .sonarqube.caCerts.registry = "docker.m.daocloud.io" |
   .sonarqube.caCerts.repository = "adoptopenjdk/openjdk11" |
   .sonarqube.caCerts.tag = "alpine" |
   .sonarqube.prometheusExporter.registry = "docker.m.daocloud.io" |
   .sonarqube.prometheusExporter.repository = "curlimages/curl" |
-  .sonarqube.prometheusExporter.tag = "8.2.0" |
+  .sonarqube.prometheusExporter.tag = "'$CURL_VERSION'" |
   .sonarqube.plugins.registry = "docker.m.daocloud.io" |
   .sonarqube.plugins.repository = "curlimages/curl" |
-  .sonarqube.plugins.tag = "8.2.0" |
+  .sonarqube.plugins.tag = "'$CURL_VERSION'" |
   .sonarqube.tests.image.registry="docker.m.daocloud.io" |
   .sonarqube.tests.image.repository = "library/sonarqube" |
-  .sonarqube.tests.image.tag = "10.2.0-community" |
+  .sonarqube.tests.image.tag = "'$SONARQUBE_VERSION'" |
   .sonarqube.persistence.storageClass = "" |
-  .sonarqube.postgresql.persistence.storageClass = ""
-' values.yaml
-
-# copy from ingress-nginx and modified
-yq -i '
-   .sonarqube.ingress-nginx.controller.image.registry="k8s.m.daocloud.io" |
-   .sonarqube.ingress-nginx.controller.admissionWebhooks.patch.image.registry="k8s.m.daocloud.io"
-' values.yaml
-
-yq -i '
+  .sonarqube.postgresql.persistence.storageClass = "" |
+  .sonarqube.ingress-nginx.controller.image.registry="k8s.m.daocloud.io" |
+  .sonarqube.ingress-nginx.controller.admissionWebhooks.patch.image.registry="k8s.m.daocloud.io" |
   .sonarqube.postgresql.volumePermissions.image.registry="docker.m.daocloud.io" |
   .sonarqube.postgresql.image.registry="docker.m.daocloud.io" |
-  .sonarqube.postgresql.metrics.image.registry="docker.m.daocloud.io"
+  .sonarqube.postgresql.image.repository="bitnamilegacy/postgresql" |
+  .sonarqube.postgresql.image.tag="15.3.0-debian-11-r0" |
+  .sonarqube.postgresql.metrics.image.registry="docker.m.daocloud.io" |
+  .sonarqube.postgresql.metrics.image.repository="bitnamilegacy/postgres-exporter" |
+  .sonarqube.postgresql.metrics.image.tag="0.12.0-debian-11-r86" |
+  .sonarqube.postgresql.volumePermissions.image.registry="docker.m.daocloud.io" |
+  .sonarqube.postgresql.volumePermissions.image.repository="bitnamilegacy/os-shell" |
+  .sonarqube.postgresql.volumePermissions.image.tag="11-debian-11-r112"
 ' values.yaml
 
 #change the image style of relok8s style

--- a/charts/sonarqube/sonarqube/values.yaml
+++ b/charts/sonarqube/sonarqube/values.yaml
@@ -450,6 +450,8 @@ sonarqube:
         runAsUser: 0
       image:
         registry: docker.m.daocloud.io
+        repository: bitnamilegacy/os-shell
+        tag: 11-debian-11-r112
     shmVolume:
       chmod:
         enabled: false
@@ -459,9 +461,13 @@ sonarqube:
       # name:
     image:
       registry: docker.m.daocloud.io
+      repository: bitnamilegacy/postgresql
+      tag: 15.3.0-debian-11-r0
     metrics:
       image:
         registry: docker.m.daocloud.io
+        repository: bitnamilegacy/postgres-exporter
+        tag: 0.12.0-debian-11-r86
   # Additional labels to add to the pods:
   # podLabels:
   #   key: value


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

由于 https://github.com/bitnami/charts/issues/35164

将bitnami的镜像全部改成bitnamilegacy

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #