### PR TITLE
feat: add dataset chart

### DIFF
--- a/charts/dataset/config
+++ b/charts/dataset/config
@@ -1,0 +1,17 @@
+export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://baizeai.github.io/charts
+export REPO_NAME=dataset
+export CHART_NAME=dataset
+export VERSION=v0.1.7
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=yyzxw
+export TEST_ASSIGNER=liyuerich
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+export CUSTOM_SHELL=custom.sh
+export NO_TRIVY=true

--- a/charts/dataset/custom.sh
+++ b/charts/dataset/custom.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+
+os=$(uname)
+echo $os
+
+yq e -i '.annotations |= (. + {"addon.kpanda.io/release-name": "dataset", "addon.kpanda.io/namespace": "dataset-system"})' Chart.yaml
+yq e -i '.dataset.global.imageRegistry="ghcr.m.daocloud.io"' values.yaml
+yq e -i '.dataset.dataloader.image.registry="ghcr.m.daocloud.io"' values.yaml
+yq e -i '.dataset.controller.image.registry="ghcr.m.daocloud.io"' values.yaml
+yq e -i '.dataset.resources={"limits":{"cpu":"1000m","memory":"2048M"},"requests":{"cpu":"100m","memory":"125M"}}' values.yaml
+yq e -i '.keywords = ["dataset"] + (.keywords)' Chart.yaml

--- a/charts/dataset/dataset/.relok8s-images.yaml
+++ b/charts/dataset/dataset/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .dataset.controller.image.registry }}/{{ .dataset.controller.image.repository }}:{{ .dataset.controller.image.tag }}"
+- "{{ .dataset.dataloader.image.registry }}/{{ .dataset.dataloader.image.repository }}:{{ .dataset.dataloader.image.tag }}"

--- a/charts/dataset/dataset/Chart.yaml
+++ b/charts/dataset/dataset/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: dataset
+type: application
+version: 0.1.7
+dependencies:
+  - name: dataset
+    version: "v0.1.7"
+    repository: "https://baizeai.github.io/charts"
+annotations:
+  addon.kpanda.io/release-name: dataset
+  addon.kpanda.io/namespace: dataset-system
+keywords:
+  - dataset

--- a/charts/dataset/dataset/charts/dataset/.helmignore
+++ b/charts/dataset/dataset/charts/dataset/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dataset/dataset/charts/dataset/Chart.yaml
+++ b/charts/dataset/dataset/charts/dataset/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: dataset
+type: application
+version: 0.1.7

--- a/charts/dataset/dataset/charts/dataset/templates/_common.tpl
+++ b/charts/dataset/dataset/charts/dataset/templates/_common.tpl
@@ -1,0 +1,22 @@
+
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .defaultTag  -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if .imageRoot.registry }}
+    {{- $registryName = .imageRoot.registry  -}}
+{{- end -}}
+{{- if .imageRoot.tag }}
+    {{- $tag = .imageRoot.tag  -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dataset/dataset/charts/dataset/templates/_helpers.tpl
+++ b/charts/dataset/dataset/charts/dataset/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dataset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dataset.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dataset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dataset.labels" -}}
+helm.sh/chart: {{ include "dataset.chart" . }}
+{{ include "dataset.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dataset.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dataset.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dataset.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dataset.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "dataset.controller.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global "defaultTag" .Chart.Version) }}
+{{- end -}}
+
+{{- define "dataset.data-loader.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.dataloader.image "global" .Values.global "defaultTag" .Chart.Version) }}
+{{- end -}}

--- a/charts/dataset/dataset/charts/dataset/templates/clusterrole.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/clusterrole.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dataset.fullname" . }}
+rules:
+  - apiGroups:
+      - dataset.baizeai.io
+    resources:
+      - datasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dataset.baizeai.io
+    resources:
+      - datasets/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - dataset.baizeai.io
+    resources:
+      - datasets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "persistentvolumeclaims"
+      - "secrets"
+      - "persistentvolumes"
+      - "configmaps"
+      - "services"
+      - "events"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "*"

--- a/charts/dataset/dataset/charts/dataset/templates/clusterrolebinding.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dataset.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dataset.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dataset.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/dataset/dataset/charts/dataset/templates/configmap.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/configmap.yaml
@@ -1,0 +1,44 @@
+{{- define "defaultJobSpec" }}
+backoffLimit: 4
+completionMode: NonIndexed
+completions: 1
+parallelism: 1
+template:
+  spec:
+    restartPolicy: Never
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: {{ template "dataset.data-loader.image" . }}
+        command:
+          - /usr/local/bin/data-loader
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 2000m
+            memory: 2000Mi
+{{end}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dataset.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "dataset.fullname" . }}
+data:
+  config.yaml: |-
+    debug: {{.Values.global.debug }}
+    enable_cascading_deletion: {{ .Values.config.enable_cascading_deletion }}
+    dataset_job_spec_yaml: |-
+      {{- if .Values.config.dataset_job_spec}}
+      {{- $cus := .Values.config.dataset_job_spec }}
+      {{- $d := include "defaultJobSpec" . | fromYaml }}
+      {{- $merged := merge $cus $d  }}
+      {{- toYaml $merged | nindent 6}}
+      {{- else }}
+      {{- $d := include "defaultJobSpec" . | fromYaml }}
+      {{- toYaml $d | nindent 6 }}
+      {{end}}

--- a/charts/dataset/dataset/charts/dataset/templates/dataset.baizeai.io_datasets.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/dataset.baizeai.io_datasets.yaml
@@ -1,0 +1,733 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: datasets.dataset.baizeai.io
+spec:
+  group: dataset.baizeai.io
+  names:
+    kind: Dataset
+    listKind: DatasetList
+    plural: datasets
+    shortNames:
+    - data
+    singular: dataset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source.type
+      name: type
+      type: string
+    - jsonPath: .spec.source.uri
+      name: uri
+      type: string
+    - jsonPath: .status.phase
+      name: phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dataset is the Schema for the datasets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatasetSpec defines the desired state of Dataset
+            properties:
+              dataSyncRound:
+                default: 1
+                description: dataSyncRound is the number of data sync rounds to be
+                  performed."
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: dataSyncRound can only be incremented by 1
+                  rule: self > 0 && self - oldSelf <= 1
+              mountOptions:
+                description: mountOptions is the options for mounting the dataset.
+                properties:
+                  gid:
+                    default: 1000
+                    description: gid is the group id of the mounted directory.
+                    format: int64
+                    type: integer
+                  mode:
+                    default: "0774"
+                    description: mode is the permission mode of the mounted directory.
+                    pattern: ^[0-7]{3,4}$
+                    type: string
+                  path:
+                    default: /
+                    description: |-
+                      path is the path to the directory to be mounted.
+                      if set to "/", the dataset will be mounted to the root of the dest volume.
+                      if set to a non-empty string, the dataset will be mounted to a subdirectory of the dest volume.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  uid:
+                    default: 1000
+                    description: uid is the user id of the mounted directory.
+                    format: int64
+                    type: integer
+                type: object
+              secretRef:
+                description: secretRef is the name of the secret that contains credentials
+                  for accessing the dataset source.
+                type: string
+              share:
+                description: |-
+                  Share indicates whether the model is shareable with others.
+                  When set to true, the model can be shared according to the specified selector.
+                type: boolean
+              shareToNamespaceSelector:
+                description: |-
+                  ShareToNamespaceSelector defines a label selector to specify the namespaces
+                  to which the model can be shared. Only namespaces that match the selector will have access to the model.
+                  If Share is true and ShareToNamespaceSelector is empty, that means all namespaces can access this.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              source:
+                description: source is the source of the dataset.
+                properties:
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      options is a map of key-value pairs that can be used to specify additional options for the dataset source, e.g. {"branch": "master"}
+                      supported keys for each type of dataset source are:
+                      - GIT: branch, commit, depth, submodules
+                      - S3: region, endpoint, provider, syncMode
+                      - HTTP: any key-value pair will be passed to the underlying http client as http headers
+                      - PVC:
+                      - NFS:
+                      - CONDA: requirements.txt, environment.yaml
+                      - REFERENCE:
+                      - HUGGING_FACE: repo, repoType, endpoint, include, exclude, revision
+                      - MODEL_SCOPE: repo, repoType, include, exclude, revision
+                      * Note: syncMode can be "sync" (default) or "copy". "sync" removes files in destination that don't exist in source, "copy" only adds/updates files without removing existing ones.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type:
+                    enum:
+                    - GIT
+                    - S3
+                    - HTTP
+                    - PVC
+                    - NFS
+                    - CONDA
+                    - REFERENCE
+                    - HUGGING_FACE
+                    - MODEL_SCOPE
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  uri:
+                    description: |-
+                      uri is the location of the dataset.
+                      each type of dataset source has its own format of uri:
+                      - GIT: http[s]://<host>/<owner>/<repo>[.git] or git://<host>/<owner>/<repo>[.git]
+                      - S3: s3://<bucket>/<path/to/directory>
+                      - HTTP: http[s]://<host>/<path/to/directory>?<query>
+                      - PVC: pvc://<name>/<path/to/directory>
+                      - NFS: nfs://<host>/<path/to/directory>
+                      - CONDA: conda://<name>?[python=<python_version>]
+                      - REFERENCE: dataset://<namespace>/<dataset>
+                      - HUGGING_FACE: huggingface://<repoName>?[repoType=<repoType>]
+                      - MODEL_SCOPE: modelscope://<namespace>/<model>
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                required:
+                - type
+                - uri
+                type: object
+              volumeClaimRef:
+                description: volumeClaimRef is the reference to an existing PVC.
+                properties:
+                  name:
+                    description: name is the name of the pvc.
+                    type: string
+                  subPath:
+                    description: subPath is the subPath of the pvc.
+                    type: string
+                required:
+                - name
+                type: object
+              volumeClaimTemplate:
+                description: PersistentVolumeClaim is a user's request for and claim
+                  to a persistent volume
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      spec defines the desired characteristics of a volume requested by a pod author.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  status:
+                    description: |-
+                      status represents the current information/status of a persistent volume claim.
+                      Read-only.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the actual access modes the volume backing the PVC has.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      allocatedResourceStatuses:
+                        additionalProperties:
+                          description: |-
+                            When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                            that it does not recognizes, then it should ignore that update and let other controllers
+                            handle it.
+                          type: string
+                        description: "allocatedResourceStatuses stores status of resource
+                          being resized for the given PVC.\nKey names follow standard
+                          Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed
+                          keys:\n\t\t- storage - the capacity of the volume.\n\t*
+                          Custom resources must use implementation-defined prefixed
+                          names such as \"example.com/my-custom-resource\"\nApart
+                          from above values - keys that are unprefixed or have kubernetes.io
+                          prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus
+                          can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState
+                          set when resize controller starts resizing the volume in
+                          control-plane.\n\t- ControllerResizeFailed:\n\t\tState set
+                          when resize has failed in resize controller with a terminal
+                          error.\n\t- NodeResizePending:\n\t\tState set when resize
+                          controller has finished resizing the volume but further
+                          resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState
+                          set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState
+                          set when resizing has failed in kubelet with a terminal
+                          error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor
+                          example: if expanding a PVC for more capacity - this field
+                          can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage']
+                          = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizeFailed\"\nWhen this field is not set, it means
+                          that no resize operation is in progress for the given PVC.\n\nA
+                          controller that receives PVC update with previously unknown
+                          resourceName or ClaimResourceStatus\nshould ignore the update
+                          for the purpose it was designed. For example - a controller
+                          that\nonly is responsible for resizing capacity of the volume,
+                          should ignore PVC updates that change other valid\nresources
+                          associated with PVC.\n\nThis is an alpha field and requires
+                          enabling RecoverVolumeExpansionFailure feature."
+                        type: object
+                        x-kubernetes-map-type: granular
+                      allocatedResources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: "allocatedResources tracks the resources allocated
+                          to a PVC including its capacity.\nKey names follow standard
+                          Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed
+                          keys:\n\t\t- storage - the capacity of the volume.\n\t*
+                          Custom resources must use implementation-defined prefixed
+                          names such as \"example.com/my-custom-resource\"\nApart
+                          from above values - keys that are unprefixed or have kubernetes.io
+                          prefix are considered\nreserved and hence may not be used.\n\nCapacity
+                          reported here may be larger than the actual capacity when
+                          a volume expansion operation\nis requested.\nFor storage
+                          quota, the larger value from allocatedResources and PVC.spec.resources
+                          is used.\nIf allocatedResources is not set, PVC.spec.resources
+                          alone is used for quota calculation.\nIf a volume expansion
+                          capacity request is lowered, allocatedResources is only\nlowered
+                          if there are no expansion operations in progress and if
+                          the actual volume capacity\nis equal or lower than the requested
+                          capacity.\n\nA controller that receives PVC update with
+                          previously unknown resourceName\nshould ignore the update
+                          for the purpose it was designed. For example - a controller
+                          that\nonly is responsible for resizing capacity of the volume,
+                          should ignore PVC updates that change other valid\nresources
+                          associated with PVC.\n\nThis is an alpha field and requires
+                          enabling RecoverVolumeExpansionFailure feature."
+                        type: object
+                      capacity:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: capacity represents the actual resources of the
+                          underlying volume.
+                        type: object
+                      conditions:
+                        description: |-
+                          conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
+                          resized then the Condition will be set to 'Resizing'.
+                        items:
+                          description: PersistentVolumeClaimCondition contains details
+                            about state of pvc
+                          properties:
+                            lastProbeTime:
+                              description: lastProbeTime is the time we probed the
+                                condition.
+                              format: date-time
+                              type: string
+                            lastTransitionTime:
+                              description: lastTransitionTime is the time the condition
+                                transitioned from one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is the human-readable message indicating
+                                details about last transition.
+                              type: string
+                            reason:
+                              description: |-
+                                reason is a unique, this should be a short, machine understandable string that gives the reason
+                                for condition's last transition. If it reports "Resizing" that means the underlying
+                                persistent volume is being resized.
+                              type: string
+                            status:
+                              description: |-
+                                Status is the status of the condition.
+                                Can be True, False, Unknown.
+                                More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required
+                              type: string
+                            type:
+                              description: |-
+                                Type is the type of the condition.
+                                More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
+                      currentVolumeAttributesClassName:
+                        description: |-
+                          currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
+                          When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                        type: string
+                      modifyVolumeStatus:
+                        description: |-
+                          ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+                          When this is unset, there is no ModifyVolume operation being attempted.
+                        properties:
+                          status:
+                            description: "status is the status of the ControllerModifyVolume
+                              operation. It can be in any of following states:\n -
+                              Pending\n   Pending indicates that the PersistentVolumeClaim
+                              cannot be modified due to unmet requirements, such as\n
+                              \  the specified VolumeAttributesClass not existing.\n
+                              - InProgress\n   InProgress indicates that the volume
+                              is being modified.\n - Infeasible\n  Infeasible indicates
+                              that the request has been rejected as invalid by the
+                              CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass
+                              needs to be specified.\nNote: New statuses can be added
+                              in the future. Consumers should check for unknown statuses
+                              and fail appropriately."
+                            type: string
+                          targetVolumeAttributesClassName:
+                            description: targetVolumeAttributesClassName is the name
+                              of the VolumeAttributesClass the PVC currently being
+                              reconciled
+                            type: string
+                        required:
+                        - status
+                        type: object
+                      phase:
+                        description: phase represents the current phase of PersistentVolumeClaim.
+                        type: string
+                    type: object
+                type: object
+            required:
+            - source
+            type: object
+          status:
+            description: DatasetStatus defines the observed state of Dataset
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inProcessing:
+                type: boolean
+              inProcessingRound:
+                format: int32
+                type: integer
+              lastSucceedRound:
+                description: lastSucceedRound is the number of the last data sync
+                  round.
+                format: int32
+                type: integer
+              lastSyncTime:
+                format: date-time
+                type: string
+              phase:
+                default: PENDING
+                type: string
+              pvcName:
+                description: pvcName is the name of the pvc that contains the dataset.
+                type: string
+              readOnly:
+                description: readOnly indicates whether the dataset is mounted as
+                  read-only.
+                type: boolean
+              syncRoundStatuses:
+                description: |-
+                  syncRoundStatuses is a list of data sync round statuses.
+                  each data sync round status contains the information of the data sync round.
+                  we only keep the data sync round statuses of the last 5 data sync rounds.
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    jobName:
+                      type: string
+                    round:
+                      format: int32
+                      type: integer
+                    startTime:
+                      format: date-time
+                      type: string
+                    succeed:
+                      type: boolean
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/dataset/dataset/charts/dataset/templates/deployment.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dataset.fullname" . }}
+  labels:
+    {{- include "dataset.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dataset.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dataset.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dataset.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "dataset.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ template "dataset.controller.image" . }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8083
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /app/config
+              name: config-volume
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dataset/dataset/charts/dataset/templates/service.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dataset.fullname" . }}
+  labels:
+    {{- include "dataset.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dataset.selectorLabels" . | nindent 4 }}

--- a/charts/dataset/dataset/charts/dataset/templates/serviceaccount.yaml
+++ b/charts/dataset/dataset/charts/dataset/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dataset.serviceAccountName" . }}
+  labels:
+    {{- include "dataset.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/dataset/dataset/charts/dataset/values.yaml
+++ b/charts/dataset/dataset/charts/dataset/values.yaml
@@ -1,0 +1,76 @@
+# Default values for dataset.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+global:
+  imageRegistry: ghcr.io
+  imagePullPolicy: IfNotPresent
+  debug: false
+
+config:
+  dataset_job_spec: {}
+  # Enable cascading deletion of reference datasets when source dataset is deleted
+  # Default: false (disabled for safety)
+  enable_cascading_deletion: false
+
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 8082
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+controller:
+  image:
+    registry: ''
+    repository: baizeai/dataset-controller
+    tag: v0.1.7
+
+dataloader:
+  image:
+    registry: ''
+    repository: baizeai/dataset-data-loader
+    tag: v0.1.7

--- a/charts/dataset/dataset/values.schema.json
+++ b/charts/dataset/dataset/values.schema.json
@@ -1,0 +1,132 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "dataset": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "dataset_job_spec": {
+                            "type": "object"
+                        },
+                        "enable_cascading_deletion": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "dataloader": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "object",
+                    "properties": {
+                        "debug": {
+                            "type": "boolean"
+                        },
+                        "imagePullPolicy": {
+                            "type": "string"
+                        },
+                        "imageRegistry": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}

--- a/charts/dataset/dataset/values.yaml
+++ b/charts/dataset/dataset/values.yaml
@@ -1,0 +1,72 @@
+# child values
+dataset:
+  # Default values for dataset.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  global:
+    imageRegistry: ghcr.m.daocloud.io
+    imagePullPolicy: IfNotPresent
+    debug: false
+  config:
+    dataset_job_spec: {}
+    # Enable cascading deletion of reference datasets when source dataset is deleted
+    # Default: false (disabled for safety)
+    enable_cascading_deletion: false
+  replicaCount: 1
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+  service:
+    type: ClusterIP
+    port: 8082
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+  podAnnotations: {}
+  podSecurityContext: {}
+  # fsGroup: 2000
+
+  securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2048M
+    requests:
+      cpu: 100m
+      memory: 125M
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  controller:
+    image:
+      registry: 'ghcr.m.daocloud.io'
+      repository: baizeai/dataset-controller
+      tag: v0.1.7
+  dataloader:
+    image:
+      registry: 'ghcr.m.daocloud.io'
+      repository: baizeai/dataset-data-loader
+      tag: v0.1.7

--- a/charts/dataset/parent/.relok8s-images.yaml
+++ b/charts/dataset/parent/.relok8s-images.yaml
@@ -1,0 +1,2 @@
+- "{{ .dataset.controller.image.registry }}/{{ .dataset.controller.image.repository }}:{{ .dataset.controller.image.tag }}"
+- "{{ .dataset.dataloader.image.registry }}/{{ .dataset.dataloader.image.repository }}:{{ .dataset.dataloader.image.tag }}"

--- a/test/dataset/install.sh
+++ b/test/dataset/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename $0 )
+CURRENT_DIR_PATH=$(cd $(dirname $0); pwd)
+
+KIND_KUBECONFIG=$1
+
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+echo "helm version: " "$(helm version)"
+helm repo update chart-museum  --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --timeout 5m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+
+set -x
+
+helm install dataset chart-museum/dataset  ${HELM_MUST_OPTION}  --create-namespace --namespace dataset-system
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+  exit 0
+else
+  echo "error, failed to deploy $CHART_DIR"
+  kubectl get all -n dataset-system --kubeconfig ${KIND_KUBECONFIG}
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

add new dataset chart

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #