### PR TITLE
add-inferencepool-chart

### DIFF
--- a/charts/inferencepool/config
+++ b/charts/inferencepool/config
@@ -1,0 +1,17 @@
+export USE_OPENSOURCE_CHART=false
+
+export REPO_URL=oci://registry.k8s.io/gateway-api-inference-extension/charts
+export REPO_NAME=inferencepool
+export CHART_NAME=inferencepool
+export VERSION=v1.3.0
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=learner0810
+export TEST_ASSIGNER=learner0810
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh

--- a/charts/inferencepool/custom.sh
+++ b/charts/inferencepool/custom.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#==============================
+yq eval -i '
+  .inferencepool.inferencePool.modelServers.matchLabels.app = "vllm-llama3-8b-instruct" |
+  .inferencepool.inferencePool.modelServers lineComment = "REQUIRED"
+' values.yaml
+
+
+yq eval -i '
+  .inferencepool.inferenceExtension |= (
+    to_entries
+    | (.[] | select(.key == "tolerations") | key + 1) as $idx
+    | (.[:$idx] + [{"key":"resources","value":{
+        "requests": {"cpu":"1000m","memory":"1Gi"},
+        "limits":   {"cpu":"4000m","memory":"8Gi"}
+      }}] + .[$idx:])
+    | from_entries
+  )
+' values.yaml
+
+awk '
+/env:/ {
+    count++
+    if(count == 2) {
+        print "        {{- with .Values.inferenceExtension.resources }}"
+        print "        resources:"
+        print "          {{- toYaml . | nindent 10 }}"
+        print "        {{- end }}"
+    }
+}
+{ print }
+' charts/inferencepool/templates/epp-deployment.yaml > temp_file && mv temp_file charts/inferencepool/templates/epp-deployment.yaml
+
+
+
+REPOSITORY=$(yq eval '.inferencepool.inferenceExtension.image.hub | split("/")[1]' values.yaml)
+IMAGE_NAME=$(yq eval '.inferencepool.inferenceExtension.image.name | sub("^/", "")' values.yaml)
+
+yq eval '.inferencepool.inferenceExtension.image.hub = "k8s.m.daocloud.io"' -i values.yaml
+yq eval ".inferencepool.inferenceExtension.image.name = \"${REPOSITORY}/${IMAGE_NAME}\"" -i values.yaml
+
+echo "keywords:" >> Chart.yaml
+echo "- networking" >> Chart.yaml

--- a/charts/inferencepool/inferencepool/.relok8s-images.yaml
+++ b/charts/inferencepool/inferencepool/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .inferencepool.inferenceExtension.image.hub }}/{{ .inferencepool.inferenceExtension.image.name }}:{{ .inferencepool.inferenceExtension.image.tag }}"

--- a/charts/inferencepool/inferencepool/Chart.yaml
+++ b/charts/inferencepool/inferencepool/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: v1.3.0
+description: A Helm chart for InferencePool
+name: inferencepool
+type: application
+version: v1.3.0
+dependencies:
+  - name: inferencepool
+    version: "v1.3.0"
+    repository: "oci://registry.k8s.io/gateway-api-inference-extension/charts"
+keywords:
+- networking

--- a/charts/inferencepool/inferencepool/README.md
+++ b/charts/inferencepool/inferencepool/README.md
@@ -1,0 +1,302 @@
+# InferencePool
+
+A chart to deploy an InferencePool and a corresponding EndpointPicker (epp) deployment.  
+
+## Install
+
+To install an InferencePool named `vllm-llama3-8b-instruct`  that selects from endpoints with label `app: vllm-llama3-8b-instruct` and listening on port `8000`, you can run the following command:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+```
+
+To install via the latest published chart in staging  (--version v0 indicates latest dev version), you can run the following command:
+
+```txt
+$ helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+Note that the provider name is needed to deploy provider-specific resources. If no provider is specified, then only the InferencePool object and the EPP are deployed.
+
+### Install with Custom Cmd-line Flags
+
+To set cmd-line flags, you can use the `--set` option to set each flag, e.g.,:
+
+```txt
+$ helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set inferenceExtension.flags.<FLAG_NAME>=<FLAG_VALUE>
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+Alternatively, you can define flags in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  flags:
+    FLAG_NAME: <FLAG_VALUE>
+    v: 3 ## Log verbosity
+    ...
+```
+
+### Install with Custom Environment Variables
+
+To set custom environment variables for the EndpointPicker deployment, you can define them as free-form YAML in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  env:
+    - name: FEATURE_FLAG_ENABLED
+      value: "true"
+    - name: CUSTOM_ENV_VAR
+      value: "custom_value"
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+```
+
+Then apply it with:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+### Install with Custom EPP Plugins Configuration
+
+To set custom EPP plugin config, you can pass it as an inline yaml. For example:
+
+```yaml
+  inferenceExtension:
+    pluginsCustomConfig:
+      custom-plugins.yaml: |
+        apiVersion: inference.networking.x-k8s.io/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: custom-scorer
+          parameters:
+            custom-threshold: 64
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: custom-scorer
+```
+
+### Install with Additional Ports
+
+To expose additional ports (e.g., for ZMQ), you can define them in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  extraContainerPorts:
+    - name: zmq
+      containerPort: 5557
+      protocol: TCP
+  extraServicePorts: # if need to expose the port for external communication
+    - name: zmq
+      port: 5557
+      protocol: TCP
+```
+
+Then apply it with:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+### Install for Triton TensorRT-LLM
+
+Use `--set inferencePool.modelServerType=triton-tensorrt-llm` to install for Triton TensorRT-LLM, e.g.,
+
+```txt
+$ helm install triton-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=triton-llama3-8b-instruct \
+  --set inferencePool.modelServerType=triton-tensorrt-llm \
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+### Install with Latency-Based Routing
+
+For full details see the dedicated [Latency-Based Routing Guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/latency-based-predictor.md)
+
+#### Latency-Based Router Configuration
+
+The behavior of the latency-based router can be fine-tuned using the configuration parameters under `inferenceExtension.latencyPredictor.sloAwareRouting` in your `values.yaml` file.
+
+| Parameter                        | Description                                                                                             | Default     |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------- |
+| `samplingMean`                   | The sampling mean (lambda) for the Poisson distribution of token sampling.                              | `100.0`     |
+| `maxSampledTokens`               | The maximum number of tokens to sample for TPOT prediction.                                             | `20`        |
+| `sloBufferFactor`                | A buffer to apply to the SLO to make it more or less strict.                                            | `1.0`       |
+| `negHeadroomTTFTWeight`          | The weight to give to the TTFT when a pod has negative headroom.                                        | `0.8`       |
+| `negHeadroomTPOTWeight`          | The weight to give to the TPOT when a pod has negative headroom.                                        | `0.2`       |
+| `headroomTTFTWeight`             | The weight to give to the TTFT when a pod has positive headroom.                                        | `0.8`       |
+| `headroomTPOTWeight`             | The weight to give to the TPOT when a pod has positive headroom.                                        | `0.2`       |
+| `headroomSelectionStrategy`      | The strategy to use for selecting a pod based on headroom. Options: `least`, `most`, `composite-least`, `composite-most`, `composite-only`. | `least`     |
+| `compositeKVWeight`              | The weight for KV cache in the composite score.                                                         | `1.0`       |
+| `compositeQueueWeight`           | The weight for queue size in the composite score.                                                       | `1.0`       |
+| `compositePrefixWeight`          | The weight for prefix cache in the composite score.                                                     | `1.0`       |
+| `epsilonExploreSticky`           | Exploration factor for sticky sessions.                                                                 | `0.01`      |
+| `epsilonExploreNeg`              | Exploration factor for negative headroom.                                                               | `0.01`      |
+| `affinityGateTau`                | Affinity gate threshold.                                                                                | `0.80`      |
+| `affinityGateTauGlobal`          | Global affinity gate threshold.                                                                         | `0.99`      |
+| `selectionMode`                  | The mode for selection (e.g., "linear").                                                                | `linear`    |
+
+**Note:** Enabling SLO-aware routing also exposes a number of Prometheus metrics for monitoring the feature, including actual vs. predicted latency, SLO violations, and more.
+
+### Install with High Availability (HA)
+
+To deploy the EndpointPicker in a high-availability (HA) active-passive configuration set replicas to be greater than one. In such a setup, only one "leader" replica will be active and ready to process traffic at any given time. If the leader pod fails, another pod will be elected as the new leader, ensuring service continuity.
+
+To enable HA, set `inferenceExtension.replicas` to a number greater than 1.
+
+* Via `--set` flag:
+
+  ```txt
+  helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set inferenceExtension.replicas=3 \
+  --set provider=[none|gke] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+  ```
+
+* Via `values.yaml`:
+
+  ```yaml
+  inferenceExtension:
+    replicas: 3
+  ```
+
+  Then apply it with:
+
+  ```txt
+  helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+  ```
+
+### Install with Monitoring
+
+To enable metrics collection and monitoring for the EndpointPicker, you can configure Prometheus ServiceMonitor creation:
+
+```yaml
+inferenceExtension:
+  monitoring:
+    interval: "10s"
+    prometheus:
+      enabled: false
+      auth:
+        enabled: true
+        secretName: inference-gateway-sa-metrics-reader-secret
+      extraLabels: {}
+```
+
+**Note:** Prometheus monitoring requires the Prometheus Operator and ServiceMonitor CRD to be installed in the cluster.
+
+For GKE environments, you need to set `provider.name` to `gke` firstly. This will create the necessary `PodMonitoring` and RBAC resources for metrics collection.
+
+If you are using a GKE Autopilot cluster, you also need to set `provider.gke.autopilot` to `true`.
+
+Then apply it with:
+
+```txt
+helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+## Uninstall
+
+Run the following command to uninstall the chart:
+
+```txt
+$ helm uninstall pool-1
+```
+
+## Configuration
+
+The following table list the configurable parameters of the chart.
+
+| **Parameter Name**                                         | **Description**                                                                                                                                                                                                                                    |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inferencePool.apiVersion`                                 | The API version of the InferencePool resource. Defaults to `inference.networking.k8s.io/v1`. This can be changed to `inference.networking.x-k8s.io/v1alpha2` to support older API versions.                                                        |
+| `inferencePool.targetPortNumber`                           | Target port number for the vllm backends, will be used to scrape metrics by the inference extension. Defaults to 8000.                                                                                                                             |
+| `inferencePool.modelServerType`                            | Type of the model servers in the pool, valid options are [vllm, triton-tensorrt-llm], default is vllm.                                                                                                                                             |
+| `inferencePool.modelServers.matchLabels`                   | Label selector to match vllm backends managed by the inference pool.                                                                                                                                                                               |
+| `inferenceExtension.replicas`                              | Number of replicas for the endpoint picker extension service. If More than one replica is used, EPP will run in HA active-passive mode. Defaults to `1`.                                                                                           |
+| `inferenceExtension.image.name`                            | Name of the container image used for the endpoint picker.                                                                                                                                                                                          |
+| `inferenceExtension.image.hub`                             | Registry URL where the endpoint picker image is hosted.                                                                                                                                                                                            |
+| `inferenceExtension.image.tag`                             | Image tag of the endpoint picker.                                                                                                                                                                                                                  |
+| `inferenceExtension.image.pullPolicy`                      | Image pull policy for the container. Possible values: `Always`, `IfNotPresent`, or `Never`. Defaults to `Always`.                                                                                                                                  |
+| `inferenceExtension.env`                                   | List of environment variables to set in the endpoint picker container as free-form YAML. Defaults to `[]`.                                                                                                                                         |
+| `inferenceExtension.extraContainerPorts`                   | List of additional container ports to expose. Defaults to `[]`.                                                                                                                                                                                    |
+| `inferenceExtension.extraServicePorts`                     | List of additional service ports to expose. Defaults to `[]`.                                                                                                                                                                                      |
+| `inferenceExtension.flags`                                 | map of flags which are passed through to endpoint picker. Example flags, enable-pprof, grpc-port etc. Refer [runner.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/cmd/epp/runner/runner.go) for complete list. |
+| `inferenceExtension.affinity`                              | Affinity for the endpoint picker. Defaults to `{}`.                                                                                                                                                                                                |
+| `inferenceExtension.tolerations`                           | Tolerations for the endpoint picker. Defaults to `[]`.                                                                                                                                                                                             |
+| `inferenceExtension.monitoring.interval`                   | Metrics scraping interval for monitoring. Defaults to `10s`.                                                                                                                                                                                       |
+| `inferenceExtension.monitoring.prometheus.enabled`         | Enable Prometheus ServiceMonitor creation for EPP metrics collection. Defaults to `false`.                                                                                                                                                         |
+| `inferenceExtension.monitoring.gke.enabled`                | **DEPRECATED**: This field is deprecated and will be removed in the next release.  Enable GKE monitoring resources (`PodMonitoring` and RBAC). Defaults to `false`.                                                                                |
+| `inferenceExtension.monitoring.prometheus.auth.enabled`    | Enable auth for Prometheus metrics endpoint. Defaults is `true`                                                                                                                                                                                    |
+| `inferenceExtension.monitoring.prometheus.auth.secretName` | Name of the service account token secret for metrics authentication. Defaults to `inference-gateway-sa-metrics-reader-secret`.                                                                                                                     |
+| `inferenceExtension.monitoring.prometheus.extraLabels`     | Extra labels added to ServiceMonitor.                                                                                                                                                                                                              |
+| `inferenceExtension.pluginsCustomConfig`                   | Custom config that is passed to EPP as inline yaml.                                                                                                                                                                                                |
+| `inferenceExtension.tracing.enabled`                       | Enables or disables OpenTelemetry tracing globally for the EndpointPicker.                                                                                                                                                                         |
+| `inferenceExtension.tracing.otelExporterEndpoint`          | OpenTelemetry collector endpoint.                                                                                                                                                                                                                  |
+| `inferenceExtension.tracing.sampling.sampler`              | The trace sampler to use. Currently, only `parentbased_traceidratio` is supported. This sampler respects the parent span’s sampling decision when present, and applies the configured ratio for root spans.                                        |
+| `inferenceExtension.tracing.sampling.samplerArg`           | Sampler-specific argument. For `parentbased_traceidratio`, this defines the base sampling rate for new traces (root spans), as a float string in the range [0.0, 1.0]. For example, "0.1" enables 10% sampling.                                    |
+| `inferenceExtension.volumes`                               | List of volumes to mount in the EPP deployment as free-form YAML. Optional.                                                                                                                                                                       |
+| `inferenceExtension.volumeMounts`                          | List of volume mounts for the EPP container as free-form YAML. Optional.                                                                                                                                                                          |
+| `experimentalHttpRoute.enabled`                             | Boolean flag to indicate whether the helm chart should create HttpRoute. Defaults to `False`. Optional.                                                                                                                                                       |
+| `experimentalHttpRoute.inferenceGatewayName`                             | Name of the inference-gateway to be used when creating the HttpRoute. Used only if `experimentalHttpRoute` is enabled. Optional.                         |
+| `experimentalHttpRoute.baseModel`                             | Base model used in the current instance of the epp. When this value is set the HttpRoute will be set to match the pool based on `X-Gateway-Base-Model-Name` header. Optional.                                                                                                                                                                       |
+| `inferenceExtension.sidecar.enabled`                       | Enables or disables the sidecar container in the EPP deployment. Defaults to `false`.                                                                                                                                                             |
+| `inferenceExtension.sidecar.name`                          | Name of the sidecar container. Required when the sidecar is enabled.                                                                                                                                                                              |
+| `inferenceExtension.sidecar.image`                         | Image for the sidecar container. Required when the sidecar is enabled.                                                                                                                                                                            |
+| `inferenceExtension.sidecar.imagePullPolicy`               | Image pull policy for the sidecar container. Possible values: `Always`, `IfNotPresent`, or `Never`. Defaults to `IfNotPresent`.                                                                                                                  |
+| `inferenceExtension.sidecar.command`                       | Command to run in the sidecar container as a single string. Optional.                                                                                                                                                                             |
+| `inferenceExtension.sidecar.args`                          | Arguments to pass to the command in the sidecar container as a list of strings. Optional.                                                                                                                                                         |
+| `inferenceExtension.sidecar.env`                           | Environment variables to set in the sidecar container as free-form YAML. Optional.                                                                                                                                                                |
+| `inferenceExtension.sidecar.ports`                         | List of ports to expose for the sidecar container. Optional.                                                                                                                                                                                      |
+| `inferenceExtension.sidecar.livenessProbe`                 | Liveness probe configuration for the sidecar container. Optional.                                                                                                                                                                                 |
+| `inferenceExtension.sidecar.readinessProbe`                | Readiness probe configuration for the sidecar container. Optional.                                                                                                                                                                                |
+| `inferenceExtension.sidecar.resources`                     | Resource limits and requests for the sidecar container. Optional.                                                                                                                                                                                 |
+| `inferenceExtension.sidecar.volumeMounts`                  | List of volume mounts for the sidecar container. Optional.                                                                                                                                                                                        |
+| `inferenceExtension.sidecar.volumes`                       | List of volumes for the sidecar container. Optional.                                                                                                                                                                                              |
+| `inferenceExtension.sidecar.configMapData`                 | Custom key-value pairs to be included in a ConfigMap created for the sidecar container. Only used when `inferenceExtension.sidecar.enabled` is `true`. Optional.                                                                                           |
+| `provider.name`                                            | Name of the Inference Gateway implementation being used. Possible values: [`none`, `gke`, or `istio`]. Defaults to `none`.                                                                                                                         |
+| `provider.gke.autopilot`                                   | Set to `true` if the cluster is a GKE Autopilot cluster. This is only used if `provider.name` is `gke`. Defaults to `false`.                                                                                                                       |
+
+### Provider Specific Configuration
+
+This section should document any Gateway provider specific values configurations.
+
+#### Istio
+
+These are the options available to you with `provider.name` set to `istio`:
+
+| **Parameter Name**                          | **Description**                                                                                                        |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `istio.destinationRule.host`            | Custom host value for the destination rule. If not set this will use the default value which is derrived from the epp service name and release namespace to gerenate a valid service address. |
+| `istio.destinationRule.trafficPolicy.connectionPool`            | Configure the connectionPool level settings of the traffic policy |
+
+#### OpenTelemetry
+
+The EndpointPicker supports OpenTelemetry-based tracing. To enable trace collection, use the following configuration:
+```yaml
+inferenceExtension:
+  tracing:
+    enabled: true
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
+```
+Make sure that the `otelExporterEndpoint` points to your OpenTelemetry collector endpoint. 
+Current only the `parentbased_traceidratio` sampler is supported. You can adjust the base sampling ratio using the `samplerArg` (e.g., 0.1 means 10% of traces will be sampled).
+
+## Notes
+
+This chart will only deploy an InferencePool and its corresponding EndpointPicker extension. Before install the chart, please make sure that the inference extension CRDs are installed in the cluster. For more details, please refer to the [getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).

--- a/charts/inferencepool/inferencepool/charts/inferencepool/.helmignore
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/inferencepool/inferencepool/charts/inferencepool/Chart.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: v1.3.0
+description: A Helm chart for InferencePool
+name: inferencepool
+type: application
+version: v1.3.0

--- a/charts/inferencepool/inferencepool/charts/inferencepool/README.md
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/README.md
@@ -1,0 +1,302 @@
+# InferencePool
+
+A chart to deploy an InferencePool and a corresponding EndpointPicker (epp) deployment.  
+
+## Install
+
+To install an InferencePool named `vllm-llama3-8b-instruct`  that selects from endpoints with label `app: vllm-llama3-8b-instruct` and listening on port `8000`, you can run the following command:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+```
+
+To install via the latest published chart in staging  (--version v0 indicates latest dev version), you can run the following command:
+
+```txt
+$ helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+Note that the provider name is needed to deploy provider-specific resources. If no provider is specified, then only the InferencePool object and the EPP are deployed.
+
+### Install with Custom Cmd-line Flags
+
+To set cmd-line flags, you can use the `--set` option to set each flag, e.g.,:
+
+```txt
+$ helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set inferenceExtension.flags.<FLAG_NAME>=<FLAG_VALUE>
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+Alternatively, you can define flags in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  flags:
+    FLAG_NAME: <FLAG_VALUE>
+    v: 3 ## Log verbosity
+    ...
+```
+
+### Install with Custom Environment Variables
+
+To set custom environment variables for the EndpointPicker deployment, you can define them as free-form YAML in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  env:
+    - name: FEATURE_FLAG_ENABLED
+      value: "true"
+    - name: CUSTOM_ENV_VAR
+      value: "custom_value"
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+```
+
+Then apply it with:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+### Install with Custom EPP Plugins Configuration
+
+To set custom EPP plugin config, you can pass it as an inline yaml. For example:
+
+```yaml
+  inferenceExtension:
+    pluginsCustomConfig:
+      custom-plugins.yaml: |
+        apiVersion: inference.networking.x-k8s.io/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: custom-scorer
+          parameters:
+            custom-threshold: 64
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: custom-scorer
+```
+
+### Install with Additional Ports
+
+To expose additional ports (e.g., for ZMQ), you can define them in the `values.yaml` file:
+
+```yaml
+inferenceExtension:
+  extraContainerPorts:
+    - name: zmq
+      containerPort: 5557
+      protocol: TCP
+  extraServicePorts: # if need to expose the port for external communication
+    - name: zmq
+      port: 5557
+      protocol: TCP
+```
+
+Then apply it with:
+
+```txt
+$ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+### Install for Triton TensorRT-LLM
+
+Use `--set inferencePool.modelServerType=triton-tensorrt-llm` to install for Triton TensorRT-LLM, e.g.,
+
+```txt
+$ helm install triton-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=triton-llama3-8b-instruct \
+  --set inferencePool.modelServerType=triton-tensorrt-llm \
+  --set provider.name=[none|gke|istio] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+```
+
+### Install with Latency-Based Routing
+
+For full details see the dedicated [Latency-Based Routing Guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/latency-based-predictor.md)
+
+#### Latency-Based Router Configuration
+
+The behavior of the latency-based router can be fine-tuned using the configuration parameters under `inferenceExtension.latencyPredictor.sloAwareRouting` in your `values.yaml` file.
+
+| Parameter                        | Description                                                                                             | Default     |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------- |
+| `samplingMean`                   | The sampling mean (lambda) for the Poisson distribution of token sampling.                              | `100.0`     |
+| `maxSampledTokens`               | The maximum number of tokens to sample for TPOT prediction.                                             | `20`        |
+| `sloBufferFactor`                | A buffer to apply to the SLO to make it more or less strict.                                            | `1.0`       |
+| `negHeadroomTTFTWeight`          | The weight to give to the TTFT when a pod has negative headroom.                                        | `0.8`       |
+| `negHeadroomTPOTWeight`          | The weight to give to the TPOT when a pod has negative headroom.                                        | `0.2`       |
+| `headroomTTFTWeight`             | The weight to give to the TTFT when a pod has positive headroom.                                        | `0.8`       |
+| `headroomTPOTWeight`             | The weight to give to the TPOT when a pod has positive headroom.                                        | `0.2`       |
+| `headroomSelectionStrategy`      | The strategy to use for selecting a pod based on headroom. Options: `least`, `most`, `composite-least`, `composite-most`, `composite-only`. | `least`     |
+| `compositeKVWeight`              | The weight for KV cache in the composite score.                                                         | `1.0`       |
+| `compositeQueueWeight`           | The weight for queue size in the composite score.                                                       | `1.0`       |
+| `compositePrefixWeight`          | The weight for prefix cache in the composite score.                                                     | `1.0`       |
+| `epsilonExploreSticky`           | Exploration factor for sticky sessions.                                                                 | `0.01`      |
+| `epsilonExploreNeg`              | Exploration factor for negative headroom.                                                               | `0.01`      |
+| `affinityGateTau`                | Affinity gate threshold.                                                                                | `0.80`      |
+| `affinityGateTauGlobal`          | Global affinity gate threshold.                                                                         | `0.99`      |
+| `selectionMode`                  | The mode for selection (e.g., "linear").                                                                | `linear`    |
+
+**Note:** Enabling SLO-aware routing also exposes a number of Prometheus metrics for monitoring the feature, including actual vs. predicted latency, SLO violations, and more.
+
+### Install with High Availability (HA)
+
+To deploy the EndpointPicker in a high-availability (HA) active-passive configuration set replicas to be greater than one. In such a setup, only one "leader" replica will be active and ready to process traffic at any given time. If the leader pod fails, another pod will be elected as the new leader, ensuring service continuity.
+
+To enable HA, set `inferenceExtension.replicas` to a number greater than 1.
+
+* Via `--set` flag:
+
+  ```txt
+  helm install vllm-llama3-8b-instruct \
+  --set inferencePool.modelServers.matchLabels.app=vllm-llama3-8b-instruct \
+  --set inferenceExtension.replicas=3 \
+  --set provider=[none|gke] \
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
+  ```
+
+* Via `values.yaml`:
+
+  ```yaml
+  inferenceExtension:
+    replicas: 3
+  ```
+
+  Then apply it with:
+
+  ```txt
+  helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+  ```
+
+### Install with Monitoring
+
+To enable metrics collection and monitoring for the EndpointPicker, you can configure Prometheus ServiceMonitor creation:
+
+```yaml
+inferenceExtension:
+  monitoring:
+    interval: "10s"
+    prometheus:
+      enabled: false
+      auth:
+        enabled: true
+        secretName: inference-gateway-sa-metrics-reader-secret
+      extraLabels: {}
+```
+
+**Note:** Prometheus monitoring requires the Prometheus Operator and ServiceMonitor CRD to be installed in the cluster.
+
+For GKE environments, you need to set `provider.name` to `gke` firstly. This will create the necessary `PodMonitoring` and RBAC resources for metrics collection.
+
+If you are using a GKE Autopilot cluster, you also need to set `provider.gke.autopilot` to `true`.
+
+Then apply it with:
+
+```txt
+helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
+```
+
+## Uninstall
+
+Run the following command to uninstall the chart:
+
+```txt
+$ helm uninstall pool-1
+```
+
+## Configuration
+
+The following table list the configurable parameters of the chart.
+
+| **Parameter Name**                                         | **Description**                                                                                                                                                                                                                                    |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inferencePool.apiVersion`                                 | The API version of the InferencePool resource. Defaults to `inference.networking.k8s.io/v1`. This can be changed to `inference.networking.x-k8s.io/v1alpha2` to support older API versions.                                                        |
+| `inferencePool.targetPortNumber`                           | Target port number for the vllm backends, will be used to scrape metrics by the inference extension. Defaults to 8000.                                                                                                                             |
+| `inferencePool.modelServerType`                            | Type of the model servers in the pool, valid options are [vllm, triton-tensorrt-llm], default is vllm.                                                                                                                                             |
+| `inferencePool.modelServers.matchLabels`                   | Label selector to match vllm backends managed by the inference pool.                                                                                                                                                                               |
+| `inferenceExtension.replicas`                              | Number of replicas for the endpoint picker extension service. If More than one replica is used, EPP will run in HA active-passive mode. Defaults to `1`.                                                                                           |
+| `inferenceExtension.image.name`                            | Name of the container image used for the endpoint picker.                                                                                                                                                                                          |
+| `inferenceExtension.image.hub`                             | Registry URL where the endpoint picker image is hosted.                                                                                                                                                                                            |
+| `inferenceExtension.image.tag`                             | Image tag of the endpoint picker.                                                                                                                                                                                                                  |
+| `inferenceExtension.image.pullPolicy`                      | Image pull policy for the container. Possible values: `Always`, `IfNotPresent`, or `Never`. Defaults to `Always`.                                                                                                                                  |
+| `inferenceExtension.env`                                   | List of environment variables to set in the endpoint picker container as free-form YAML. Defaults to `[]`.                                                                                                                                         |
+| `inferenceExtension.extraContainerPorts`                   | List of additional container ports to expose. Defaults to `[]`.                                                                                                                                                                                    |
+| `inferenceExtension.extraServicePorts`                     | List of additional service ports to expose. Defaults to `[]`.                                                                                                                                                                                      |
+| `inferenceExtension.flags`                                 | map of flags which are passed through to endpoint picker. Example flags, enable-pprof, grpc-port etc. Refer [runner.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/cmd/epp/runner/runner.go) for complete list. |
+| `inferenceExtension.affinity`                              | Affinity for the endpoint picker. Defaults to `{}`.                                                                                                                                                                                                |
+| `inferenceExtension.tolerations`                           | Tolerations for the endpoint picker. Defaults to `[]`.                                                                                                                                                                                             |
+| `inferenceExtension.monitoring.interval`                   | Metrics scraping interval for monitoring. Defaults to `10s`.                                                                                                                                                                                       |
+| `inferenceExtension.monitoring.prometheus.enabled`         | Enable Prometheus ServiceMonitor creation for EPP metrics collection. Defaults to `false`.                                                                                                                                                         |
+| `inferenceExtension.monitoring.gke.enabled`                | **DEPRECATED**: This field is deprecated and will be removed in the next release.  Enable GKE monitoring resources (`PodMonitoring` and RBAC). Defaults to `false`.                                                                                |
+| `inferenceExtension.monitoring.prometheus.auth.enabled`    | Enable auth for Prometheus metrics endpoint. Defaults is `true`                                                                                                                                                                                    |
+| `inferenceExtension.monitoring.prometheus.auth.secretName` | Name of the service account token secret for metrics authentication. Defaults to `inference-gateway-sa-metrics-reader-secret`.                                                                                                                     |
+| `inferenceExtension.monitoring.prometheus.extraLabels`     | Extra labels added to ServiceMonitor.                                                                                                                                                                                                              |
+| `inferenceExtension.pluginsCustomConfig`                   | Custom config that is passed to EPP as inline yaml.                                                                                                                                                                                                |
+| `inferenceExtension.tracing.enabled`                       | Enables or disables OpenTelemetry tracing globally for the EndpointPicker.                                                                                                                                                                         |
+| `inferenceExtension.tracing.otelExporterEndpoint`          | OpenTelemetry collector endpoint.                                                                                                                                                                                                                  |
+| `inferenceExtension.tracing.sampling.sampler`              | The trace sampler to use. Currently, only `parentbased_traceidratio` is supported. This sampler respects the parent span’s sampling decision when present, and applies the configured ratio for root spans.                                        |
+| `inferenceExtension.tracing.sampling.samplerArg`           | Sampler-specific argument. For `parentbased_traceidratio`, this defines the base sampling rate for new traces (root spans), as a float string in the range [0.0, 1.0]. For example, "0.1" enables 10% sampling.                                    |
+| `inferenceExtension.volumes`                               | List of volumes to mount in the EPP deployment as free-form YAML. Optional.                                                                                                                                                                       |
+| `inferenceExtension.volumeMounts`                          | List of volume mounts for the EPP container as free-form YAML. Optional.                                                                                                                                                                          |
+| `experimentalHttpRoute.enabled`                             | Boolean flag to indicate whether the helm chart should create HttpRoute. Defaults to `False`. Optional.                                                                                                                                                       |
+| `experimentalHttpRoute.inferenceGatewayName`                             | Name of the inference-gateway to be used when creating the HttpRoute. Used only if `experimentalHttpRoute` is enabled. Optional.                         |
+| `experimentalHttpRoute.baseModel`                             | Base model used in the current instance of the epp. When this value is set the HttpRoute will be set to match the pool based on `X-Gateway-Base-Model-Name` header. Optional.                                                                                                                                                                       |
+| `inferenceExtension.sidecar.enabled`                       | Enables or disables the sidecar container in the EPP deployment. Defaults to `false`.                                                                                                                                                             |
+| `inferenceExtension.sidecar.name`                          | Name of the sidecar container. Required when the sidecar is enabled.                                                                                                                                                                              |
+| `inferenceExtension.sidecar.image`                         | Image for the sidecar container. Required when the sidecar is enabled.                                                                                                                                                                            |
+| `inferenceExtension.sidecar.imagePullPolicy`               | Image pull policy for the sidecar container. Possible values: `Always`, `IfNotPresent`, or `Never`. Defaults to `IfNotPresent`.                                                                                                                  |
+| `inferenceExtension.sidecar.command`                       | Command to run in the sidecar container as a single string. Optional.                                                                                                                                                                             |
+| `inferenceExtension.sidecar.args`                          | Arguments to pass to the command in the sidecar container as a list of strings. Optional.                                                                                                                                                         |
+| `inferenceExtension.sidecar.env`                           | Environment variables to set in the sidecar container as free-form YAML. Optional.                                                                                                                                                                |
+| `inferenceExtension.sidecar.ports`                         | List of ports to expose for the sidecar container. Optional.                                                                                                                                                                                      |
+| `inferenceExtension.sidecar.livenessProbe`                 | Liveness probe configuration for the sidecar container. Optional.                                                                                                                                                                                 |
+| `inferenceExtension.sidecar.readinessProbe`                | Readiness probe configuration for the sidecar container. Optional.                                                                                                                                                                                |
+| `inferenceExtension.sidecar.resources`                     | Resource limits and requests for the sidecar container. Optional.                                                                                                                                                                                 |
+| `inferenceExtension.sidecar.volumeMounts`                  | List of volume mounts for the sidecar container. Optional.                                                                                                                                                                                        |
+| `inferenceExtension.sidecar.volumes`                       | List of volumes for the sidecar container. Optional.                                                                                                                                                                                              |
+| `inferenceExtension.sidecar.configMapData`                 | Custom key-value pairs to be included in a ConfigMap created for the sidecar container. Only used when `inferenceExtension.sidecar.enabled` is `true`. Optional.                                                                                           |
+| `provider.name`                                            | Name of the Inference Gateway implementation being used. Possible values: [`none`, `gke`, or `istio`]. Defaults to `none`.                                                                                                                         |
+| `provider.gke.autopilot`                                   | Set to `true` if the cluster is a GKE Autopilot cluster. This is only used if `provider.name` is `gke`. Defaults to `false`.                                                                                                                       |
+
+### Provider Specific Configuration
+
+This section should document any Gateway provider specific values configurations.
+
+#### Istio
+
+These are the options available to you with `provider.name` set to `istio`:
+
+| **Parameter Name**                          | **Description**                                                                                                        |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `istio.destinationRule.host`            | Custom host value for the destination rule. If not set this will use the default value which is derrived from the epp service name and release namespace to gerenate a valid service address. |
+| `istio.destinationRule.trafficPolicy.connectionPool`            | Configure the connectionPool level settings of the traffic policy |
+
+#### OpenTelemetry
+
+The EndpointPicker supports OpenTelemetry-based tracing. To enable trace collection, use the following configuration:
+```yaml
+inferenceExtension:
+  tracing:
+    enabled: true
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
+```
+Make sure that the `otelExporterEndpoint` points to your OpenTelemetry collector endpoint. 
+Current only the `parentbased_traceidratio` sampler is supported. You can adjust the base sampling ratio using the `samplerArg` (e.g., 0.1 means 10% of traces will be sampled).
+
+## Notes
+
+This chart will only deploy an InferencePool and its corresponding EndpointPicker extension. Before install the chart, please make sure that the inference extension CRDs are installed in the cluster. For more details, please refer to the [getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/NOTES.txt
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/NOTES.txt
@@ -1,0 +1,1 @@
+InferencePool {{ .Release.Name }} deployed.

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/_helpers.tpl
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Common labels
+*/}}
+{{- define "gateway-api-inference-extension.labels" -}}
+app.kubernetes.io/name: {{ include "gateway-api-inference-extension.name" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Inference extension name
+*/}}
+{{- define "gateway-api-inference-extension.name" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
+{{ $base }}-epp
+{{- end -}}
+
+{{/*
+Cluster RBAC unique name
+*/}}
+{{- define "gateway-api-inference-extension.cluster-rbac-name" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 }}
+{{- $ns := .Release.Namespace | default "default" | lower | trim | trunc 40 }}
+{{- printf "%s-%s-epp" $base $ns | quote | trunc 84 }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gateway-api-inference-extension.selectorLabels" -}}
+inferencepool: {{ include "gateway-api-inference-extension.name" . }}
+{{- end -}}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/_latency-predictor.tpl
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/_latency-predictor.tpl
@@ -1,0 +1,112 @@
+{{/*
+Latency Predictor Env
+*/}}
+{{- define "gateway-api-inference-extension.latencyPredictor.env" -}}
+{{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+- name: PREDICTION_SERVER_URL
+  value: "{{- $count := int .Values.inferenceExtension.latencyPredictor.predictionServers.count -}}
+          {{- $startPort := int .Values.inferenceExtension.latencyPredictor.predictionServers.startPort -}}
+          {{- range $i := until $count -}}
+            {{- if $i }},{{ end }}http://localhost:{{ add $startPort $i }}
+          {{- end }}"
+- name: TRAINING_SERVER_URL
+  value: "http://localhost:{{ .Values.inferenceExtension.latencyPredictor.trainingServer.port }}"
+{{- range $key, $value := .Values.inferenceExtension.latencyPredictor.eppEnv }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Latency Predictor Sidecar Containers
+*/}}
+{{- define "gateway-api-inference-extension.latencyPredictor.containers" -}}
+{{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+# Training Server Sidecar Container
+- name: training-server
+  image: {{ .Values.inferenceExtension.latencyPredictor.trainingServer.image.hub }}/{{ .Values.inferenceExtension.latencyPredictor.trainingServer.image.name }}:{{ .Values.inferenceExtension.latencyPredictor.trainingServer.image.tag }}
+  imagePullPolicy: {{ .Values.inferenceExtension.latencyPredictor.trainingServer.image.pullPolicy }}
+  ports:
+  - containerPort: {{ .Values.inferenceExtension.latencyPredictor.trainingServer.port }}
+    name: training-port
+  livenessProbe:
+    {{- toYaml .Values.inferenceExtension.latencyPredictor.trainingServer.livenessProbe | nindent 4 }}
+  readinessProbe:
+    {{- toYaml .Values.inferenceExtension.latencyPredictor.trainingServer.readinessProbe | nindent 4 }}
+  resources:
+    {{- toYaml .Values.inferenceExtension.latencyPredictor.trainingServer.resources | nindent 4 }}
+  envFrom:
+  - configMapRef:
+      name: {{ include "gateway-api-inference-extension.name" . }}-latency-predictor-training
+  env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: SERVER_TYPE
+    value: "training"
+  volumeMounts:
+  - name: training-server-storage
+    mountPath: /models
+{{- range $i := until (int .Values.inferenceExtension.latencyPredictor.predictionServers.count) }}
+# Prediction Server Sidecar Container {{ add $i 1 }}
+- name: prediction-server-{{ add $i 1 }}
+  image: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.image.hub }}/{{ $.Values.inferenceExtension.latencyPredictor.predictionServers.image.name }}:{{ $.Values.inferenceExtension.latencyPredictor.predictionServers.image.tag }}
+  imagePullPolicy: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.image.pullPolicy }}
+  command: ["uvicorn"]
+  args: ["prediction_server:app", "--host", "0.0.0.0", "--port", "{{ add $.Values.inferenceExtension.latencyPredictor.predictionServers.startPort $i }}"]
+  ports:
+  - containerPort: {{ add $.Values.inferenceExtension.latencyPredictor.predictionServers.startPort $i }}
+    name: predict-port-{{ add $i 1 }}
+  livenessProbe:
+    httpGet:
+      path: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.livenessProbe.httpGet.path }}
+      port: {{ add $.Values.inferenceExtension.latencyPredictor.predictionServers.startPort $i }}
+    initialDelaySeconds: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.livenessProbe.initialDelaySeconds }}
+    periodSeconds: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.livenessProbe.periodSeconds }}
+  readinessProbe:
+    httpGet:
+      path: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.readinessProbe.httpGet.path }}
+      port: {{ add $.Values.inferenceExtension.latencyPredictor.predictionServers.startPort $i }}
+    initialDelaySeconds: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.readinessProbe.initialDelaySeconds }}
+    periodSeconds: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.readinessProbe.periodSeconds }}
+    failureThreshold: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.readinessProbe.failureThreshold }}
+  resources:
+    {{- toYaml $.Values.inferenceExtension.latencyPredictor.predictionServers.resources | nindent 4 }}
+  envFrom:
+  - configMapRef:
+      name: {{ include "gateway-api-inference-extension.name" $ }}-latency-predictor-prediction
+  env:
+  - name: PREDICT_PORT
+    value: "{{ add $.Values.inferenceExtension.latencyPredictor.predictionServers.startPort $i }}"
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: SERVER_TYPE
+    value: "prediction-{{ add $i 1 }}"
+  - name: TRAINING_SERVER_URL
+    value: "http://localhost:{{ $.Values.inferenceExtension.latencyPredictor.trainingServer.port }}"
+  volumeMounts:
+  - name: prediction-server-{{ add $i 1 }}-storage
+    mountPath: /server_models
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Latency Predictor Volumes
+*/}}
+{{- define "gateway-api-inference-extension.latencyPredictor.volumes" -}}
+{{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+- name: training-server-storage
+  emptyDir: 
+    sizeLimit: {{ .Values.inferenceExtension.latencyPredictor.trainingServer.volumeSize }}
+{{- range $i := until (int .Values.inferenceExtension.latencyPredictor.predictionServers.count) }}
+- name: prediction-server-{{ add $i 1 }}-storage
+  emptyDir: 
+    sizeLimit: {{ $.Values.inferenceExtension.latencyPredictor.predictionServers.volumeSize }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/_validations.tpl
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/_validations.tpl
@@ -1,0 +1,8 @@
+{{/*
+common validations
+*/}}
+{{- define "gateway-api-inference-extension.validations.inferencepool.common" -}}
+{{- if or (empty $.Values.inferencePool.modelServers) (not $.Values.inferencePool.modelServers.matchLabels) }}
+{{- fail ".Values.inferencePool.modelServers.matchLabels is required" }}
+{{- end }}
+{{- end -}}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-config.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  default-plugins.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: queue-scorer
+    - type: kv-cache-utilization-scorer
+    - type: prefix-cache-scorer
+    {{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+    - type: predicted-latency-scorer
+      parameters:
+        {{- with .Values.inferenceExtension.latencyPredictor.sloAwareRouting | default dict }}
+        samplingMean: {{ .samplingMean | default 1000.0 }}
+        maxSampledTokens: {{ .maxSampledTokens | default 20 }}
+        sloBufferFactor: {{ .sloBufferFactor | default 1.0 }}
+        negHeadroomTTFTWeight: {{ .negHeadroomTTFTWeight | default 0.8 }}
+        negHeadroomTPOTWeight: {{ .negHeadroomTPOTWeight | default 0.2 }}
+        headroomTTFTWeight: {{ .headroomTTFTWeight | default 0.8 }}
+        headroomTPOTWeight: {{ .headroomTPOTWeight | default 0.2 }}
+        headroomSelectionStrategy: {{ .headroomSelectionStrategy | default "least" | quote }}
+        compositeKVWeight: {{ .compositeKVWeight | default 1.0 }}
+        compositeQueueWeight: {{ .compositeQueueWeight | default 1.0 }}
+        compositePrefixWeight: {{ .compositePrefixWeight | default 1.0 }}
+        epsilonExploreSticky: {{ .epsilonExploreSticky | default 0.01 }}
+        epsilonExploreNeg: {{ .epsilonExploreNeg | default 0.01 }}
+        affinityGateTau: {{ .affinityGateTau | default 0.80 }}
+        affinityGateTauGlobal: {{ .affinityGateTauGlobal | default 0.99 }}
+        selectionMode: {{ .selectionMode | default "linear" | quote }}
+        {{- end }}
+    {{- end }}
+    schedulingProfiles:
+    {{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+    - name: default
+      plugins:
+      - pluginRef: predicted-latency-scorer
+    featureGates:
+      - prepareDataPlugins
+    {{- else }}
+    - name: default
+      plugins:
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+    {{- end }}
+  {{- if (hasKey .Values.inferenceExtension "pluginsCustomConfig") }}
+  {{- .Values.inferenceExtension.pluginsCustomConfig | toYaml | nindent 2 }}
+  {{- end }}
+  
+---
+{{- if and .Values.inferenceExtension.sidecar.enabled .Values.inferenceExtension.sidecar.configMapData }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-sidecar
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- .Values.inferenceExtension.sidecar.configMapData | toYaml | nindent 2 }}
+{{- end }}
+---
+{{- if .Values.inferenceExtension.latencyPredictor.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-latency-predictor-training
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range $key, $value := .Values.inferenceExtension.latencyPredictor.trainingServer.config }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-latency-predictor-prediction
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range $key, $value := .Values.inferenceExtension.latencyPredictor.predictionServers.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-deployment.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-deployment.yaml
@@ -1,0 +1,211 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.inferenceExtension.replicas | default 1 }}
+  strategy:
+    # The current recommended EPP deployment pattern is to have a single active replica. This ensures 
+    # optimal performance of the stateful operations such prefix cache aware scorer.
+    # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to 
+    # quickly take over. This is particularly important in the high availability set up with leader
+    # election, as the rolling update strategy would prevent the old leader being killed because 
+    # otherwise the maxUnavailable would be 100%.
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "gateway-api-inference-extension.name" . }}
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
+      containers:
+      {{- if .Values.inferenceExtension.sidecar.enabled }}
+      - name: {{ .Values.inferenceExtension.sidecar.name }}
+        image: {{ .Values.inferenceExtension.sidecar.image }}
+        imagePullPolicy: {{ .Values.inferenceExtension.sidecar.imagePullPolicy | default "IfNotPresent" }}
+        {{- with .Values.inferenceExtension.sidecar.command }}
+        command:
+          - {{ . | quote }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.args }}
+        args:
+          {{- range . }}
+            - {{ tpl . $ | quote }}
+          {{- end }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.env }}
+        env:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.ports }}
+        ports:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.inferenceExtension.sidecar.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+      - name: epp
+        image: {{ .Values.inferenceExtension.image.hub }}/{{ .Values.inferenceExtension.image.name }}:{{ .Values.inferenceExtension.image.tag }}
+        imagePullPolicy: {{ .Values.inferenceExtension.image.pullPolicy | default "IfNotPresent" }}
+        args:
+        - --pool-name
+        - {{ .Release.Name }}
+        # The pool namespace is optional because EPP can default to the NAMESPACE env var.
+        # We still keep this here so that the template works with older versions of EPP, or other
+        # distros of EPP which may not have implemented the NAMESPACE env var defaulting behavior.
+        - --pool-namespace
+        - {{ .Release.Namespace }}
+        {{- if ne .Values.inferencePool.apiVersion "inference.networking.k8s.io" }}
+        - --pool-group
+        - "{{ (split "/" .Values.inferencePool.apiVersion)._0 }}"
+        {{- end }}
+        - --zap-encoder
+        - "json"
+        - --config-file
+        - "/config/{{ .Values.inferenceExtension.pluginsConfigFile }}"
+        {{- if eq (.Values.inferencePool.modelServerType | default "vllm") "triton-tensorrt-llm" }}
+        - --total-queued-requests-metric
+        - "nv_trt_llm_request_metrics{request_type=waiting}"
+        - --kv-cache-usage-percentage-metric
+        - "nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=fraction}"
+        - --lora-info-metric
+        - "" # Set an empty metric to disable LoRA metric scraping as they are not supported by Triton yet.
+        {{- end }}
+        {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}
+        - --ha-enable-leader-election
+        {{- end }}
+        # Pass additional flags via the inferenceExtension.flags field in values.yaml.
+        {{- range $key, $value := .Values.inferenceExtension.flags }}
+        - --{{ $key }}
+        - "{{ $value }}"
+        {{- end }}
+        {{- if .Values.inferenceExtension.tracing.enabled }}
+        - --tracing=true
+        {{- else }}
+        - --tracing=false
+        {{- end }}
+        {{- if not .Values.inferenceExtension.monitoring.prometheus.auth.enabled }}
+        - --metrics-endpoint-auth=false
+        {{- end }}
+        ports:
+        - name: grpc
+          containerPort: 9002
+        - name: grpc-health
+          containerPort: 9003
+        - name: metrics
+          containerPort: 9090
+        {{- if .Values.inferenceExtension.extraContainerPorts }}
+        {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 8 }}
+        {{- end }}
+        livenessProbe:
+          {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}
+          grpc:
+            port: 9003
+            service: liveness
+          {{- else }}
+          grpc:
+            port: 9003
+            service: inference-extension
+          {{- end }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}
+          grpc:
+            port: 9003
+            service: readiness
+          {{- else }}
+          grpc:
+            port: 9003
+            service: inference-extension
+          {{- end }}
+          periodSeconds: 2
+        {{- with .Values.inferenceExtension.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- include "gateway-api-inference-extension.latencyPredictor.env" . | nindent 8 }}
+        {{- if .Values.inferenceExtension.tracing.enabled }}
+        - name: OTEL_SERVICE_NAME
+          value: "gateway-api-inference-extension"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.inferenceExtension.tracing.otelExporterEndpoint | quote }}
+        - name: OTEL_TRACES_EXPORTER
+          value: "otlp"
+        - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: 'k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)'
+        - name: OTEL_TRACES_SAMPLER
+          value: {{ .Values.inferenceExtension.tracing.sampling.sampler | quote }}
+        - name: OTEL_TRACES_SAMPLER_ARG
+          value: {{ .Values.inferenceExtension.tracing.sampling.samplerArg | quote }}
+        {{- end }}
+        {{- if .Values.inferenceExtension.env }}
+        {{- toYaml .Values.inferenceExtension.env | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: plugins-config-volume
+          mountPath: "/config"
+        {{- if .Values.inferenceExtension.volumeMounts }}
+        {{- toYaml .Values.inferenceExtension.volumeMounts | nindent 8 }}
+        {{- end }}
+      {{- include "gateway-api-inference-extension.latencyPredictor.containers" . | nindent 6 }}
+      volumes:
+      {{- if .Values.inferenceExtension.volumes }}
+      {{- toYaml .Values.inferenceExtension.volumes | nindent 6 }}
+      {{- end }}
+      {{- if .Values.inferenceExtension.sidecar.volumes }}
+      {{- tpl (toYaml .Values.inferenceExtension.sidecar.volumes) $ | nindent 6 }}
+      {{- end }}
+      - name: plugins-config-volume
+        configMap:
+          name: {{ include "gateway-api-inference-extension.name" . }}
+      {{- include "gateway-api-inference-extension.latencyPredictor.volumes" . | nindent 6 }}
+      {{- if .Values.inferenceExtension.affinity }}
+      affinity:
+        {{- toYaml .Values.inferenceExtension.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.inferenceExtension.tolerations }}
+      tolerations:
+        {{- toYaml .Values.inferenceExtension.tolerations | nindent 8 }}
+      {{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-sa-token-secret.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-sa-token-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.inferenceExtension.monitoring.prometheus.enabled .Values.inferenceExtension.monitoring.prometheus.auth.enabled (ne (lower .Values.provider.name) "gke") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.inferenceExtension.monitoring.prometheus.auth.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "gateway-api-inference-extension.name" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-service.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ .Values.inferenceExtension.extProcPort | default 9002 }}
+    - name: http-metrics
+      protocol: TCP
+      port: {{ .Values.inferenceExtension.metricsPort | default 9090 }}
+    {{- with .Values.inferenceExtension.extraServicePorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  type: ClusterIP

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-servicemonitor.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.inferenceExtension.monitoring.prometheus.enabled (ne (lower .Values.provider.name) "gke") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+    {{- with .Values.inferenceExtension.monitoring.prometheus.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.inferenceExtension.monitoring.interval }}
+    port: "http-metrics"
+    path: "/metrics"
+    {{- if .Values.inferenceExtension.monitoring.prometheus.auth.enabled }}
+    authorization:
+      credentials:
+        key: token
+        name: {{ .Values.inferenceExtension.monitoring.prometheus.auth.secretName }}
+    {{- end }}
+  jobLabel: {{ include "gateway-api-inference-extension.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "gateway-api-inference-extension.labels" . | nindent 6 }}
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/gke.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/gke.yaml
@@ -1,0 +1,146 @@
+{{- if eq (lower .Values.provider.name) "gke" }}
+---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: "{{ (split "/" .Values.inferencePool.apiVersion)._0 }}"
+    kind: InferencePool
+    name: {{ .Release.Name }}
+  default:
+    # Set a more aggressive health check than the default 5s for faster switch
+    # over during EPP rollout.
+    timeoutSec: 2
+    checkIntervalSec: 2
+    config:
+      type: HTTP
+      httpHealthCheck:
+          requestPath: /health
+          port:  {{ .Values.inferencePool.targetPortNumber }}
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: "{{ (split "/" .Values.inferencePool.apiVersion)._0 }}"
+    kind: InferencePool
+    name: {{ .Release.Name }}
+  default:
+    timeoutSec: 300    # 5-minute timeout (adjust as needed)
+    logging:
+      enabled: true    # log all requests by default
+---
+{{- if and .Values.inferenceExtension.monitoring.prometheus.enabled .Values.inferenceExtension.monitoring.prometheus.auth.enabled }}
+{{- $metricsReadSA := printf "%s-metrics-reader-sa" .Release.Name -}}
+{{- $metricsReadSecretName := printf "%s-metrics-reader-secret" .Release.Name -}}
+{{- $metricsReadRoleName := printf "%s-%s-metrics-reader" .Release.Namespace .Release.Name -}}
+{{- $metricsReadRoleBindingName := printf "%s-%s-metrics-reader-role-binding" .Release.Namespace .Release.Name -}}
+{{- $secretReadRoleName := printf "%s-metrics-reader-secret-read" .Release.Name -}}
+{{- $gmpNamespace := "gmp-system" -}}
+{{- $isAutopilot := false -}}
+{{- with .Values.provider.gke }}
+  {{- $isAutopilot = .autopilot | default false -}}
+{{- end }}
+{{- if $isAutopilot -}}
+{{-   $gmpNamespace = "gke-gmp-system" -}}
+{{- end -}}
+{{- $gmpCollectorRoleBindingName := printf "%s:collector:%s-%s-metrics-reader-secret-read" $gmpNamespace .Release.Namespace .Release.Name -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $metricsReadSA }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $metricsReadSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $metricsReadSA }}
+type: kubernetes.io/service-account-token
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: metrics
+    scheme: http
+    interval: {{ .Values.inferenceExtension.monitoring.interval }}
+    path: /metrics
+    authorization:
+      type: Bearer
+      credentials:
+        secret:
+          name: {{ $metricsReadSecretName }}
+          key: token
+  selector:
+    matchLabels:
+      {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 8 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $metricsReadRoleName }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $metricsReadRoleBindingName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $metricsReadSA }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $metricsReadRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $secretReadRoleName }}
+rules:
+- resources:
+  - secrets
+  apiGroups: [""]
+  verbs: ["get", "list", "watch"]
+  resourceNames: [{{ $metricsReadSecretName | quote }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $gmpCollectorRoleBindingName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ $secretReadRoleName }}
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- name: collector
+  namespace: {{ $gmpNamespace }}
+  kind: ServiceAccount
+{{- end }}
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.experimentalHttpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.experimentalHttpRoute.inferenceGatewayName }}
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: {{ .Release.Name }}
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+      {{- if .Values.experimentalHttpRoute.baseModel }}
+      headers:
+        - type: Exact
+          name: X-Gateway-Base-Model-Name
+          value: {{ .Values.experimentalHttpRoute.baseModel }}
+      {{- end }}
+    timeouts:
+      request: 300s
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/inferencepool.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/inferencepool.yaml
@@ -1,0 +1,48 @@
+{{ if eq .Values.inferencePool.apiVersion "inference.networking.x-k8s.io/v1alpha2"}}
+apiVersion: {{ .Values.inferencePool.apiVersion }}
+kind: InferencePool
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  targetPortNumber: {{ .Values.inferencePool.targetPortNumber | default 8000 }}
+  selector:
+    {{- if .Values.inferencePool.modelServers.matchLabels }}
+    {{- range $key, $value := .Values.inferencePool.modelServers.matchLabels }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+    {{- end }}
+  extensionRef:
+    name: {{ include "gateway-api-inference-extension.name" . }}
+    portNumber: {{ .Values.inferenceExtension.extProcPort | default 9002 }}
+    failureMode: {{ .Values.inferenceExtension.failureMode | default "FailClose" }}
+{{ else }}
+{{ include "gateway-api-inference-extension.validations.inferencepool.common" $ }}
+apiVersion: "inference.networking.k8s.io/v1"
+kind: InferencePool
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+spec:
+  targetPorts:
+    {{- range .Values.inferencePool.targetPorts }}
+      - number: {{ .number }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- if .Values.inferencePool.modelServers.matchLabels }}
+      {{- range $key, $value := .Values.inferencePool.modelServers.matchLabels }}
+      {{ $key }}: {{ quote $value }}
+      {{- end }}
+      {{- end }}
+  endpointPickerRef:
+    name: {{ include "gateway-api-inference-extension.name" . }}
+    port:
+      number: {{ .Values.inferenceExtension.extProcPort | default 9002 }}
+{{- end }}
+
+

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/istio.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/istio.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.provider.name "istio" }}
+{{- /* Prefer .Values.provider.istio, fallback to legacy .Values.istio, then {} */ -}}
+{{- $provIstio := (index .Values "provider" "istio") -}}
+{{- $legacyIstio := .Values.istio -}}
+{{- $istio := coalesce $provIstio $legacyIstio (dict) -}}
+{{- $dr := (index $istio "destinationRule") | default (dict) -}}
+
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+spec:
+  host: {{ (index $dr "host") | default (printf "%s.%s.svc.cluster.local" (include "gateway-api-inference-extension.name" .) .Release.Namespace) }}
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+    {{- with (index (index $dr "trafficPolicy") "connectionPool") }}
+    connectionPool:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/leader-election-rbac.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/leader-election-rbac.yaml
@@ -1,0 +1,30 @@
+{{- if gt (.Values.inferenceExtension.replicas | int) 1 }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+rules:
+- apiGroups: [ "coordination.k8s.io" ]
+  resources: [ "leases" ]
+  verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+- apiGroups: [ "" ]
+  resources: [ "events" ]
+  verbs: [ "create", "patch" ]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}-leader-election-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gateway-api-inference-extension.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gateway-api-inference-extension.name" . }}-leader-election
+{{- end }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/rbac.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/rbac.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.inferenceExtension.monitoring.prometheus.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["inference.networking.x-k8s.io"]
+  resources: ["inferenceobjectives", "inferencemodelrewrites"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["{{ (split "/" .Values.inferencePool.apiVersion)._0 }}"]
+  resources: ["inferencepools"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gateway-api-inference-extension.name" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gateway-api-inference-extension.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}

--- a/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
@@ -1,0 +1,188 @@
+inferenceExtension:
+  replicas: 1
+  image:
+    name: epp
+    hub: registry.k8s.io/gateway-api-inference-extension
+    tag: v1.3.0
+    pullPolicy: Always
+  extProcPort: 9002
+  env: []
+  pluginsConfigFile: "default-plugins.yaml"
+  # Define additional container ports
+  extraContainerPorts: []
+  # Define additional service ports
+  extraServicePorts: []
+  #  extraServicePorts:
+  #    - name: http
+  #      port: 8081
+  #      protocol: TCP
+  #      targetPort: 8081
+
+  # This is the plugins configuration file.
+  # pluginsCustomConfig:
+  #   custom-plugins.yaml: |
+  #     apiVersion: inference.networking.x-k8s.io/v1alpha1
+  #     kind: EndpointPickerConfig
+  #     plugins:
+  #     - type: custom-scorer
+  #       parameters:
+  #         custom-threshold: 64
+  #     schedulingProfiles:
+  #     - name: default
+  #       plugins:
+  #       - pluginRef: custom-scorer
+
+  # Example environment variables:
+  # env:
+  #   ENABLE_EXPERIMENTAL_FEATURE: "true"
+  flags:
+    # Log verbosity
+    v: 1
+  affinity: {}
+  tolerations: []
+  # Sidecar configuration for EPP
+  sidecar:
+    enabled: false
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: false
+      auth:
+        enabled: true
+        # Service account token secret for authentication
+        secretName: inference-gateway-sa-metrics-reader-secret
+      # additional labels for the ServiceMonitor
+      extraLabels: {}
+  tracing:
+    enabled: false
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
+  # Latency Predictor Configuration
+  latencyPredictor:
+    enabled: false
+    # Training Server Configuration
+    trainingServer:
+      image:
+        hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
+        name: latencypredictor-training-server
+        tag: v1.3.0
+        pullPolicy: Always
+      port: 8000
+      resources:
+        requests:
+          cpu: "2000m"
+          memory: "4Gi"
+        limits:
+          cpu: "4000m"
+          memory: "8Gi"
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8000
+        initialDelaySeconds: 30
+        periodSeconds: 20
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: 8000
+        initialDelaySeconds: 45
+        periodSeconds: 10
+      volumeSize: "20Gi"
+      config:
+        LATENCY_RETRAINING_INTERVAL_SEC: "1"
+        LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
+        LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
+        LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
+        LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
+        LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
+        LATENCY_MODEL_TYPE: "xgboost"
+        LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "5000"
+        LATENCY_QUANTILE_ALPHA: "0.9"
+    # Prediction Server Configuration
+    predictionServers:
+      count: 10
+      startPort: 8001
+      image:
+        hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
+        name: latencypredictor-prediction-server
+        tag: v1.3.0
+        pullPolicy: Always
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "2Gi"
+      livenessProbe:
+        httpGet:
+          path: /healthz
+        initialDelaySeconds: 15
+        periodSeconds: 15
+      readinessProbe:
+        httpGet:
+          path: /readyz
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        failureThreshold: 10
+      volumeSize: "10Gi"
+      config:
+        LATENCY_MODEL_TYPE: "xgboost"
+        PREDICT_HOST: "0.0.0.0"
+        LOCAL_TTFT_MODEL_PATH: "/server_models/ttft.joblib"
+        LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
+        LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
+        LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
+    # EPP Environment Variables for Latency Predictor
+    eppEnv:
+      LATENCY_MAX_SAMPLE_SIZE: "10000"
+inferencePool:
+  targetPorts:
+    - number: 8000
+  modelServerType: vllm # vllm, triton-tensorrt-llm
+  apiVersion: inference.networking.k8s.io/v1
+  # modelServers: # REQUIRED
+  #   matchLabels:
+  #     app: vllm-llama3-8b-instruct
+
+  # Should only used if apiVersion is inference.networking.x-k8s.io/v1alpha2, 
+  # This will soon be deprecated when upstream GW providers support v1, just doing something simple for now.
+  targetPortNumber: 8000
+# Options: ["gke", "istio", "none"]
+provider:
+  name: none
+  # GKE-specific configuration.
+  # This block is only used if name is "gke".
+  gke:
+    # Set to true if the cluster is an Autopilot cluster.
+    autopilot: false
+  # Istio-specific configuration.
+  # This block is only used if name is "istio".
+  istio:
+    destinationRule:
+      # Provide a way to override the default calculated host
+      host: ""
+      # Optional: Enables customization of the traffic policy
+      trafficPolicy: {}
+      # connectionPool:
+      #   http:
+      #     maxRequestsPerConnection: 256000
+# experimentalHttpRoute section is used to deploy httproute as part of the epp helm chart.
+# this section is temporary and should be extracted to a separate chart.
+experimentalHttpRoute:
+  enabled: false # a flag to indicate whether to create the httproute as part of the chart or not.
+  inferenceGatewayName: inference-gateway
+# DEPRECATED and will be removed in v1.3. Instead, use `provider.istio.*`.
+istio:
+  destinationRule:
+    # Provide a way to override the default calculated host
+    host: ""
+    # Optional: Enables customization of the traffic policy
+    trafficPolicy: {}
+    # connectionPool:
+    #   http:
+    #     maxRequestsPerConnection: 256000

--- a/charts/inferencepool/inferencepool/values.schema.json
+++ b/charts/inferencepool/inferencepool/values.schema.json
@@ -1,0 +1,478 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "inferencepool": {
+            "type": "object",
+            "properties": {
+                "experimentalHttpRoute": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "inferenceGatewayName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "inferenceExtension": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "env": {
+                            "type": "array"
+                        },
+                        "extProcPort": {
+                            "type": "integer"
+                        },
+                        "extraContainerPorts": {
+                            "type": "array"
+                        },
+                        "extraServicePorts": {
+                            "type": "array"
+                        },
+                        "flags": {
+                            "type": "object",
+                            "properties": {
+                                "v": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "hub": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "latencyPredictor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "eppEnv": {
+                                    "type": "object",
+                                    "properties": {
+                                        "LATENCY_MAX_SAMPLE_SIZE": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "predictionServers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "config": {
+                                            "type": "object",
+                                            "properties": {
+                                                "LATENCY_MODEL_TYPE": {
+                                                    "type": "string"
+                                                },
+                                                "LOCAL_TPOT_MODEL_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LOCAL_TPOT_SCALER_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LOCAL_TTFT_MODEL_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LOCAL_TTFT_SCALER_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "PREDICT_HOST": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "count": {
+                                            "type": "integer"
+                                        },
+                                        "image": {
+                                            "type": "object",
+                                            "properties": {
+                                                "hub": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "pullPolicy": {
+                                                    "type": "string"
+                                                },
+                                                "tag": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "livenessProbe": {
+                                            "type": "object",
+                                            "properties": {
+                                                "httpGet": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "path": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "initialDelaySeconds": {
+                                                    "type": "integer"
+                                                },
+                                                "periodSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "readinessProbe": {
+                                            "type": "object",
+                                            "properties": {
+                                                "failureThreshold": {
+                                                    "type": "integer"
+                                                },
+                                                "httpGet": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "path": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "initialDelaySeconds": {
+                                                    "type": "integer"
+                                                },
+                                                "periodSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "resources": {
+                                            "type": "object",
+                                            "properties": {
+                                                "limits": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "cpu": {
+                                                            "type": "string"
+                                                        },
+                                                        "memory": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "requests": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "cpu": {
+                                                            "type": "string"
+                                                        },
+                                                        "memory": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "startPort": {
+                                            "type": "integer"
+                                        },
+                                        "volumeSize": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "trainingServer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "config": {
+                                            "type": "object",
+                                            "properties": {
+                                                "LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_MIN_SAMPLES_FOR_RETRAIN": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_MODEL_TYPE": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_QUANTILE_ALPHA": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_RETRAINING_INTERVAL_SEC": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_TPOT_MODEL_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_TPOT_SCALER_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_TTFT_MODEL_PATH": {
+                                                    "type": "string"
+                                                },
+                                                "LATENCY_TTFT_SCALER_PATH": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "image": {
+                                            "type": "object",
+                                            "properties": {
+                                                "hub": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "pullPolicy": {
+                                                    "type": "string"
+                                                },
+                                                "tag": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "livenessProbe": {
+                                            "type": "object",
+                                            "properties": {
+                                                "httpGet": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "path": {
+                                                            "type": "string"
+                                                        },
+                                                        "port": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                },
+                                                "initialDelaySeconds": {
+                                                    "type": "integer"
+                                                },
+                                                "periodSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "readinessProbe": {
+                                            "type": "object",
+                                            "properties": {
+                                                "httpGet": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "path": {
+                                                            "type": "string"
+                                                        },
+                                                        "port": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                },
+                                                "initialDelaySeconds": {
+                                                    "type": "integer"
+                                                },
+                                                "periodSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "resources": {
+                                            "type": "object",
+                                            "properties": {
+                                                "limits": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "cpu": {
+                                                            "type": "string"
+                                                        },
+                                                        "memory": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "requests": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "cpu": {
+                                                            "type": "string"
+                                                        },
+                                                        "memory": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "volumeSize": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "monitoring": {
+                            "type": "object",
+                            "properties": {
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "auth": {
+                                            "type": "object",
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                },
+                                                "secretName": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "extraLabels": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "pluginsConfigFile": {
+                            "type": "string"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "sidecar": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "tracing": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "otelExporterEndpoint": {
+                                    "type": "string"
+                                },
+                                "sampling": {
+                                    "type": "object",
+                                    "properties": {
+                                        "sampler": {
+                                            "type": "string"
+                                        },
+                                        "samplerArg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "inferencePool": {
+                    "type": "object",
+                    "properties": {
+                        "apiVersion": {
+                            "type": "string"
+                        },
+                        "modelServerType": {
+                            "type": "string"
+                        },
+                        "targetPortNumber": {
+                            "type": "integer"
+                        },
+                        "targetPorts": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "number": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "istio": {
+                    "type": "object",
+                    "properties": {
+                        "destinationRule": {
+                            "type": "object",
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "trafficPolicy": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "provider": {
+                    "type": "object",
+                    "properties": {
+                        "gke": {
+                            "type": "object",
+                            "properties": {
+                                "autopilot": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "istio": {
+                            "type": "object",
+                            "properties": {
+                                "destinationRule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "host": {
+                                            "type": "string"
+                                        },
+                                        "trafficPolicy": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/inferencepool/inferencepool/values.yaml
+++ b/charts/inferencepool/inferencepool/values.yaml
@@ -1,0 +1,200 @@
+# child values
+inferencepool:
+  inferenceExtension:
+    replicas: 1
+    image:
+      name: gateway-api-inference-extension/epp
+      hub: k8s.m.daocloud.io
+      tag: v1.3.0
+      pullPolicy: Always
+    extProcPort: 9002
+    env: []
+    pluginsConfigFile: "default-plugins.yaml"
+    # Define additional container ports
+    extraContainerPorts: []
+    # Define additional service ports
+    extraServicePorts: []
+    #  extraServicePorts:
+    #    - name: http
+    #      port: 8081
+    #      protocol: TCP
+    #      targetPort: 8081
+
+    # This is the plugins configuration file.
+    # pluginsCustomConfig:
+    #   custom-plugins.yaml: |
+    #     apiVersion: inference.networking.x-k8s.io/v1alpha1
+    #     kind: EndpointPickerConfig
+    #     plugins:
+    #     - type: custom-scorer
+    #       parameters:
+    #         custom-threshold: 64
+    #     schedulingProfiles:
+    #     - name: default
+    #       plugins:
+    #       - pluginRef: custom-scorer
+
+    # Example environment variables:
+    # env:
+    #   ENABLE_EXPERIMENTAL_FEATURE: "true"
+    flags:
+      # Log verbosity
+      v: 1
+    affinity: {}
+    tolerations: []
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1Gi
+      limits:
+        cpu: 4000m
+        memory: 8Gi
+    # Sidecar configuration for EPP
+    sidecar:
+      enabled: false
+    # Monitoring configuration for EPP
+    monitoring:
+      interval: "10s"
+      # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+      prometheus:
+        enabled: false
+        auth:
+          enabled: true
+          # Service account token secret for authentication
+          secretName: inference-gateway-sa-metrics-reader-secret
+        # additional labels for the ServiceMonitor
+        extraLabels: {}
+    tracing:
+      enabled: false
+      otelExporterEndpoint: "http://localhost:4317"
+      sampling:
+        sampler: "parentbased_traceidratio"
+        samplerArg: "0.1"
+    # Latency Predictor Configuration
+    latencyPredictor:
+      enabled: false
+      # Training Server Configuration
+      trainingServer:
+        image:
+          hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
+          name: latencypredictor-training-server
+          tag: v1.3.0
+          pullPolicy: Always
+        port: 8000
+        resources:
+          requests:
+            cpu: "2000m"
+            memory: "4Gi"
+          limits:
+            cpu: "4000m"
+            memory: "8Gi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8000
+          initialDelaySeconds: 45
+          periodSeconds: 10
+        volumeSize: "20Gi"
+        config:
+          LATENCY_RETRAINING_INTERVAL_SEC: "1"
+          LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
+          LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
+          LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
+          LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
+          LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
+          LATENCY_MODEL_TYPE: "xgboost"
+          LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "5000"
+          LATENCY_QUANTILE_ALPHA: "0.9"
+      # Prediction Server Configuration
+      predictionServers:
+        count: 10
+        startPort: 8001
+        image:
+          hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
+          name: latencypredictor-prediction-server
+          tag: v1.3.0
+          pullPolicy: Always
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "1000m"
+            memory: "2Gi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+          initialDelaySeconds: 15
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /readyz
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 10
+        volumeSize: "10Gi"
+        config:
+          LATENCY_MODEL_TYPE: "xgboost"
+          PREDICT_HOST: "0.0.0.0"
+          LOCAL_TTFT_MODEL_PATH: "/server_models/ttft.joblib"
+          LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
+          LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
+          LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
+      # EPP Environment Variables for Latency Predictor
+      eppEnv:
+        LATENCY_MAX_SAMPLE_SIZE: "10000"
+  inferencePool:
+    targetPorts:
+      - number: 8000
+    modelServerType: vllm # vllm, triton-tensorrt-llm
+    apiVersion: inference.networking.k8s.io/v1
+    # modelServers: # REQUIRED
+    #   matchLabels:
+    #     app: vllm-llama3-8b-instruct
+
+    # Should only used if apiVersion is inference.networking.x-k8s.io/v1alpha2, 
+    # This will soon be deprecated when upstream GW providers support v1, just doing something simple for now.
+    targetPortNumber: 8000
+    modelServers:
+      matchLabels:
+        app: vllm-llama3-8b-instruct
+  # Options: ["gke", "istio", "none"]
+  provider: # REQUIRED
+    name: none
+    # GKE-specific configuration.
+    # This block is only used if name is "gke".
+    gke:
+      # Set to true if the cluster is an Autopilot cluster.
+      autopilot: false
+    # Istio-specific configuration.
+    # This block is only used if name is "istio".
+    istio:
+      destinationRule:
+        # Provide a way to override the default calculated host
+        host: ""
+        # Optional: Enables customization of the traffic policy
+        trafficPolicy: {}
+        # connectionPool:
+        #   http:
+        #     maxRequestsPerConnection: 256000
+  # experimentalHttpRoute section is used to deploy httproute as part of the epp helm chart.
+  # this section is temporary and should be extracted to a separate chart.
+  experimentalHttpRoute:
+    enabled: false # a flag to indicate whether to create the httproute as part of the chart or not.
+    inferenceGatewayName: inference-gateway
+  # DEPRECATED and will be removed in v1.3. Instead, use `provider.istio.*`.
+  istio:
+    destinationRule:
+      # Provide a way to override the default calculated host
+      host: ""
+      # Optional: Enables customization of the traffic policy
+      trafficPolicy: {}
+      # connectionPool:
+      #   http:
+      #     maxRequestsPerConnection: 256000

--- a/charts/inferencepool/parent/.relok8s-images.yaml
+++ b/charts/inferencepool/parent/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .inferencepool.inferenceExtension.image.hub }}/{{ .inferencepool.inferenceExtension.image.name }}:{{ .inferencepool.inferenceExtension.image.tag }}"

--- a/charts/inferencepool/skip-check.yaml
+++ b/charts/inferencepool/skip-check.yaml
@@ -1,0 +1,12 @@
+inferencepool:
+  - "inferencePool/modelServers/matchLabels/app"
+  - "inferencePool/modelServers/matchLabels"
+  - "inferencePool/modelServers"
+  - "inferenceExtension/resources/requests/cpu"
+  - "inferenceExtension/resources/requests/memory"
+  - "inferenceExtension/resources/requests"
+  - "inferenceExtension/resources"
+  - "inferenceExtension/resources/limits/cpu"
+  - "inferenceExtension/resources/limits/memory"
+  - "inferenceExtension/resources/limits"
+

--- a/scripts/generateChart.sh
+++ b/scripts/generateChart.sh
@@ -79,9 +79,14 @@ fi
 #======
 
 echo "generate $PROJECT_NAME chart from custom chart "
-helm repo add $REPO_NAME $REPO_URL
-(($?!=0)) && echo "error, failed to add repo" && exit 7
-helm repo update $REPO_NAME
+if [[ "$REPO_URL" == oci://* ]]; then
+    REPO_NAME=${REPO_URL}
+    echo "REPO_URL is OCI-based, skipping helm repo operations"
+else
+  helm repo add $REPO_NAME $REPO_URL
+  (($?!=0)) && echo "error, failed to add repo" && exit 7
+  helm repo update $REPO_NAME
+fi
 
 cd $BUILD_DIR
 helm pull ${REPO_NAME}/${CHART_NAME} --untar --version $VERSION


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #