### PR TITLE
add-llm-d-modelservice-charts

### DIFF
--- a/charts/llm-d-modelservice/config
+++ b/charts/llm-d-modelservice/config
@@ -1,0 +1,23 @@
+export USE_OPENSOURCE_CHART=false
+
+export REPO_URL=https://llm-d-incubation.github.io/llm-d-modelservice
+export REPO_NAME=llm-d-modelservice
+export CHART_NAME=llm-d-modelservice
+export VERSION=v0.4.5
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=learner0810
+export TEST_ASSIGNER=learner0810
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# SKIP_SCHEMA
+export SKIP_SCHEMA=true
+
+# Use charts-syncer v2(dt) in the e2e pipeline
+export USE_CHARTS_SYNCER_DT=true

--- a/charts/llm-d-modelservice/custom.sh
+++ b/charts/llm-d-modelservice/custom.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+CHART_DIRECTORY=$1
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd $CHART_DIRECTORY
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#==============================
+
+yq eval -i '
+  (.llm-d-modelservice.decode.containers[] | select(.image) | .image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.llm-d-modelservice.prefill.containers[] | select(.image) | .image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.llm-d-modelservice.requester.image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.llm-d-modelservice.routing.proxy.image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  )
+' values.yaml
+
+yq eval -i '
+  (.decode.containers[] | select(.image) | .image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.prefill.containers[] | select(.image) | .image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.requester.image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  ) |
+  (.routing.proxy.image) |= (
+    split(":") as $parts |
+    {
+      "registry": ($parts[0] | split("/") | .[0]),
+      "repository": ($parts[0] | split("/") | .[1:] | join("/")),
+      "tag": ($parts[1] // "latest")
+    }
+  )
+' charts/llm-d-modelservice/values.yaml
+
+yq eval -i '
+  (.llm-d-modelservice.decode.containers[].image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.llm-d-modelservice.prefill.containers[].image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.llm-d-modelservice.requester.image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.llm-d-modelservice.routing.proxy.image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io"
+' values.yaml
+
+yq eval -i '
+  (.decode.containers[].image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.prefill.containers[].image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.requester.image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io" |
+  (.routing.proxy.image.registry | select(. == "ghcr.io")) |= "ghcr.m.daocloud.io"
+' charts/llm-d-modelservice/values.yaml
+
+if [ "$(uname)" = "Darwin" ]; then
+  SED_INPLACE=(-i '')
+else
+  SED_INPLACE=(-i)
+fi
+
+sed "${SED_INPLACE[@]}" \
+  -e '/{{- if and .container .container.image (contains "llm-d-inference-sim" .container.image) -}}/{
+    N
+    s/{{- if and .container .container.image (contains "llm-d-inference-sim" .container.image) -}}/{{- $fullImage := include "llm-d-modelservice.imageAddress" .container.image -}}\
+{{- if and .container .container.image (contains "llm-d-inference-sim" $fullImage) -}}/
+  }' \
+  charts/llm-d-modelservice/templates/_helpers.tpl
+
+sed "${SED_INPLACE[@]}" \
+  -e 's/image: {{ required "\(.*\)" \.container\.image }}/image: {{ required "\1" (include "llm-d-modelservice.imageAddress" .container.image) }}/g' \
+  -e 's/image: {{ required "\(.*\)" \.proxy\.image }}/image: {{ required "\1" (include "llm-d-modelservice.imageAddress" .proxy.image) }}/g' \
+  charts/llm-d-modelservice/templates/_helpers.tpl
+
+
+rm -rf charts/llm-d-modelservice/values.schema.json charts/llm-d-modelservice/values.schema.tmpl.json
+
+CPU_LIMIT=${CPU_LIMIT:-"1"}
+MEMORY_LIMIT=${MEMORY_LIMIT:-"1Gi"}
+yq -i "
+  (.llm-d-modelservice.decode.containers[] | select(.name == \"vllm\") | .resources.limits) |= {
+    \"cpu\": \"${CPU_LIMIT}\",
+    \"memory\": \"${MEMORY_LIMIT}\"
+  } |
+  (.llm-d-modelservice.prefill.containers[] | select(.name == \"vllm\") | .resources.limits) |= {
+    \"cpu\": \"${CPU_LIMIT}\",
+    \"memory\": \"${MEMORY_LIMIT}\"
+  }
+" values.yaml
+
+yq eval -i '.keywords |= (. + ["inference"] | unique)' Chart.yaml
+
+yq -i '.annotations.images = "- image: ghcr.m.daocloud.io/llm-d/llm-d-routing-sidecar:latest
+  name: llm-d-routing-sidecar
+- image: ghcr.m.daocloud.io/llm-d/llm-d-inference-sim:latest
+  name: llm-d-inference-sim
+"' Chart.yaml

--- a/charts/llm-d-modelservice/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+appVersion: v0.4.0
+description: A Helm chart for ModelService in llm-d
+maintainers:
+  - email: jing.chen2@ibm.com
+    name: Jing Chen
+    url: https://github.com/jgchn
+  - email: kalantar@us.ibm.com
+    name: Michael Kalantar
+    url: https://github.com/kalantar
+name: llm-d-modelservice
+sources:
+  - https://github.com/llm-d-incubation/llm-d-modelservice
+type: application
+version: v0.4.5
+dependencies:
+  - name: llm-d-modelservice
+    version: "v0.4.5"
+    repository: "https://llm-d-incubation.github.io/llm-d-modelservice"
+keywords:
+  - inference
+annotations:
+  images: |
+    - image: ghcr.m.daocloud.io/llm-d/llm-d-routing-sidecar:latest
+      name: llm-d-routing-sidecar
+    - image: ghcr.m.daocloud.io/llm-d/llm-d-inference-sim:latest
+      name: llm-d-inference-sim

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/.helmignore
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/Chart.lock
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.27.0
+digest: sha256:19b8483e731784bfe20a4d8d60dea334748d9a44d6661eeecffc3e8c15ff98c7
+generated: "2025-07-25T14:58:16.234637-04:00"

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+appVersion: v0.4.0
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - bitnami-common
+  version: 2.27.0
+description: A Helm chart for ModelService in llm-d
+maintainers:
+- email: jing.chen2@ibm.com
+  name: Jing Chen
+  url: https://github.com/jgchn
+- email: kalantar@us.ibm.com
+  name: Michael Kalantar
+  url: https://github.com/kalantar
+name: llm-d-modelservice
+sources:
+- https://github.com/llm-d-incubation/llm-d-modelservice
+type: application
+version: v0.4.5

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/.helmignore
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# img folder
+img/
+# Changelog
+CHANGELOG.md

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/Chart.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/Chart.yaml
@@ -1,0 +1,23 @@
+annotations:
+  category: Infrastructure
+  licenses: Apache-2.0
+apiVersion: v2
+appVersion: 2.27.0
+description: A Library Helm Chart for grouping common logic between bitnami charts.
+  This chart is not deployable by itself.
+home: https://bitnami.com
+icon: https://bitnami.com/downloads/logos/bitnami-mark.png
+keywords:
+- common
+- helper
+- template
+- function
+- bitnami
+maintainers:
+- name: Broadcom, Inc. All Rights Reserved.
+  url: https://github.com/bitnami/charts
+name: common
+sources:
+- https://github.com/bitnami/charts/tree/main/bitnami/common
+type: library
+version: 2.27.0

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/README.md
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/README.md
@@ -1,0 +1,235 @@
+# Bitnami Common Library Chart
+
+A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for grouping common logic between Bitnami charts.
+
+## TL;DR
+
+```yaml
+dependencies:
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
+```
+
+```console
+helm dependency update
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+data:
+  myvalue: "Hello World"
+```
+
+Looking to use our applications in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.
+
+## Introduction
+
+This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.8.0+
+
+## Parameters
+
+## Special input schemas
+
+### ImageRoot
+
+```yaml
+registry:
+  type: string
+  description: Docker registry where the image is located
+  example: docker.io
+
+repository:
+  type: string
+  description: Repository and image name
+  example: bitnami/nginx
+
+tag:
+  type: string
+  description: image tag
+  example: 1.16.1-debian-10-r63
+
+pullPolicy:
+  type: string
+  description: Specify a imagePullPolicy.'
+
+pullSecrets:
+  type: array
+  items:
+    type: string
+  description: Optionally specify an array of imagePullSecrets (evaluated as templates).
+
+debug:
+  type: boolean
+  description: Set to true if you would like to see extra information on logs
+  example: false
+
+## An instance would be:
+# registry: docker.io
+# repository: bitnami/nginx
+# tag: 1.16.1-debian-10-r63
+# pullPolicy: IfNotPresent
+# debug: false
+```
+
+### Persistence
+
+```yaml
+enabled:
+  type: boolean
+  description: Whether enable persistence.
+  example: true
+
+storageClass:
+  type: string
+  description: Ghost data Persistent Volume Storage Class, If set to "-", storageClassName: "" which disables dynamic provisioning.
+  example: "-"
+
+accessMode:
+  type: string
+  description: Access mode for the Persistent Volume Storage.
+  example: ReadWriteOnce
+
+size:
+  type: string
+  description: Size the Persistent Volume Storage.
+  example: 8Gi
+
+path:
+  type: string
+  description: Path to be persisted.
+  example: /bitnami
+
+## An instance would be:
+# enabled: true
+# storageClass: "-"
+# accessMode: ReadWriteOnce
+# size: 8Gi
+# path: /bitnami
+```
+
+### ExistingSecret
+
+```yaml
+name:
+  type: string
+  description: Name of the existing secret.
+  example: mySecret
+keyMapping:
+  description: Mapping between the expected key name and the name of the key in the existing secret.
+  type: object
+
+## An instance would be:
+# name: mySecret
+# keyMapping:
+#   password: myPasswordKey
+```
+
+#### Example of use
+
+When we store sensitive data for a deployment in a secret, some times we want to give to users the possibility of using theirs existing secrets.
+
+```yaml
+# templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels:
+    app: {{ include "common.names.fullname" . }}
+type: Opaque
+data:
+  password: {{ .Values.password | b64enc | quote }}
+
+# templates/dpl.yaml
+---
+...
+      env:
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
+              key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "password") }}
+...
+
+# values.yaml
+---
+name: mySecret
+keyMapping:
+  password: myPasswordKey
+```
+
+### ValidateValue
+
+#### NOTES.txt
+
+```console
+{{- $validateValueConf00 := (dict "valueKey" "path.to.value00" "secret" "secretName" "field" "password-00") -}}
+{{- $validateValueConf01 := (dict "valueKey" "path.to.value01" "secret" "secretName" "field" "password-01") -}}
+
+{{ include "common.validations.values.multiple.empty" (dict "required" (list $validateValueConf00 $validateValueConf01) "context" $) }}
+```
+
+If we force those values to be empty we will see some alerts
+
+```console
+helm install test mychart --set path.to.value00="",path.to.value01=""
+    'path.to.value00' must not be empty, please add '--set path.to.value00=$PASSWORD_00' to the command. To get the current value:
+
+        export PASSWORD_00=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-00}" | base64 -d)
+
+    'path.to.value01' must not be empty, please add '--set path.to.value01=$PASSWORD_01' to the command. To get the current value:
+
+        export PASSWORD_01=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-01}" | base64 -d)
+```
+
+## Upgrading
+
+### To 1.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+#### What changes were introduced in this major version?
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Use `type: library`. [Here](https://v3.helm.sh/docs/faq/#library-chart-support) you can find more information.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+#### Considerations when upgrading to this version
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+#### Useful links
+
+- <https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-resolve-helm2-helm3-post-migration-issues-index.html>
+- <https://helm.sh/docs/topics/v2_v3_migration/>
+- <https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/>
+
+## License
+
+Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_affinities.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_affinities.tpl
@@ -1,0 +1,155 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return a soft nodeAffinity definition
+{{ include "common.affinities.nodes.soft" (dict "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes.soft" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - preference:
+      matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . | quote }}
+            {{- end }}
+    weight: 1
+{{- end -}}
+
+{{/*
+Return a hard nodeAffinity definition
+{{ include "common.affinities.nodes.hard" (dict "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes.hard" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  nodeSelectorTerms:
+    - matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . | quote }}
+            {{- end }}
+{{- end -}}
+
+{{/*
+Return a nodeAffinity definition
+{{ include "common.affinities.nodes" (dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes" -}}
+  {{- if eq .type "soft" }}
+    {{- include "common.affinities.nodes.soft" . -}}
+  {{- else if eq .type "hard" }}
+    {{- include "common.affinities.nodes.hard" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return a topologyKey definition
+{{ include "common.affinities.topologyKey" (dict "topologyKey" "BAR") -}}
+*/}}
+{{- define "common.affinities.topologyKey" -}}
+{{ .topologyKey | default "kubernetes.io/hostname" -}}
+{{- end -}}
+
+{{/*
+Return a soft podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods.soft" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "extraNamespaces" (list "namespace1" "namespace2") "context" $) -}}
+*/}}
+{{- define "common.affinities.pods.soft" -}}
+{{- $component := default "" .component -}}
+{{- $customLabels := default (dict) .customLabels -}}
+{{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+{{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
+{{- $extraNamespaces := default (list) .extraNamespaces -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - podAffinityTerm:
+      labelSelector:
+        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 10 }}
+          {{- if not (empty $component) }}
+          {{ printf "app.kubernetes.io/component: %s" $component }}
+          {{- end }}
+          {{- range $key, $value := $extraMatchLabels }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      {{- if $extraNamespaces }}
+      namespaces:
+        - {{ .context.Release.Namespace }}
+        {{- with $extraNamespaces }}
+        {{ include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+    weight: 1
+  {{- range $extraPodAffinityTerms }}
+  - podAffinityTerm:
+      labelSelector:
+        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 10 }}
+          {{- if not (empty $component) }}
+          {{ printf "app.kubernetes.io/component: %s" $component }}
+          {{- end }}
+          {{- range $key, $value := .extraMatchLabels }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+    weight: {{ .weight | default 1 -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return a hard podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods.hard" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "extraNamespaces" (list "namespace1" "namespace2") "context" $) -}}
+*/}}
+{{- define "common.affinities.pods.hard" -}}
+{{- $component := default "" .component -}}
+{{- $customLabels := default (dict) .customLabels -}}
+{{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+{{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
+{{- $extraNamespaces := default (list) .extraNamespaces -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 8 }}
+        {{- if not (empty $component) }}
+        {{ printf "app.kubernetes.io/component: %s" $component }}
+        {{- end }}
+        {{- range $key, $value := $extraMatchLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if $extraNamespaces }}
+      namespaces:
+        - {{ .context.Release.Namespace }}
+        {{- with $extraNamespaces }}
+        {{ include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+  {{- range $extraPodAffinityTerms }}
+  - labelSelector:
+      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 8 }}
+        {{- if not (empty $component) }}
+        {{ printf "app.kubernetes.io/component: %s" $component }}
+        {{- end }}
+        {{- range $key, $value := .extraMatchLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return a podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods" (dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.pods" -}}
+  {{- if eq .type "soft" }}
+    {{- include "common.affinities.pods.soft" . -}}
+  {{- else if eq .type "hard" }}
+    {{- include "common.affinities.pods.hard" . -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_capabilities.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_capabilities.tpl
@@ -1,0 +1,229 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "common.capabilities.kubeVersion" -}}
+{{- default (default .Capabilities.KubeVersion.Version .Values.kubeVersion) ((.Values.global).kubeVersion) -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "common.capabilities.policy.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "common.capabilities.networkPolicy.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.7-0" $kubeVersion) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "common.capabilities.cronjob.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for daemonset.
+*/}}
+{{- define "common.capabilities.daemonset.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "common.capabilities.statefulset.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
+{{- print "apps/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if (.Values.ingress).apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC resources.
+*/}}
+{{- define "common.capabilities.rbac.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.17-0" $kubeVersion) -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRDs.
+*/}}
+{{- define "common.capabilities.crd.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
+{{- print "apiextensions.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for APIService.
+*/}}
+{{- define "common.capabilities.apiService.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.10-0" $kubeVersion) -}}
+{{- print "apiregistration.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiregistration.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Horizontal Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.hpa.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Vertical Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.vpa.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if PodSecurityPolicy is supported
+*/}}
+{{- define "common.capabilities.psp.supported" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if or (empty $kubeVersion) (semverCompare "<1.25-0" $kubeVersion) -}}
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if AdmissionConfiguration is supported
+*/}}
+{{- define "common.capabilities.admissionConfiguration.supported" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if or (empty $kubeVersion) (not (semverCompare "<1.23-0" $kubeVersion)) -}}
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for AdmissionConfiguration.
+*/}}
+{{- define "common.capabilities.admissionConfiguration.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
+{{- print "apiserver.config.k8s.io/v1alpha1" -}}
+{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- print "apiserver.config.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiserver.config.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for PodSecurityConfiguration.
+*/}}
+{{- define "common.capabilities.podSecurityConfiguration.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
+{{- print "pod-security.admission.config.k8s.io/v1alpha1" -}}
+{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- print "pod-security.admission.config.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "pod-security.admission.config.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if the used Helm version is 3.3+.
+A way to check the used Helm version was not introduced until version 3.3.0 with .Capabilities.HelmVersion, which contains an additional "{}}"  structure.
+This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVersion }} because checking for the key HelmVersion in <3.3 results in a "interface not found" error.
+**To be removed when the catalog's minimun Helm version is 3.3**
+*/}}
+{{- define "common.capabilities.supportsHelmVersion" -}}
+{{- if regexMatch "{(v[0-9])*[^}]*}}$" (.Capabilities | toString ) }}
+  {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_compatibility.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_compatibility.tpl
@@ -1,0 +1,46 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/* 
+Return true if the detected platform is Openshift
+Usage:
+{{- include "common.compatibility.isOpenshift" . -}}
+*/}}
+{{- define "common.compatibility.isOpenshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
+Usage:
+{{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+*/}}
+{{- define "common.compatibility.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+
+{{- if (((.context.Values.global).compatibility).openshift) -}}
+  {{- if or (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "auto") (include "common.compatibility.isOpenshift" .context)) -}}
+    {{/* Remove incompatible user/group values that do not work in Openshift out of the box */}}
+    {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+    {{- if not .secContext.seLinuxOptions -}}
+    {{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+    {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{/* Remove empty seLinuxOptions object if global.compatibility.omitEmptySeLinuxOptions is set to true */}}
+{{- if and (((.context.Values.global).compatibility).omitEmptySeLinuxOptions) (not .secContext.seLinuxOptions) -}}
+  {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+{{- end -}}
+{{/* Remove fields that are disregarded when running the container in privileged mode */}}
+{{- if $adaptedContext.privileged -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_errors.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_errors.tpl
@@ -1,0 +1,28 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Through error when upgrading using empty passwords values that must not be empty.
+
+Usage:
+{{- $validationError00 := include "common.validations.values.single.empty" (dict "valueKey" "path.to.password00" "secret" "secretName" "field" "password-00") -}}
+{{- $validationError01 := include "common.validations.values.single.empty" (dict "valueKey" "path.to.password01" "secret" "secretName" "field" "password-01") -}}
+{{ include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $validationError00 $validationError01) "context" $) }}
+
+Required password params:
+  - validationErrors - String - Required. List of validation strings to be return, if it is empty it won't throw error.
+  - context - Context - Required. Parent context.
+*/}}
+{{- define "common.errors.upgrade.passwords.empty" -}}
+  {{- $validationErrors := join "" .validationErrors -}}
+  {{- if and $validationErrors .context.Release.IsUpgrade -}}
+    {{- $errorString := "\nPASSWORDS ERROR: You must provide your current passwords when upgrading the release." -}}
+    {{- $errorString = print $errorString "\n                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims." -}}
+    {{- $errorString = print $errorString "\n                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases" -}}
+    {{- $errorString = print $errorString "\n%s" -}}
+    {{- printf $errorString $validationErrors | fail -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_images.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_images.tpl
@@ -1,0 +1,115 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the proper image name.
+If image tag and digest are not defined, termination fallbacks to chart appVersion.
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global "chart" .Chart ) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+
+{{- if not .imageRoot.tag }}
+  {{- if .chart }}
+    {{- $termination = .chart.AppVersion | toString -}}
+  {{- end -}}
+{{- end -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead)
+{{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global) }}
+*/}}
+{{- define "common.images.pullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{- range ((.global).imagePullSecrets) -}}
+    {{- if kindIs "map" . -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- else -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end }}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets .name -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+    {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ include "common.images.renderPullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $) }}
+*/}}
+{{- define "common.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- range (($context.Values.global).imagePullSecrets) -}}
+    {{- if kindIs "map" . -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context)) -}}
+    {{- else -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context)) -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+    {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper image version (ingores image revision/prerelease info & fallbacks to chart appVersion)
+{{ include "common.images.version" ( dict "imageRoot" .Values.path.to.the.image "chart" .Chart ) }}
+*/}}
+{{- define "common.images.version" -}}
+{{- $imageTag := .imageRoot.tag | toString -}}
+{{/* regexp from https://github.com/Masterminds/semver/blob/23f51de38a0866c5ef0bfc42b3f735c73107b700/version.go#L41-L44 */}}
+{{- if regexMatch `^([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$` $imageTag -}}
+    {{- $version := semver $imageTag -}}
+    {{- printf "%d.%d.%d" $version.Major $version.Minor $version.Patch -}}
+{{- else -}}
+    {{- print .chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_ingress.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_ingress.tpl
@@ -1,0 +1,73 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Generate backend entry that is compatible with all Kubernetes API versions.
+
+Usage:
+{{ include "common.ingress.backend" (dict "serviceName" "backendName" "servicePort" "backendPort" "context" $) }}
+
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service. It will be translated to different yaml depending if it is a string or an integer.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "common.ingress.backend" -}}
+{{- $apiVersion := (include "common.capabilities.ingress.apiVersion" .context) -}}
+{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- else -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print "true" if the API pathType field is supported
+Usage:
+{{ include "common.ingress.supportsPathType" . }}
+*/}}
+{{- define "common.ingress.supportsPathType" -}}
+{{- if (semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .)) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if the ingressClassname field is supported
+Usage:
+{{ include "common.ingress.supportsIngressClassname" . }}
+*/}}
+{{- define "common.ingress.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if cert-manager required annotations for TLS signed
+certificates are set in the Ingress annotations
+Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+Usage:
+{{ include "common.ingress.certManagerRequest" ( dict "annotations" .Values.path.to.the.ingress.annotations ) }}
+*/}}
+{{- define "common.ingress.certManagerRequest" -}}
+{{ if or (hasKey .annotations "cert-manager.io/cluster-issuer") (hasKey .annotations "cert-manager.io/issuer") (hasKey .annotations "kubernetes.io/tls-acme") }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_labels.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_labels.tpl
@@ -1,0 +1,46 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Kubernetes standard labels
+{{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) -}}
+*/}}
+{{- define "common.labels.standard" -}}
+{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
+{{- $default := dict "app.kubernetes.io/name" (include "common.names.name" .context) "helm.sh/chart" (include "common.names.chart" .context) "app.kubernetes.io/instance" .context.Release.Name "app.kubernetes.io/managed-by" .context.Release.Service -}}
+{{- with .context.Chart.AppVersion -}}
+{{- $_ := set $default "app.kubernetes.io/version" . -}}
+{{- end -}}
+{{ template "common.tplvalues.merge" (dict "values" (list .customLabels $default) "context" .context) }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+helm.sh/chart: {{ include "common.names.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Labels used on immutable fields such as deploy.spec.selector.matchLabels or svc.spec.selector
+{{ include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $) -}}
+
+We don't want to loop over custom labels appending them to the selector
+since it's very likely that it will break deployments, services, etc.
+However, it's important to overwrite the standard labels if the user
+overwrote them on metadata.labels fields.
+*/}}
+{{- define "common.labels.matchLabels" -}}
+{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
+{{ merge (pick (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) "app.kubernetes.io/name" "app.kubernetes.io/instance") (dict "app.kubernetes.io/name" (include "common.names.name" .context) "app.kubernetes.io/instance" .context.Release.Name ) | toYaml }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_names.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_names.tpl
@@ -1,0 +1,71 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Usage:
+{{ include "common.names.dependency.fullname" (dict "chartName" "dependency-chart-name" "chartValues" .Values.dependency-chart "context" $) }}
+*/}}
+{{- define "common.names.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "common.names.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name adding the installation's namespace.
+*/}}
+{{- define "common.names.fullname.namespace" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) (include "common.names.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_resources.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_resources.tpl
@@ -1,0 +1,50 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return a resource request/limit object based on a given preset.
+These presets are for basic testing and not meant to be used in production
+{{ include "common.resources.preset" (dict "type" "nano") -}}
+*/}}
+{{- define "common.resources.preset" -}}
+{{/* The limits are the requests increased by 50% (except ephemeral-storage and xlarge/2xlarge sizes)*/}}
+{{- $presets := dict 
+  "nano" (dict 
+      "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "2Gi")
+   )
+  "micro" (dict 
+      "requests" (dict "cpu" "250m" "memory" "256Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "375m" "memory" "384Mi" "ephemeral-storage" "2Gi")
+   )
+  "small" (dict 
+      "requests" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "750m" "memory" "768Mi" "ephemeral-storage" "2Gi")
+   )
+  "medium" (dict 
+      "requests" (dict "cpu" "500m" "memory" "1024Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "750m" "memory" "1536Mi" "ephemeral-storage" "2Gi")
+   )
+  "large" (dict 
+      "requests" (dict "cpu" "1.0" "memory" "2048Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "2Gi")
+   )
+  "xlarge" (dict 
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "2Gi")
+   )
+  "2xlarge" (dict 
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "2Gi")
+   )
+ }}
+{{- if hasKey $presets .type -}}
+{{- index $presets .type | toYaml -}}
+{{- else -}}
+{{- printf "ERROR: Preset key '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_secrets.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_secrets.tpl
@@ -1,0 +1,192 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate secret name.
+
+Usage:
+{{ include "common.secrets.name" (dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $) }}
+
+Params:
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/main/bitnami/common#existingsecret
+  - defaultNameSuffix - String - Optional. It is used only if we have several secrets in the same deployment.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "common.secrets.name" -}}
+{{- $name := (include "common.names.fullname" .context) -}}
+
+{{- if .defaultNameSuffix -}}
+{{- $name = printf "%s-%s" $name .defaultNameSuffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- with .existingSecret -}}
+{{- if not (typeIs "string" .) -}}
+{{- with .name -}}
+{{- $name = . -}}
+{{- end -}}
+{{- else -}}
+{{- $name = . -}}
+{{- end -}}
+{{- end -}}
+
+{{- printf "%s" $name -}}
+{{- end -}}
+
+{{/*
+Generate secret key.
+
+Usage:
+{{ include "common.secrets.key" (dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName") }}
+
+Params:
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/main/bitnami/common#existingsecret
+  - key - String - Required. Name of the key in the secret.
+*/}}
+{{- define "common.secrets.key" -}}
+{{- $key := .key -}}
+
+{{- if .existingSecret -}}
+  {{- if not (typeIs "string" .existingSecret) -}}
+    {{- if .existingSecret.keyMapping -}}
+      {{- $key = index .existingSecret.keyMapping $.key -}}
+    {{- end -}}
+  {{- end }}
+{{- end -}}
+
+{{- printf "%s" $key -}}
+{{- end -}}
+
+{{/*
+Generate secret password or retrieve one if already created.
+
+Usage:
+{{ include "common.secrets.passwords.manage" (dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "honorProvidedValues" false "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - providedValues - List<String> - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - length - int - Optional - Length of the generated random password.
+  - strong - Boolean - Optional - Whether to add symbols to the generated random password.
+  - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
+  - context - Context - Required - Parent context.
+  - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
+  - skipB64enc - Boolean - Optional - Default to false. If set to true, no the secret will not be base64 encrypted.
+  - skipQuote - Boolean - Optional - Default to false. If set to true, no quotes will be added around the secret.
+  - honorProvidedValues - Boolean - Optional - Default to false. If set to true, the values in providedValues have higher priority than an existing secret
+The order in which this function returns a secret password:
+  1. Password provided via the values.yaml if honorProvidedValues = true
+     (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
+  2. Already existing 'Secret' resource
+     (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
+  3. Password provided via the values.yaml if honorProvidedValues = false
+     (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
+  4. Randomly generated secret password
+     (A new random secret password with the length specified in the 'length' parameter will be generated and returned)
+
+*/}}
+{{- define "common.secrets.passwords.manage" -}}
+
+{{- $password := "" }}
+{{- $subchart := "" }}
+{{- $chartName := default "" .chartName }}
+{{- $passwordLength := default 10 .length }}
+{{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
+{{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
+{{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data }}
+{{- if $secretData }}
+  {{- if hasKey $secretData .key }}
+    {{- $password = index $secretData .key | b64dec }}
+  {{- else if not (eq .failOnNew false) }}
+    {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
+  {{- end -}}
+{{- end }}
+
+{{- if and $providedPasswordValue .honorProvidedValues }}
+  {{- $password = $providedPasswordValue | toString }}
+{{- end }}
+
+{{- if not $password }}
+  {{- if $providedPasswordValue }}
+    {{- $password = $providedPasswordValue | toString }}
+  {{- else }}
+    {{- if .context.Values.enabled }}
+      {{- $subchart = $chartName }}
+    {{- end -}}
+
+    {{- if not (eq .failOnNew false) }}
+      {{- $requiredPassword := dict "valueKey" $providedPasswordKey "secret" .secret "field" .key "subchart" $subchart "context" $.context -}}
+      {{- $requiredPasswordError := include "common.validations.values.single.empty" $requiredPassword -}}
+      {{- $passwordValidationErrors := list $requiredPasswordError -}}
+      {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $.context) -}}
+    {{- end }}
+
+    {{- if .strong }}
+      {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
+      {{- $password = randAscii $passwordLength }}
+      {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
+      {{- $password = printf "%s%s" $subStr $password | toString | shuffle }}
+    {{- else }}
+      {{- $password = randAlphaNum $passwordLength }}
+    {{- end }}
+  {{- end -}}
+{{- end -}}
+{{- if not .skipB64enc }}
+{{- $password = $password | b64enc }}
+{{- end -}}
+{{- if .skipQuote -}}
+{{- printf "%s" $password -}}
+{{- else -}}
+{{- printf "%s" $password | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Reuses the value from an existing secret, otherwise sets its value to a default value.
+
+Usage:
+{{ include "common.secrets.lookup" (dict "secret" "secret-name" "key" "keyName" "defaultValue" .Values.myValue "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - defaultValue - String - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - context - Context - Required - Parent context.
+
+*/}}
+{{- define "common.secrets.lookup" -}}
+{{- $value := "" -}}
+{{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data -}}
+{{- if and $secretData (hasKey $secretData .key) -}}
+  {{- $value = index $secretData .key -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString | b64enc -}}
+{{- end -}}
+{{- if $value -}}
+{{- printf "%s" $value -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns whether a previous generated secret already exists
+
+Usage:
+{{ include "common.secrets.exists" (dict "secret" "secret-name" "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - context - Context - Required - Parent context.
+*/}}
+{{- define "common.secrets.exists" -}}
+{{- $secret := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret) }}
+{{- if $secret }}
+  {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_storage.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_storage.tpl
@@ -1,0 +1,21 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return  the proper Storage Class
+{{ include "common.storage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
+*/}}
+{{- define "common.storage.class" -}}
+{{- $storageClass := (.global).storageClass | default .persistence.storageClass | default (.global).defaultStorageClass | default "" -}}
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else -}}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_tplvalues.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_tplvalues.tpl
@@ -1,0 +1,52 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite
+Usage:
+{{ include "common.tplvalues.merge-overwrite" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge-overwrite" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_utils.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_utils.tpl
@@ -1,0 +1,77 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Print instructions to get a secret value.
+Usage:
+{{ include "common.utils.secret.getvalue" (dict "secret" "secret-name" "field" "secret-value-field" "context" $) }}
+*/}}
+{{- define "common.utils.secret.getvalue" -}}
+{{- $varname := include "common.utils.fieldToEnvVar" . -}}
+export {{ $varname }}=$(kubectl get secret --namespace {{ include "common.names.namespace" .context | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 -d)
+{{- end -}}
+
+{{/*
+Build env var name given a field
+Usage:
+{{ include "common.utils.fieldToEnvVar" dict "field" "my-password" }}
+*/}}
+{{- define "common.utils.fieldToEnvVar" -}}
+  {{- $fieldNameSplit := splitList "-" .field -}}
+  {{- $upperCaseFieldNameSplit := list -}}
+
+  {{- range $fieldNameSplit -}}
+    {{- $upperCaseFieldNameSplit = append $upperCaseFieldNameSplit ( upper . ) -}}
+  {{- end -}}
+
+  {{ join "_" $upperCaseFieldNameSplit }}
+{{- end -}}
+
+{{/*
+Gets a value from .Values given
+Usage:
+{{ include "common.utils.getValueFromKey" (dict "key" "path.to.key" "context" $) }}
+*/}}
+{{- define "common.utils.getValueFromKey" -}}
+{{- $splitKey := splitList "." .key -}}
+{{- $value := "" -}}
+{{- $latestObj := $.context.Values -}}
+{{- range $splitKey -}}
+  {{- if not $latestObj -}}
+    {{- printf "please review the entire path of '%s' exists in values" $.key | fail -}}
+  {{- end -}}
+  {{- $value = ( index $latestObj . ) -}}
+  {{- $latestObj = $value -}}
+{{- end -}}
+{{- printf "%v" (default "" $value) -}} 
+{{- end -}}
+
+{{/*
+Returns first .Values key with a defined value or first of the list if all non-defined
+Usage:
+{{ include "common.utils.getKeyFromList" (dict "keys" (list "path.to.key1" "path.to.key2") "context" $) }}
+*/}}
+{{- define "common.utils.getKeyFromList" -}}
+{{- $key := first .keys -}}
+{{- $reverseKeys := reverse .keys }}
+{{- range $reverseKeys }}
+  {{- $value := include "common.utils.getValueFromKey" (dict "key" . "context" $.context ) }}
+  {{- if $value -}}
+    {{- $key = . }}
+  {{- end -}}
+{{- end -}}
+{{- printf "%s" $key -}} 
+{{- end -}}
+
+{{/*
+Checksum a template at "path" containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376).
+Usage:
+{{ include "common.utils.checksumTemplate" (dict "path" "/configmap.yaml" "context" $) }}
+*/}}
+{{- define "common.utils.checksumTemplate" -}}
+{{- $obj := include (print .context.Template.BasePath .path) .context | fromYaml -}}
+{{ omit $obj "apiVersion" "kind" "metadata" | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_warnings.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/_warnings.tpl
@@ -1,0 +1,109 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Warning about using rolling tag.
+Usage:
+{{ include "common.warnings.rollingTag" .Values.path.to.the.imageRoot }}
+*/}}
+{{- define "common.warnings.rollingTag" -}}
+
+{{- if and (contains "bitnami/" .repository) (not (.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html
+{{- end }}
+{{- end -}}
+
+{{/*
+Warning about replaced images from the original.
+Usage:
+{{ include "common.warnings.modifiedImages" (dict "images" (list .Values.path.to.the.imageRoot) "context" $) }}
+*/}}
+{{- define "common.warnings.modifiedImages" -}}
+{{- $affectedImages := list -}}
+{{- $printMessage := false -}}
+{{- $originalImages := .context.Chart.Annotations.images -}}
+{{- range .images -}}
+  {{- $fullImageName := printf (printf "%s/%s:%s" .registry .repository .tag) -}}
+  {{- if not (contains $fullImageName $originalImages) }}
+    {{- $affectedImages = append $affectedImages (printf "%s/%s:%s" .registry .repository .tag) -}}
+    {{- $printMessage = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $printMessage }}
+
+⚠ SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.
+
+Substituted images detected:
+{{- range $affectedImages }}
+  - {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Warning about not setting the resource object in all deployments.
+Usage:
+{{ include "common.warnings.resources" (dict "sections" (list "path1" "path2") context $) }}
+Example:
+{{- include "common.warnings.resources" (dict "sections" (list "csiProvider.provider" "server" "volumePermissions" "") "context" $) }}
+The list in the example assumes that the following values exist:
+  - csiProvider.provider.resources
+  - server.resources
+  - volumePermissions.resources
+  - resources
+*/}}
+{{- define "common.warnings.resources" -}}
+{{- $values := .context.Values -}}
+{{- $printMessage := false -}}
+{{ $affectedSections := list -}}
+{{- range .sections -}}
+  {{- if eq . "" -}}
+    {{/* Case where the resources section is at the root (one main deployment in the chart) */}}
+    {{- if not (index $values "resources") -}}
+    {{- $affectedSections = append $affectedSections "resources" -}}
+    {{- $printMessage = true -}}
+    {{- end -}}
+  {{- else -}}
+    {{/* Case where the are multiple resources sections (more than one main deployment in the chart) */}}
+    {{- $keys := split "." . -}}
+    {{/* We iterate through the different levels until arriving to the resource section. Example: a.b.c.resources */}}
+    {{- $section := $values -}}
+    {{- range $keys -}}
+      {{- $section = index $section . -}}
+    {{- end -}}
+    {{- if not (index $section "resources") -}}
+      {{/* If the section has enabled=false or replicaCount=0, do not include it */}}
+      {{- if and (hasKey $section "enabled") -}}
+        {{- if index $section "enabled" -}}
+          {{/* enabled=true */}}
+          {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+          {{- $printMessage = true -}}
+        {{- end -}}
+      {{- else if and (hasKey $section "replicaCount")  -}}
+        {{/* We need a casting to int because number 0 is not treated as an int by default */}}
+        {{- if (gt (index $section "replicaCount" | int) 0) -}}
+          {{/* replicaCount > 0 */}}
+          {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+          {{- $printMessage = true -}}
+        {{- end -}}
+      {{- else -}}
+        {{/* Default case, add it to the affected sections */}}
+        {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+        {{- $printMessage = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $printMessage }}
+
+WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
+{{- range $affectedSections }}
+  - {{ . }}
+{{- end }}
++info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_cassandra.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_cassandra.tpl
@@ -1,0 +1,51 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.cassandra.values.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
+*/}}
+{{- define "common.cassandra.values.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.cassandra.dbUser.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.dbUser.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled cassandra.
+
+Usage:
+{{ include "common.cassandra.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.cassandra.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.cassandra.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key dbUser
+
+Usage:
+{{ include "common.cassandra.values.key.dbUser" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
+*/}}
+{{- define "common.cassandra.values.key.dbUser" -}}
+  {{- if .subchart -}}
+    cassandra.dbUser
+  {{- else -}}
+    dbUser
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mariadb.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mariadb.tpl
@@ -1,0 +1,108 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate MariaDB required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.mariadb.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where MariaDB values are stored, e.g: "mysql-passwords-secret"
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.mariadb.passwords" -}}
+  {{- $existingSecret := include "common.mariadb.values.auth.existingSecret" . -}}
+  {{- $enabled := include "common.mariadb.values.enabled" . -}}
+  {{- $architecture := include "common.mariadb.values.architecture" . -}}
+  {{- $authPrefix := include "common.mariadb.values.key.auth" . -}}
+  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
+  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
+  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
+  {{- $valueKeyReplicationPassword := printf "%s.replicationPassword" $authPrefix -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mariadb-root-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+    {{- if not (empty $valueUsername) -}}
+        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mariadb-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+    {{- end -}}
+
+    {{- if (eq $architecture "replication") -}}
+        {{- $requiredReplicationPassword := dict "valueKey" $valueKeyReplicationPassword "secret" .secret "field" "mariadb-replication-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mariadb.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mariadb.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mariadb.
+
+Usage:
+{{ include "common.mariadb.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mariadb.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mariadb.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mariadb.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mariadb.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mariadb.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.key.auth" -}}
+  {{- if .subchart -}}
+    mariadb.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mongodb.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mongodb.tpl
@@ -1,0 +1,67 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mongodb.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDb is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mongodb.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mongodb.
+
+Usage:
+{{ include "common.mongodb.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mongodb.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mongodb.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mongodb.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.key.auth" -}}
+  {{- if .subchart -}}
+    mongodb.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mongodb.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mongodb.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mysql.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_mysql.tpl
@@ -1,0 +1,67 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mysql.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mysql.
+
+Usage:
+{{ include "common.mysql.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mysql.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mysql.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mysql.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mysql.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.key.auth" -}}
+  {{- if .subchart -}}
+    mysql.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_postgresql.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_postgresql.tpl
@@ -1,0 +1,105 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Auxiliary function to decide whether evaluate global values.
+
+Usage:
+{{ include "common.postgresql.values.use.global" (dict "key" "key-of-global" "context" $) }}
+Params:
+  - key - String - Required. Field to be evaluated within global, e.g: "existingSecret"
+*/}}
+{{- define "common.postgresql.values.use.global" -}}
+  {{- if .context.Values.global -}}
+    {{- if .context.Values.global.postgresql -}}
+      {{- index .context.Values.global.postgresql .key | quote -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.postgresql.values.existingSecret" (dict "context" $) }}
+*/}}
+{{- define "common.postgresql.values.existingSecret" -}}
+  {{- $globalValue := include "common.postgresql.values.use.global" (dict "key" "existingSecret" "context" .context) -}}
+
+  {{- if .subchart -}}
+    {{- default (.context.Values.postgresql.existingSecret | quote) $globalValue -}}
+  {{- else -}}
+    {{- default (.context.Values.existingSecret | quote) $globalValue -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled postgresql.
+
+Usage:
+{{ include "common.postgresql.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.postgresql.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.postgresql.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key postgressPassword.
+
+Usage:
+{{ include "common.postgresql.values.key.postgressPassword" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.key.postgressPassword" -}}
+  {{- $globalValue := include "common.postgresql.values.use.global" (dict "key" "postgresqlUsername" "context" .context) -}}
+
+  {{- if not $globalValue -}}
+    {{- if .subchart -}}
+      postgresql.postgresqlPassword
+    {{- else -}}
+      postgresqlPassword
+    {{- end -}}
+  {{- else -}}
+    global.postgresql.postgresqlPassword
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled.replication.
+
+Usage:
+{{ include "common.postgresql.values.enabled.replication" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.enabled.replication" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.postgresql.replication.enabled -}}
+  {{- else -}}
+    {{- printf "%v" .context.Values.replication.enabled -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key replication.password.
+
+Usage:
+{{ include "common.postgresql.values.key.replicationPassword" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.key.replicationPassword" -}}
+  {{- if .subchart -}}
+    postgresql.replication.password
+  {{- else -}}
+    replication.password
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_redis.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_redis.tpl
@@ -1,0 +1,48 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Auxiliary function to get the right value for enabled redis.
+
+Usage:
+{{ include "common.redis.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.redis.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.redis.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right prefix path for the values
+
+Usage:
+{{ include "common.redis.values.key.prefix" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether redis is used as subchart or not. Default: false
+*/}}
+{{- define "common.redis.values.keys.prefix" -}}
+  {{- if .subchart -}}redis.{{- else -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Checks whether the redis chart's includes the standarizations (version >= 14)
+
+Usage:
+{{ include "common.redis.values.standarized.version" (dict "context" $) }}
+*/}}
+{{- define "common.redis.values.standarized.version" -}}
+
+  {{- $standarizedAuth := printf "%s%s" (include "common.redis.values.keys.prefix" .) "auth" -}}
+  {{- $standarizedAuthValues := include "common.utils.getValueFromKey" (dict "key" $standarizedAuth "context" .context) }}
+
+  {{- if $standarizedAuthValues -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_validations.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/templates/validations/_validations.tpl
@@ -1,0 +1,51 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate values must not be empty.
+
+Usage:
+{{- $validateValueConf00 := (dict "valueKey" "path.to.value" "secret" "secretName" "field" "password-00") -}}
+{{- $validateValueConf01 := (dict "valueKey" "path.to.value" "secret" "secretName" "field" "password-01") -}}
+{{ include "common.validations.values.empty" (dict "required" (list $validateValueConf00 $validateValueConf01) "context" $) }}
+
+Validate value params:
+  - valueKey - String - Required. The path to the validating value in the values.yaml, e.g: "mysql.password"
+  - secret - String - Optional. Name of the secret where the validating value is generated/stored, e.g: "mysql-passwords-secret"
+  - field - String - Optional. Name of the field in the secret data, e.g: "mysql-password"
+*/}}
+{{- define "common.validations.values.multiple.empty" -}}
+  {{- range .required -}}
+    {{- include "common.validations.values.single.empty" (dict "valueKey" .valueKey "secret" .secret "field" .field "context" $.context) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Validate a value must not be empty.
+
+Usage:
+{{ include "common.validations.value.empty" (dict "valueKey" "mariadb.password" "secret" "secretName" "field" "my-password" "subchart" "subchart" "context" $) }}
+
+Validate value params:
+  - valueKey - String - Required. The path to the validating value in the values.yaml, e.g: "mysql.password"
+  - secret - String - Optional. Name of the secret where the validating value is generated/stored, e.g: "mysql-passwords-secret"
+  - field - String - Optional. Name of the field in the secret data, e.g: "mysql-password"
+  - subchart - String - Optional - Name of the subchart that the validated password is part of.
+*/}}
+{{- define "common.validations.values.single.empty" -}}
+  {{- $value := include "common.utils.getValueFromKey" (dict "key" .valueKey "context" .context) }}
+  {{- $subchart := ternary "" (printf "%s." .subchart) (empty .subchart) }}
+
+  {{- if not $value -}}
+    {{- $varname := "my-value" -}}
+    {{- $getCurrentValue := "" -}}
+    {{- if and .secret .field -}}
+      {{- $varname = include "common.utils.fieldToEnvVar" . -}}
+      {{- $getCurrentValue = printf " To get the current value:\n\n        %s\n" (include "common.utils.secret.getvalue" .) -}}
+    {{- end -}}
+    {{- printf "\n    '%s' must not be empty, please add '--set %s%s=$%s' to the command.%s" .valueKey $subchart .valueKey $varname $getCurrentValue -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/values.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/charts/common/values.yaml
@@ -1,0 +1,8 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+## bitnami/common
+## It is required by CI/CD tools and processes.
+## @skip exampleValue
+##
+exampleValue: common-chart

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_helpers-dra.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_helpers-dra.tpl
@@ -1,0 +1,148 @@
+{{/*
+DRA (Dynamic Resource Allocation) Helper Functions
+*/}}
+
+{{/* Check if DRA is enabled */}}
+{{- define "llm-d-modelservice.draEnabled" -}}
+{{- $draEnabled := false -}}
+{{- if and .role (eq .role "decode") -}}
+  {{- if and .Values.decode.accelerator (hasKey .Values.decode.accelerator "dra") -}}
+    {{- $draEnabled = .Values.decode.accelerator.dra -}}
+  {{- else -}}
+    {{- $draEnabled = .Values.accelerator.dra | default false -}}
+  {{- end -}}
+{{- else if and .role (eq .role "prefill") -}}
+  {{- if and .Values.prefill.accelerator (hasKey .Values.prefill.accelerator "dra") -}}
+    {{- $draEnabled = .Values.prefill.accelerator.dra -}}
+  {{- else -}}
+    {{- $draEnabled = .Values.accelerator.dra | default false -}}
+  {{- end -}}
+{{- else -}}
+  {{- $draEnabled = .Values.accelerator.dra | default false -}}
+{{- end -}}
+{{- if $draEnabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/* Get accelerator type */}}
+{{- define "llm-d-modelservice.acceleratorType" -}}
+{{- if and .role (eq .role "decode") -}}
+  {{- if and .Values.decode.accelerator (hasKey .Values.decode.accelerator "type") -}}
+    {{- .Values.decode.accelerator.type -}}
+  {{- else -}}
+    {{- .Values.accelerator.type | default "nvidia" -}}
+  {{- end -}}
+{{- else if and .role (eq .role "prefill") -}}
+  {{- if and .Values.prefill.accelerator (hasKey .Values.prefill.accelerator "type") -}}
+    {{- .Values.prefill.accelerator.type -}}
+  {{- else -}}
+    {{- .Values.accelerator.type | default "nvidia" -}}
+  {{- end -}}
+{{- else -}}
+  {{- .Values.accelerator.type | default "nvidia" -}}
+{{- end -}}
+{{- end }}
+
+{{/* Get accelerator claim name based on type */}}
+{{- define "llm-d-modelservice.acceleratorClaimName" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- $role := .role | default "" -}}
+{{- if hasKey .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- $template := index .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- if $role -}}
+    {{- if $template.name -}}
+      {{- printf "%s-%s-claim" (trimSuffix "-claim-template" $template.name) $role -}}
+    {{- else -}}
+      {{- printf "%s-%s-claim" $acceleratorType $role -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $template.name | default (printf "%s-claim" $acceleratorType) -}}
+  {{- end -}}
+{{- else -}}
+  {{- if $role -}}
+    {{- printf "%s-%s-claim" $acceleratorType $role -}}
+  {{- else -}}
+    {{- printf "%s-claim" $acceleratorType -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* Get accelerator claim template name */}}
+{{- define "llm-d-modelservice.acceleratorClaimTemplateName" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- $role := .role | default "" -}}
+{{- if hasKey .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- $template := index .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- if $role -}}
+    {{- if $template.name -}}
+      {{- printf "%s-%s" $template.name $role -}}
+    {{- else -}}
+      {{- printf "%s-%s-claim-template" $acceleratorType $role -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $template.name | default (printf "%s-claim-template" $acceleratorType) -}}
+  {{- end -}}
+{{- else -}}
+  {{- if $role -}}
+    {{- printf "%s-%s-claim-template" $acceleratorType $role -}}
+  {{- else -}}
+    {{- printf "%s-claim-template" $acceleratorType -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* Get DRA claim count (auto-calculate from parallelism if not set) */}}
+{{- define "llm-d-modelservice.draClaimCount" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- $count := 1 -}}
+{{- if hasKey .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- $template := index .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- if hasKey $template "count" -}}
+    {{- $count = $template.count -}}
+  {{- else -}}
+    {{- /* Auto-calculate from parallelism */}}
+    {{- $count = int (include "llm-d-modelservice.numGpuPerWorker" .parallelism) -}}
+  {{- end -}}
+{{- else -}}
+  {{- $count = int (include "llm-d-modelservice.numGpuPerWorker" .parallelism) -}}
+{{- end -}}
+{{- $count -}}
+{{- end }}
+
+{{/* Generate resourceClaims Variable (merges accelerator + user-defined claims) */}}
+{{- define "llm-d-modelservice.resourceClaimsBase" -}}
+{{- $claims := list -}}
+{{- $draEnabled := eq (include "llm-d-modelservice.draEnabled" .) "true" -}}
+{{- if $draEnabled -}}
+  {{- $claimName := include "llm-d-modelservice.acceleratorClaimName" . -}}
+  {{- $templateName := include "llm-d-modelservice.acceleratorClaimTemplateName" . -}}
+  {{- $claims = append $claims (dict "name" $claimName "resourceClaimTemplateName" $templateName) -}}
+{{- end -}}
+{{- if .pdSpec.resourceClaims -}}
+  {{- $claims = concat $claims .pdSpec.resourceClaims -}}
+{{- end -}}
+{{- if $claims -}}
+{{- toYaml $claims }}
+{{- end -}}
+{{- end }}
+
+{{- define "llm-d-modelservice.podResourceClaims" -}}
+{{- $claimList := include "llm-d-modelservice.resourceClaimsBase" . -}}
+{{- if $claimList -}}
+resourceClaims:
+{{- $claimList | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/* Get DRA ResourceClaimTemplate configuration for the current accelerator type */}}
+{{- define "llm-d-modelservice.draResourceClaimTemplateConfig" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- $config := dict -}}
+{{- if hasKey .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+  {{- $config = index .Values.accelerator.resourceClaimTemplates $acceleratorType -}}
+{{- end -}}
+{{- $config | toJson -}}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -1,0 +1,726 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "llm-d-modelservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 55 chars because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+We use 55 because we add up to 8 characters (`-prefill`)
+*/}}
+{{- define "llm-d-modelservice.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 55 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 55 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 55 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+Truncated to 63 characrters because Kubernetes label values are limited to this
+*/}}
+{{- define "llm-d-modelservice.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create common labels for the resources managed by this chart.
+*/}}
+{{- define "llm-d-modelservice.labels" -}}
+helm.sh/chart: {{ include "llm-d-modelservice.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Create sanitized model name (DNS compliant) */}}
+{{- define "llm-d-modelservice.sanitizedModelName" -}}
+  {{- $name := .Release.Name | lower | trim -}}
+  {{- $name = regexReplaceAll "[^a-z0-9_.-]" $name "-" -}}
+  {{- $name = regexReplaceAll "^[\\-._]+" $name "" -}}
+  {{- $name = regexReplaceAll "[\\-._]+$" $name "" -}}
+  {{- $name = regexReplaceAll "\\." $name "-" -}}
+
+  {{- if gt (len $name) 63 -}}
+    {{- $name = substr 0 63 $name -}}
+  {{- end -}}
+
+{{- $name -}}
+{{- end }}
+
+{{/* Create common shared by prefill and decode deployment/LWS */}}
+{{- define "llm-d-modelservice.pdlabels" -}}
+{{ .Values.modelArtifacts.labels | toYaml }}
+{{- end }}
+
+{{/* Create labels for the prefill deployment/LWS */}}
+{{- define "llm-d-modelservice.prefilllabels" -}}
+{{ include "llm-d-modelservice.pdlabels" . }}
+llm-d.ai/role: prefill
+{{- end }}
+
+{{/* Create labels for the decode deployment/LWS */}}
+{{- define "llm-d-modelservice.decodelabels" -}}
+{{ include "llm-d-modelservice.pdlabels" . }}
+llm-d.ai/role: decode
+{{- end }}
+
+{{/* Create node affinity from acceleratorTypes in Values */}}
+{{- define "llm-d-modelservice.acceleratorTypes" -}}
+{{- if .labelKey }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: {{ .labelKey }}
+            operator: In
+            {{- with .labelValues }}
+            values:
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+{{- end }}
+{{- end }}
+{{/* Create the init container for the routing proxy/sidecar for decode pods */}}
+{{- define "llm-d-modelservice.routingProxy" -}}
+{{- if or (not (hasKey .proxy "enabled")) (ne .proxy.enabled false) -}}
+- name: routing-proxy
+  args:
+    - --port={{ default 8000 .servicePort }}
+    - --vllm-port={{ default 8200 .proxy.targetPort }}
+    - --connector={{ .proxy.connector | default "nixlv2" }}
+    {{- if hasKey .proxy "zapDevel" }}
+    - --zap-devel={{ .proxy.zapDevel }}
+    {{- end }}
+    {{- if hasKey .proxy "zapEncoder" }}
+    - --zap-encoder={{ .proxy.zapEncoder }}
+    {{- end }}
+    {{- if hasKey .proxy "zapLogLevel" }}
+    - --zap-log-level={{ .proxy.zapLogLevel }}
+    {{- end }}
+    {{- if hasKey .proxy "zapStacktraceLevel" }}
+    - --zap-stacktrace-level={{ .proxy.zapStacktraceLevel }}
+    {{- end }}
+    {{- if hasKey .proxy "zapTimeEncoding" }}
+    - --zap-time-encoding={{ .proxy.zapTimeEncoding }}
+    {{- end }}
+    {{- if hasKey .proxy "secure" }}
+    - --secure-proxy={{ .proxy.secure }}
+    {{- end }}
+    {{- if hasKey .proxy "prefillerUseTLS" }}
+    - --prefiller-use-tls={{ .proxy.prefillerUseTLS }}
+    {{- end }}
+    {{- if hasKey .proxy "certPath" }}
+    - --cert-path={{ .proxy.certPath }}
+    {{- end }}
+  image: {{ required "routing.proxy.image must be specified" (include "llm-d-modelservice.imageAddress" .proxy.image) }}
+  imagePullPolicy: {{ default "Always" .proxy.imagePullPolicy }}
+  ports:
+    - containerPort: {{ default 8000 .servicePort }}
+  resources: {}
+  restartPolicy: Always
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+{{- end }}
+{{- end }}
+
+{{/* Desired tensor parallelism --
+- if tensor set, return it
+- else return 1
+*/}}
+{{- define "llm-d-modelservice.tensorParallelism" -}}
+{{- if and . .tensor -}}
+{{ .tensor }}
+{{- else -}}
+1
+{{- end -}}
+{{- end }}
+
+{{/*
+Desired data parallelism --
+- if data set, return it
+- else if dataLocal and workers set, return dataLocal * workers
+- else if dataLocal set, return dataLocal (w = 1)
+- else return 1 (dpl = 1, w = 1)
+*/}}
+{{- define "llm-d-modelservice.dataParallelism" -}}
+{{- if and . .data -}}
+{{ .data }}
+{{- else if and . .dataLocal .workers -}}
+{{ mul .dataLocal .workers }}
+{{- else if and . .dataLocal -}}
+{{ .dataLocal }}
+{{- else -}}
+1
+{{- end -}}
+{{- end }}
+
+{{/*
+Desired data local parallelism --
+- if dataLocal set, return it
+- else if data and workers set, return data / workers
+- else if data set, return data (w = 1)
+- else return 1 (dp = 1, w = 1)
+*/}}
+{{- define "llm-d-modelservice.dataLocalParallelism" -}}
+{{- if and . .dataLocal -}}
+{{ .dataLocal }}
+{{- else if and . .data .workers -}}
+{{ $result :=  div (int .data) (int .workers) }}
+{{- if ne (int .data) (mul $result .workers) -}}
+{{- fail "parallelism.data must be a multiple of parallelism.workers" -}}
+{{- else -}}
+{{ $result }}
+{{- end -}}
+{{- else if and . .data -}}
+{{ .data }}
+{{- else -}}
+1
+{{- end -}}
+{{- end }}
+
+{{/*
+Desired number of workers --
+- if workers set, return it
+- else if data and dataLocal set, return data / dataLocal
+- else return 1 (dp = 1, dpl = 1)
+*/}}
+{{- define "llm-d-modelservice.numWorkers" -}}
+{{- if and . .workers -}}
+{{ .workers }}
+{{- else if and . .data .dataLocal -}}
+{{ $result :=  div (int .data) (int .dataLocal) }}
+{{- if ne (int .data) (mul $result .dataLocal) -}}
+{{- fail "parallelism.data must be a multiple of parallelism.dataLocal" -}}
+{{- else -}}
+{{ $result }}
+{{- end -}}
+{{- else -}}
+1
+{{- end -}}
+{{- end }}
+
+{{/*
+Required number of GPU per worker -- dpl * tp
+*/}}
+{{- define "llm-d-modelservice.numGpuPerWorker" -}}
+{{ mul  (include "llm-d-modelservice.dataLocalParallelism" .) (include "llm-d-modelservice.tensorParallelism" .) }}
+{{- end }}
+
+{{/*
+Port on which vllm container should listen.
+Context is helm root context plus key "role" ("decode" or "prefill")
+*/}}
+{{- define "llm-d-modelservice.vllmPort" -}}
+{{- if or (eq .role "prefill") (eq .Values.routing.proxy.enabled false) }}
+{{- .Values.routing.servicePort }}
+{{- else }}
+{{- .Values.routing.proxy.targetPort }}
+{{- end }}
+{{- end }}
+
+{{/* Get accelerator resource name based on type */}}
+{{- define "llm-d-modelservice.acceleratorResource" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- $fullImage := include "llm-d-modelservice.imageAddress" .container.image -}}
+{{- if and .container .container.image (contains "llm-d-inference-sim" $fullImage) -}}
+{{/* No resource name for llm-d-inference-sim */}}
+{{- else if eq $acceleratorType "cpu" -}}
+{{/* No resource name for CPU */}}
+{{- else if hasKey .Values.accelerator.resources $acceleratorType -}}
+{{- index .Values.accelerator.resources $acceleratorType -}}
+{{- else -}}
+nvidia.com/gpu
+{{- end -}}
+{{- end }}
+
+{{/* Get accelerator environment variables based on type */}}
+{{- define "llm-d-modelservice.acceleratorEnv" -}}
+{{- $acceleratorType := include "llm-d-modelservice.acceleratorType" . -}}
+{{- if and (ne $acceleratorType "cpu") (hasKey .Values.accelerator.env $acceleratorType) -}}
+{{- $envVars := index .Values.accelerator.env $acceleratorType -}}
+{{- range $envVars }}
+- name: {{ .name }}
+  value: {{ .value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* Check for accelerator resource mismatch and return warning message if any */}}
+{{- define "llm-d-modelservice.acceleratorWarning" -}}
+{{- $numGpus := int (include "llm-d-modelservice.numGpuPerWorker" .parallelism) -}}
+{{- $acceleratorResource := include "llm-d-modelservice.acceleratorResource" . -}}
+{{- if and (ge $numGpus 1) (ne $acceleratorResource "") }}
+{{- if and .resources .resources.limits (hasKey .resources.limits $acceleratorResource) }}
+{{- $userValue := int (index .resources.limits $acceleratorResource) }}
+{{- if ne $userValue $numGpus }}
+{{- printf "Accelerator mismatch: %s is set to %d but parallelism calculates %d. Using %d." $acceleratorResource $userValue $numGpus $userValue }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* P/D deployment container resources */}}
+{{- define "llm-d-modelservice.resources" -}}
+{{- $limits := dict }}
+{{- if and .resources .resources.limits }}
+  {{- $limits = deepCopy .resources.limits }}
+{{- end }}
+{{- $requests := dict }}
+{{- if and .resources .resources.requests }}
+  {{- $requests = deepCopy .resources.requests }}
+{{- end }}
+{{- $draEnabled := eq (include "llm-d-modelservice.draEnabled" .) "true" -}}
+resources:
+{{- if $draEnabled -}}
+  {{- /* DRA mode: pass through user-defined limits/requests as-is, add claims */}}
+  {{- /* Users should not include accelerator resources in limits when DRA is enabled */}}
+  limits:
+    {{- toYaml $limits | nindent 4 }}
+  requests:
+    {{- toYaml $requests | nindent 4 }}
+{{- else -}}
+  {{- /* Device Plugin mode: existing logic */}}
+  {{- $numGpus := int (include "llm-d-modelservice.numGpuPerWorker" .parallelism) -}}
+  {{- $acceleratorResource := include "llm-d-modelservice.acceleratorResource" . -}}
+  {{- if and (ge (int $numGpus) 1) (ne $acceleratorResource "") }}
+    {{- /* Respect user's explicit accelerator setting; only auto-fill if not set */}}
+    {{- /* This allows TPUs where tensor_parallelism != num_accelerators (e.g., TP=8 needs 4 TPUs) */}}
+    {{- if not (hasKey $limits $acceleratorResource) }}
+      {{- $limits = mergeOverwrite $limits (dict $acceleratorResource (toString $numGpus)) }}
+    {{- end }}
+  {{- end }}
+  {{- if and (ge (int $numGpus) 1) (ne $acceleratorResource "") }}
+    {{- /* Respect user's explicit accelerator setting; only auto-fill if not set */}}
+    {{- if not (hasKey $requests $acceleratorResource) }}
+      {{- $requests = mergeOverwrite $requests (dict $acceleratorResource (toString $numGpus)) }}
+    {{- end }}
+  {{- end }}
+  limits:
+    {{- toYaml $limits | nindent 4 }}
+  requests:
+    {{- toYaml $requests | nindent 4 }}
+{{- end -}}
+{{- $claimList := include "llm-d-modelservice.resourceClaimsBase" . | fromYamlArray -}}
+{{- if $claimList }}
+  claims:
+  {{- $containerClaims := list -}}
+  {{- range $claimList -}}
+    {{- $containerClaims = append $containerClaims (dict "name" .name) -}}
+  {{- end }}
+    {{- toYaml $containerClaims | nindent 4 }}
+{{- end }}
+{{- end }}
+
+{{/* prefill name */}}
+{{- define "llm-d-modelservice.prefillName" -}}
+{{ include "llm-d-modelservice.fullname" . }}-prefill
+{{- end }}
+
+{{/* decode name */}}
+{{- define "llm-d-modelservice.decodeName" -}}
+{{ include "llm-d-modelservice.fullname" . }}-decode
+{{- end }}
+
+{{/* P/D service account name */}}
+{{- define "llm-d-modelservice.pdServiceAccountName" -}}
+{{- if or .Values.serviceAccountOverride -}}
+{{ .Values.serviceAccountOverride }}
+{{- else -}}
+{{ include "llm-d-modelservice.fullname" . }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Volumes for PD containers based on model artifact prefix
+Context is .Values.modelArtifacts
+*/}}
+{{- define "llm-d-modelservice.mountModelVolumeVolumes" -}}
+{{- $parsedArtifacts := regexSplit "://" .uri -1 -}}
+{{- $protocol := first $parsedArtifacts -}}
+{{- $path := last $parsedArtifacts -}}
+{{- if eq $protocol "hf" -}}
+- name: model-storage
+  emptyDir:
+    sizeLimit: {{ default "0" .size }}
+{{/* supports pvc or pvc+hf prefixes */}}
+{{- else if hasPrefix "pvc" $protocol }}
+{{- $parsedArtifacts := regexSplit "/" $path -1 -}}
+{{- $claim := first $parsedArtifacts -}}
+- name: model-storage
+  persistentVolumeClaim:
+    claimName: {{ $claim }}
+    readOnly: true
+{{- else if eq $protocol "oci" }}
+- name: model-storage
+  image:
+    reference: {{ $path }}
+    pullPolicy: {{ default "Always" .imagePullPolicy }}
+{{- end }}
+{{- end }}
+
+{{/*
+VolumeMount for a PD container
+Supplies model-storage mount if mountModelVolume: true for the container
+*/}}
+{{- define "llm-d-modelservice.mountModelVolumeVolumeMounts" -}}
+{{- if or .container.volumeMounts .container.mountModelVolume }}
+volumeMounts:
+{{- end }}
+{{- /* user supplied volume mount in values */}}
+{{- with .container.volumeMounts }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- /* what we add if mounModelVolume is true */}}
+{{- if .container.mountModelVolume }}
+  - name: model-storage
+    mountPath: {{ .Values.modelArtifacts.mountPath }}
+{{- /* enforce readOnly volumeMounts for OCI and PVCs */}}
+{{- $parsedArtifacts := regexSplit "://" .Values.modelArtifacts.uri -1 -}}
+{{- $protocol := first $parsedArtifacts -}}
+{{- $path := last $parsedArtifacts -}}
+{{- if or (eq $protocol "oci") (eq $protocol "pvc") }}
+    readOnly: true
+{{- end -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod elements of deployment/lws spec template
+context is a pdSpec
+*/}}
+{{- define "llm-d-modelservice.modelPod" -}}
+  {{- with .pdSpec.extraConfig }}
+    {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.imagePullSecrets instead */ -}}
+  {{- with .pdSpec.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.scheulerName instead */ -}}
+  {{- if or .pdSpec.schedulerName .Values.schedulerName }}
+  schedulerName: {{ .pdSpec.schedulerName | default .Values.schedulerName }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.securityContext instead */ -}}
+  {{- with .pdSpec.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  serviceAccountName: {{ include "llm-d-modelservice.pdServiceAccountName" . }}
+  {{- with .pdSpec.acceleratorTypes }}
+  {{- include "llm-d-modelservice.acceleratorTypes" . | nindent 2 }}
+  {{- end -}}
+  {{- /* define volume for the pd pod. Create a volume depending on the model artifact uri type */}}
+  volumes:
+  {{- if or .pdSpec.volumes }}
+    {{- toYaml .pdSpec.volumes | nindent 4 }}
+  {{- end -}}
+  {{- /* create volume if at least one of the containers in pdSpec has mountModelVolume: true */ -}}
+  {{- $hasModelVolume := false }}
+  {{- range .pdSpec.containers }}
+    {{- if .mountModelVolume }}
+      {{- $hasModelVolume = true }}
+    {{- end -}}
+  {{- end -}}
+  {{- if $hasModelVolume }}
+  {{ include "llm-d-modelservice.mountModelVolumeVolumes" .Values.modelArtifacts | nindent 4}}
+  {{- end -}}
+  {{- /* Add resourceClaims for DRA (new and old API) */}}
+  {{- include "llm-d-modelservice.podResourceClaims" . | nindent 2 }}
+{{- end }}
+
+{{/*
+Container elements of deployment/lws spec template
+context is a dict with helm root context plus:
+   key - "container"; value - container spec
+   key - "role"; value - either "decode" or "prefill"
+   key - "parallelism"; value - $.Values.decode.parallelism
+*/}}
+{{- define "llm-d-modelservice.container" -}}
+- name: {{ default "vllm" .container.name }}
+  image: {{ required "image of container is required" (include "llm-d-modelservice.imageAddress" .container.image) }}
+  {{- with .container.extraConfig }}
+    {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.securityContext instead */ -}}
+  {{- with .container.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.imagePullPolicy instead */ -}}
+  {{- with .container.imagePullPolicy }}
+  imagePullPolicy: {{ . }}
+  {{- end }}
+  {{- /* handle command and args */}}
+  {{- include "llm-d-modelservice.command" . | nindent 2 }}
+  {{- /* insert user's env for this container */}}
+  env:
+  {{- with .container.env }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
+  {{- end }}
+  {{- (include "llm-d-modelservice.parallelismEnv" .) | nindent 2 }}
+  {{- /* insert envs based on what modelArtifact prefix */}}
+  {{- (include "llm-d-modelservice.hfEnv" .) | nindent 2 }}
+  {{- /* Add accelerator-specific environment variables */}}
+  {{- $acceleratorEnv := include "llm-d-modelservice.acceleratorEnv" . }}
+  {{- if $acceleratorEnv }}{{ $acceleratorEnv | nindent 2 }}{{- end }}
+  {{- /* Add tracing environment variables from global config */}}
+  {{- (include "llm-d-modelservice.tracingEnv" .) | nindent 2 }}
+  {{- with .container.ports }}
+  ports:
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.livenessProbe instead */ -}}
+  {{- with .container.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.readinessProbe instead */ -}}
+  {{- with .container.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.startupProbe instead */ -}}
+  {{- with .container.startupProbe }}
+  startupProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- (include "llm-d-modelservice.resources" (dict "resources" .container.resources "parallelism" .parallelism "container" .container "Values" .Values "role" .role "pdSpec" .pdSpec)) | nindent 2 }}
+  {{- include "llm-d-modelservice.mountModelVolumeVolumeMounts" (dict "container" .container "Values" .Values) | nindent 2 }}
+  {{- /* DEPRECATED; use extraConfig.workingDir instead */ -}}
+  {{- with .container.workingDir }}
+  workingDir: {{ . }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.stdin instead */ -}}
+  {{- with .container.stdin }}
+  stdin: {{ . }}
+  {{- end }}
+  {{- /* DEPRECATED; use extraConfig.tty instead */ -}}
+  {{- with .container.tty }}
+  tty: {{ . }}
+  {{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.container" */}}
+
+{{- define "llm-d-modelservice.argsByProtocol" -}}
+{{- $parsedArtifacts := regexSplit "://" .Values.modelArtifacts.uri -1 -}}
+{{- $protocol := first $parsedArtifacts -}}
+{{- $other := last $parsedArtifacts -}}
+{{- if eq $protocol "hf" -}}
+{{- /* $other is the the model */}}
+  {{- if .modelArg }}
+  - --model
+  {{- end }}
+  - {{ include "common.tplvalues.render" ( dict "value" $other "context" $ ) }}
+{{- else if eq $protocol "pvc" }}
+{{- /* $other is the PVC claim and the path to the model */}}
+{{- $claimpath := regexSplit "/" $other 2 -}}
+{{- $path := last $claimpath -}}
+  {{- if .modelArg }}
+  - --model
+  {{- end }}
+  - {{ .Values.modelArtifacts.mountPath }}/{{ $path }}
+{{- else if eq $protocol "pvc+hf" }}
+{{- $claimpath := regexSplit "/" $other -1 -}}
+{{- $length := len $claimpath }}
+{{- $namespace := index $claimpath (sub $length 2) -}}
+{{- $modelID := last $claimpath -}}
+  {{- if .modelArg }}
+  - --model
+  {{- end }}
+  - {{ $namespace }}/{{ $modelID }}
+{{- else if eq $protocol "oci" }}
+{{- /* TBD */}}
+{{- fail "arguments for oci:// not implemented" }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.argsByProtocol" */}}
+
+{{- define "llm-d-modelservice.vllmServeModelCommand" -}}
+{{- /* override command and set model and --port arguments */}}
+command: ["vllm", "serve"]
+args:
+{{- (include "llm-d-modelservice.argsByProtocol" .) }}
+  - --port
+  - {{ (include "llm-d-modelservice.vllmPort" .) | quote }}
+  {{- $tensorParallelism := int (include "llm-d-modelservice.tensorParallelism" .parallelism) -}}
+  {{- if gt (int $tensorParallelism) 1 }}
+  - --tensor-parallel-size
+  - {{ $tensorParallelism | quote }}
+  {{- end }}
+  {{- $dataParallelism := int (include "llm-d-modelservice.dataParallelism" .parallelism) -}}
+  {{- if gt (int $dataParallelism) 1 }}
+  - --data-parallel-size
+  - {{ $dataParallelism | quote }}
+  {{- end }}
+  {{- $dataLocalParallelism := int (include "llm-d-modelservice.dataLocalParallelism" .parallelism) -}}
+  {{- if gt (int $dataLocalParallelism) 1 }}
+  - --data-parallel-size-local
+  - {{ $dataLocalParallelism | quote }}
+  {{- end }}
+  - --served-model-name
+  - {{ .Values.modelArtifacts.name | quote }}
+{{- /* Add tracing args from global config */}}
+{{- (include "llm-d-modelservice.vllmTracingArgs" .) | nindent 2 }}
+{{- with .container.args }}
+  {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.vllmServeModelCommand" */}}
+
+{{- define "llm-d-modelservice.imageDefaultModelCommand" -}}
+{{- /* no command needed, set --model and --port arguments */}}
+args:
+{{- (include "llm-d-modelservice.argsByProtocol" (merge . (dict "modelArg" true))) }}
+  - --port
+  - {{ (include "llm-d-modelservice.vllmPort" .) | quote }}
+  {{- $tensorParallelism := int (include "llm-d-modelservice.tensorParallelism" .parallelism) -}}
+  {{- if gt (int $tensorParallelism) 1 }}
+  - --tensor-parallel-size
+  - {{ $tensorParallelism | quote }}
+  {{- end }}
+  {{- $dataParallelism := int (include "llm-d-modelservice.dataParallelism" .parallelism) -}}
+  {{- if gt (int $dataParallelism) 1 }}
+  - --data-parallel-size
+  - {{ $dataParallelism | quote }}
+  {{- end }}
+  {{- $dataLocalParallelism := int (include "llm-d-modelservice.dataLocalParallelism" .parallelism) -}}
+  {{- if gt (int $dataLocalParallelism) 1 }}
+  - --data-parallel-size-local
+  - {{ $dataLocalParallelism | quote }}
+  {{- end }}
+  - --served-model-name
+  - {{ .Values.modelArtifacts.name | quote }}
+{{- /* Add tracing args from global config */}}
+{{- (include "llm-d-modelservice.vllmTracingArgs" .) | nindent 2 }}
+{{- with .container.args }}
+  {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.imageDefaultModelCommand" */}}
+
+{{- define "llm-d-modelservice.customModelCommand" -}}
+{{- /* use provided command and args (fail if no command) */}}
+{{- if not .container.command }}
+{{- fail "When .container.modelCommand not set or `custom`, a `command` is required." }}
+{{- else }}
+{{- with .container.command }}
+command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .container.args }}
+args:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.modelCommandCustom" */}}
+
+{{/*
+Container elements of deployment/lws spec template
+context is a dict with helm root context plus:
+   key - "container"; value - container spec
+   key - "role"; value - either "decode" or "prefill"
+   key - "parallelism"; value - $.Values.decode.parallelism
+*/}}
+{{- define "llm-d-modelservice.command" -}}
+{{- $modelCommand := default "custom" .container.modelCommand -}}
+{{- if eq $modelCommand "vllmServe" }}
+{{- include "llm-d-modelservice.vllmServeModelCommand" . }}
+{{- else if eq $modelCommand "imageDefault" }}
+{{- include "llm-d-modelservice.imageDefaultModelCommand" . }}
+{{- else if eq $modelCommand "custom" }}
+{{- include "llm-d-modelservice.customModelCommand" . }}
+{{- else }}
+{{- fail ".container.modelCommand is not as expected. Valid values are `vllmServe`, `imageDefault` and `custom`." }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.command" */}}
+
+{{- define "llm-d-modelservice.hfEnv" -}}
+{{- $parsedArtifacts := regexSplit "://" .Values.modelArtifacts.uri -1 -}}
+{{- $protocol := first $parsedArtifacts -}}
+{{- $other := last $parsedArtifacts -}}
+{{- if contains "hf" $protocol }}
+{{- if eq $protocol "hf" }}
+{{- if .container.mountModelVolume }}
+- name: HF_HOME
+  value: {{ .Values.modelArtifacts.mountPath }}
+{{- end }}
+{{- end }}
+{{- if eq $protocol "pvc+hf" }}
+{{- $claimpath := regexSplit "/" $other -1 -}}
+{{- $length := len $claimpath }}
+{{- $start := 1 }}
+{{- $end := sub $length 2 }}
+{{- $middle := slice $claimpath $start $end }}
+{{- $hfhubcache := join "/" $middle }}
+{{- if .container.mountModelVolume }}
+- name: HF_HUB_CACHE
+  value: /model-cache/{{ $hfhubcache }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with .Values.modelArtifacts.authSecretName }}
+- name: HF_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ . }}
+      key: HF_TOKEN
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.hfEnv" */}}
+
+{{- define "llm-d-modelservice.parallelismEnv" -}}
+- name: DP_SIZE
+  value: {{ include "llm-d-modelservice.dataParallelism" .parallelism | quote }}
+- name: TP_SIZE
+  value: {{ include "llm-d-modelservice.tensorParallelism" .parallelism | quote }}
+- name: DP_SIZE_LOCAL
+  value: {{ include "llm-d-modelservice.dataLocalParallelism" .parallelism | quote }}
+{{- end }} {{- /* define "llm-d-modelservice.parallelismEnv" */}}
+
+{{/*
+OpenTelemetry tracing environment variables for vLLM containers
+Requires: .Values.global.tracing, .role ("decode" or "prefill")
+Returns: YAML list of environment variables if tracing is enabled, empty otherwise
+*/}}
+{{- define "llm-d-modelservice.tracingEnv" -}}
+{{- if and .Values.global.tracing .Values.global.tracing.enabled }}
+{{- $serviceName := "" }}
+{{- if eq .role "decode" }}
+  {{- $serviceName = .Values.global.tracing.serviceNames.vllmDecode }}
+{{- else if eq .role "prefill" }}
+  {{- $serviceName = .Values.global.tracing.serviceNames.vllmPrefill }}
+{{- end }}
+- name: OTEL_SERVICE_NAME
+  value: {{ $serviceName | quote }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ .Values.global.tracing.otlpEndpoint | quote }}
+- name: OTEL_TRACES_EXPORTER
+  value: "otlp"
+- name: OTEL_TRACES_SAMPLER
+  value: {{ .Values.global.tracing.sampling.sampler | quote }}
+- name: OTEL_TRACES_SAMPLER_ARG
+  value: {{ .Values.global.tracing.sampling.samplerArg | quote }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.tracingEnv" */}}
+
+{{/*
+vLLM tracing command-line arguments
+Requires: .Values.global.tracing
+Returns: YAML list of vLLM args (--otlp-traces-endpoint, --collect-detailed-traces) if tracing is enabled
+*/}}
+{{- define "llm-d-modelservice.vllmTracingArgs" -}}
+{{- if and .Values.global.tracing .Values.global.tracing.enabled }}
+- --otlp-traces-endpoint
+- {{ .Values.global.tracing.otlpEndpoint | quote }}
+- --collect-detailed-traces
+- {{ .Values.global.tracing.vllm.collectDetailedTraces | quote }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.vllmTracingArgs" */}}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_image.tpl
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/_image.tpl
@@ -1,0 +1,11 @@
+{{/*
+Concatenate the full image address
+Receives an image object containing registry, repository, and tag fields
+Returns format: <registry>/<repository>:<tag>
+*/}}
+{{- define "llm-d-modelservice.imageAddress" -}}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $repository := .repository | required "image.repository is required" -}}
+{{- $tag := .tag | default "latest" -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -1,0 +1,66 @@
+{{- if and (not .Values.requester.enable) .Values.decode.create (not .Values.multinode) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-modelservice.decodeName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+  {{- $warning := "" }}
+  {{- if .Values.decode.containers }}
+  {{- $firstContainer := index .Values.decode.containers 0 }}
+  {{- $warning = include "llm-d-modelservice.acceleratorWarning" (dict "parallelism" .Values.decode.parallelism "resources" $firstContainer.resources "Values" .Values "container" $firstContainer) }}
+  {{- end }}
+  {{- if or .Values.decode.annotations $warning }}
+  annotations:
+    {{- if .Values.decode.annotations }}
+    {{- toYaml .Values.decode.annotations | nindent 4 }}
+    {{- end }}
+    {{- if $warning }}
+    llm-d.ai/accelerator-warning: {{ $warning | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-modelservice.decodelabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-modelservice.decodelabels" . | nindent 8 }}
+      {{- if .Values.decode.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.decode.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.decode.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.decode.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
+      initContainers:
+      {{- with .Values.routing }}
+      {{- (include "llm-d-modelservice.routingProxy" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.decode.initContainers }}
+      {{- toYaml .Values.decode.initContainers | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- if hasKey .Values.decode "enableServiceLinks" }}
+      enableServiceLinks: {{ .Values.decode.enableServiceLinks }}
+      {{- end }}
+      {{- if hasKey .Values.decode "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
+      {{- with .Values.decode.containers }}
+      containers:
+        {{- range . }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.decode.tolerations }}
+      tolerations:
+        {{- toYaml .Values.decode.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -1,0 +1,88 @@
+{{- if and .Values.decode.create .Values.multinode }}
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: {{ include "llm-d-modelservice.decodeName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+    {{- include "llm-d-modelservice.decodelabels" . | nindent 4 }}
+  {{- $warning := "" }}
+  {{- if .Values.decode.containers }}
+  {{- $firstContainer := index .Values.decode.containers 0 }}
+  {{- $warning = include "llm-d-modelservice.acceleratorWarning" (dict "parallelism" .Values.decode.parallelism "resources" $firstContainer.resources "Values" .Values "container" $firstContainer) }}
+  {{- end }}
+  {{- if or .Values.decode.subGroupExclusiveTopology .Values.decode.annotations $warning }}
+  annotations:
+  {{- if .Values.decode.subGroupExclusiveTopology }}
+    leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
+  {{- end }}
+  {{- if .Values.decode.annotations }}
+    {{ toYaml .Values.decode.annotations | nindent 4 }}
+  {{- end }}
+  {{- if $warning }}
+    llm-d.ai/accelerator-warning: {{ $warning | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  {{- if not .Values.decode.autoscaling.enabled }}
+  replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
+  {{- end }}
+  leaderWorkerTemplate:
+    size: {{ int (include "llm-d-modelservice.numWorkers" .Values.decode.parallelism) }}
+    {{- if .Values.decode.subGroupPolicy }}
+    subGroupPolicy:
+    {{- toYaml .Values.decode.subGroupPolicy | nindent 6 }}
+    {{- end }}
+    workerTemplate:
+      metadata:
+        labels:
+          {{- include "llm-d-modelservice.decodelabels" . | nindent 10 }}
+        {{- if or .Values.decode.subGroupExclusiveTopology .Values.decode.podAnnotations }}
+        annotations:
+        {{- if .Values.decode.subGroupExclusiveTopology }}
+          leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
+        {{- end }}
+        {{- if .Values.decode.podAnnotations }}
+          {{ toYaml .Values.decode.podAnnotations | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      spec:
+        {{- /* DEPRECATED; use extraConfig.hostIPC instead */ -}}
+        {{- if hasKey .Values.decode "hostIPC" }}
+        hostIPC: {{ .Values.decode.hostIPC }}
+        {{- end }}
+        {{- /* DEPRECATED; use extraConfig.hostPID instead */ -}}
+        {{- if hasKey .Values.decode "hostPID" }}
+        hostPID: {{ .Values.decode.hostPID }}
+        {{- end }}
+        {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
+        initContainers:
+        {{- with .Values.routing }}
+        {{- (include "llm-d-modelservice.routingProxy" .) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.decode.initContainers }}
+        {{- toYaml .Values.decode.initContainers | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if hasKey .Values.decode "enableServiceLinks" }}
+        enableServiceLinks: {{ .Values.decode.enableServiceLinks }}
+        {{- end }}
+        {{- if hasKey .Values.decode "terminationGracePeriodSeconds" }}
+        terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
+        {{- end }}
+        {{ (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
+        {{- with .Values.decode.containers }}
+        containers:
+          {{- range . }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.decode.nodeSelector }}
+        nodeSelector:
+          {{- toYaml .Values.decode.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if .Values.decode.tolerations }}
+        tolerations:
+          {{- toYaml .Values.decode.tolerations | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-podmonitor.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-podmonitor.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.decode.create .Values.decode.monitoring.podmonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "llm-d-modelservice.decodeName" . }}-podmonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+    app.kubernetes.io/component: decode
+  {{- with .Values.decode.monitoring.podmonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.decode.monitoring.podmonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "llm-d-modelservice.decodelabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  # For decode service, this is port 8200. Must use port name.
+  - port: {{ .Values.decode.monitoring.podmonitor.portName | default "metrics" | quote }}
+    path: {{ .Values.decode.monitoring.podmonitor.path | default "/metrics" }}
+    interval: {{ .Values.decode.monitoring.podmonitor.interval | default "30s" }}
+    {{- with .Values.decode.monitoring.podmonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.decode.monitoring.podmonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.decode.monitoring.podmonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- with .Values.decode.monitoring.podmonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.requester.enable (and .Values.decode.create (not .Values.multinode)) }}
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: {{ include "llm-d-modelservice.decodeName" . }}
+spec:
+  replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
+  selector:
+    matchLabels:
+      app: dp-app
+  template:
+    metadata:
+      labels:
+        app: dp-app
+      annotations:
+        dual-pod.llm-d.ai/admin-port: "{{ .Values.requester.adminPort }}"
+        dual-pod.llm-d.ai/server-patch: |
+          metadata:
+            labels: {
+              {{- $modelParts := split "/" .Values.modelArtifacts.name -}}
+              "model-reg": {{ index $modelParts._1 | quote }},
+              "model-repo": {{ index $modelParts._0 | quote }},
+              "app": null}
+          spec:
+            {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
+            initContainers:
+            {{- with .Values.routing }}
+            {{- (include "llm-d-modelservice.routingProxy" .) | nindent 12 }}
+            {{- end }}
+            {{- if .Values.decode.initContainers }}
+            {{- toYaml .Values.decode.initContainers | nindent 12 }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.decode.containers }}
+            containers:
+              {{- range . }}
+              {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 14 }}
+              {{- end }}
+            {{- end }}
+    spec:
+      containers:
+        - name: inference-server
+          image: {{ .Values.requester.image }}
+          imagePullPolicy: Always
+          command:
+          - /app/requester
+          env:
+          - name: PROBES_PORT
+            value: {{ .Values.requester.port.probes | quote }}
+          - name: SPI_PORT
+            value: {{ .Values.requester.port.spi | quote }}
+          ports:
+          - name: probes
+            containerPort: {{ .Values.requester.port.probes }}
+          - name: spi
+            containerPort: {{ .Values.requester.port.spi }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.requester.port.probes }}
+            initialDelaySeconds: {{ .Values.requester.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.requester.readinessProbe.periodSeconds }}
+          resources:
+            limits:
+              nvidia.com/gpu: {{ .Values.requester.resources.limits.gpus }}
+              cpu: {{ .Values.requester.resources.limits.cpus }}
+              memory: {{ .Values.requester.resources.limits.memory }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/extra-objects.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.prefill.create (not .Values.multinode) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-modelservice.prefillName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+  {{- $warning := "" }}
+  {{- if .Values.prefill.containers }}
+  {{- $firstContainer := index .Values.prefill.containers 0 }}
+  {{- $warning = include "llm-d-modelservice.acceleratorWarning" (dict "parallelism" .Values.prefill.parallelism "resources" $firstContainer.resources "Values" .Values "container" $firstContainer) }}
+  {{- end }}
+  {{- if or .Values.prefill.annotations $warning }}
+  annotations:
+    {{- if .Values.prefill.annotations }}
+    {{- toYaml .Values.prefill.annotations | nindent 4 }}
+    {{- end }}
+    {{- if $warning }}
+    llm-d.ai/accelerator-warning: {{ $warning | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: {{ ternary .Values.prefill.replicas 1 (hasKey .Values.prefill "replicas") }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-modelservice.prefilllabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-modelservice.prefilllabels" . | nindent 8 }}
+      {{- if .Values.prefill.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.prefill.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.prefill.initContainers }}
+      initContainers:
+      {{- toYaml .Values.prefill.initContainers | nindent 8 }}
+      {{- end }}
+      {{- if hasKey .Values.prefill "enableServiceLinks" }}
+      enableServiceLinks: {{ .Values.prefill.enableServiceLinks }}
+      {{- end }}
+      {{- if hasKey .Values.prefill "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.prefill.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
+      {{- if .Values.prefill.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.prefill.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prefill.containers }}
+      containers:
+        {{- range . }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.prefill)) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.prefill.tolerations }}
+      tolerations:
+        {{- toYaml .Values.prefill.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-lws.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-lws.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.prefill.create .Values.multinode }}
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: {{ include "llm-d-modelservice.prefillName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+    {{- include "llm-d-modelservice.prefilllabels" . | nindent 4 }}
+  {{- $warning := "" }}
+  {{- if .Values.prefill.containers }}
+  {{- $firstContainer := index .Values.prefill.containers 0 }}
+  {{- $warning = include "llm-d-modelservice.acceleratorWarning" (dict "parallelism" .Values.prefill.parallelism "resources" $firstContainer.resources "Values" .Values "container" $firstContainer) }}
+  {{- end }}
+  {{- if or .Values.prefill.subGroupExclusiveTopology .Values.prefill.annotations $warning }}
+  annotations:
+  {{- if .Values.prefill.subGroupExclusiveTopology }}
+    leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
+  {{- end }}
+  {{- if .Values.prefill.annotations }}
+    {{ toYaml .Values.prefill.annotations | nindent 4 }}
+  {{- end }}
+  {{- if $warning }}
+    llm-d.ai/accelerator-warning: {{ $warning | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  {{- if not .Values.prefill.autoscaling.enabled }}
+  replicas: {{ ternary .Values.prefill.replicas 1 (hasKey .Values.prefill "replicas") }}
+  {{- end }}
+  leaderWorkerTemplate:
+    size: {{ int (include "llm-d-modelservice.numWorkers" .Values.prefill.parallelism) }}
+    {{- if .Values.prefill.subGroupPolicy }}
+    subGroupPolicy:
+    {{- toYaml .Values.prefill.subGroupPolicy | nindent 6 }}
+    {{- end }}
+    workerTemplate:
+      metadata:
+        labels:
+          {{- include "llm-d-modelservice.prefilllabels" . | nindent 10 }}
+        {{- if or .Values.prefill.subGroupExclusiveTopology .Values.prefill.podAnnotations }}
+        annotations:
+        {{- if .Values.prefill.subGroupExclusiveTopology }}
+          leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
+        {{- end }}
+        {{- if .Values.prefill.podAnnotations }}
+          {{ toYaml .Values.prefill.podAnnotations | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      spec:
+        {{- /* DEPRECATED; use extraConfig.hostIPC instead */ -}}
+        {{- if hasKey .Values.prefill "hostIPC" }}
+        hostIPC: {{ .Values.prefill.hostIPC }}
+        {{- end }}
+        {{- /* DEPRECATED; use extraConfig.hostPID instead */ -}}
+        {{- if hasKey .Values.prefill "hostPID" }}
+        hostPID: {{ .Values.prefill.hostPID }}
+        {{- end }}
+        {{- if .Values.prefill.initContainers }}
+        initContainers:
+        {{- toYaml .Values.prefill.initContainers | nindent 10 }}
+        {{- end }}
+        {{- if hasKey .Values.prefill "enableServiceLinks" }}
+        enableServiceLinks: {{ .Values.prefill.enableServiceLinks }}
+        {{- end }}
+        {{- if hasKey .Values.prefill "terminationGracePeriodSeconds" }}
+        terminationGracePeriodSeconds: {{ .Values.prefill.terminationGracePeriodSeconds }}
+        {{- end }}
+        {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
+        {{- with .Values.prefill.containers }}
+        containers:
+          {{- range . }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.prefill)) | nindent 8 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.prefill.nodeSelector }}
+        nodeSelector:
+          {{- toYaml .Values.prefill.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if .Values.prefill.tolerations }}
+        tolerations:
+          {{- toYaml .Values.prefill.tolerations | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-podmonitor.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/prefill-podmonitor.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.prefill.create .Values.prefill.monitoring.podmonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "llm-d-modelservice.prefillName" . }}-podmonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+    app.kubernetes.io/component: prefill
+  {{- with .Values.prefill.monitoring.podmonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.prefill.monitoring.podmonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "llm-d-modelservice.prefilllabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  # For prefill, this is port 8000. Must use port name.
+  - port: {{ .Values.prefill.monitoring.podmonitor.portName | default "metrics" | quote }}
+    path: {{ .Values.prefill.monitoring.podmonitor.path | default "/metrics" }}
+    interval: {{ .Values.prefill.monitoring.podmonitor.interval | default "30s" }}
+    {{- with .Values.prefill.monitoring.podmonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.prefill.monitoring.podmonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.prefill.monitoring.podmonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- with .Values.prefill.monitoring.podmonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/resource-claim-template.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/resource-claim-template.yaml
@@ -1,0 +1,70 @@
+{{- /* Iterate over decode and prefill roles to create role-specific templates */}}
+{{- $roles := list
+  (dict "name" "decode" "config" .Values.decode)
+  (dict "name" "prefill" "config" .Values.prefill)
+-}}
+{{- $globalDra := .Values.accelerator.dra | default false -}}
+{{- range $role := $roles -}}
+  {{- if $role.config.create -}}
+    {{- /* Check if this role uses DRA */ -}}
+    {{- $useDra := $globalDra -}}
+    {{- if and $role.config.accelerator (hasKey $role.config.accelerator "dra") -}}
+      {{- $useDra = $role.config.accelerator.dra -}}
+    {{- end -}}
+
+    {{- if $useDra -}}
+      {{- /* Determine accelerator type */ -}}
+      {{- $acceleratorType := $.Values.accelerator.type | default "nvidia" -}}
+      {{- if and $role.config.accelerator (hasKey $role.config.accelerator "type") -}}
+        {{- $acceleratorType = $role.config.accelerator.type -}}
+      {{- end -}}
+
+      {{- /* Create context and get config */ -}}
+      {{- $context := dict "Values" $.Values "role" $role.name -}}
+      {{- $configJson := include "llm-d-modelservice.draResourceClaimTemplateConfig" $context -}}
+      {{- $config := $configJson | fromJson -}}
+
+      {{- if $config -}}
+        {{- /* Calculate template name */ -}}
+        {{- $templateName := "" -}}
+        {{- if hasKey $config "name" -}}
+          {{- $templateName = printf "%s-%s" $config.name $role.name -}}
+        {{- else -}}
+          {{- $templateName = printf "%s-%s-claim-template" $acceleratorType $role.name -}}
+        {{- end -}}
+
+        {{- /* Calculate count */ -}}
+        {{- $count := 1 -}}
+        {{- if hasKey $config "count" -}}
+          {{- $count = $config.count -}}
+        {{- else -}}
+          {{- $count = int (include "llm-d-modelservice.numGpuPerWorker" $role.config.parallelism) -}}
+        {{- end -}}
+
+        {{- $class := $config.class | default (printf "gpu.%s.com" $acceleratorType) -}}
+        {{- $match := $config.match | default "exactly" -}}
+        {{- $selectors := $config.selectors | default list }}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: {{ $templateName }}
+  labels:
+    {{- include "llm-d-modelservice.labels" $ | nindent 4 }}
+    llm-d.ai/role: {{ $role.name }}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: {{ $acceleratorType }}
+        {{ $match }}:
+          deviceClassName: {{ $class }}
+          count: {{ $count }}
+          {{- if $selectors }}
+          selectors:
+          {{- toYaml $selectors | nindent 10 }}
+          {{- end }}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/serviceaccount.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and (not .Values.serviceAccountOverride) (or .Values.prefill .Values.decode) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "llm-d-modelservice.pdServiceAccountName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/charts/llm-d-modelservice/values.yaml
@@ -1,0 +1,667 @@
+# yaml-language-server: $schema=values.schema.json
+# This values.yaml file is a default values file. It can be overridden using another.
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Common configuration values
+common: {}
+# -- Usually used when using llm-d-modelservice as a subchart
+enabled: true
+# -- String to fully override common.names.fullname
+fullnameOverride: ""
+# -- Override to default pod serviceAccountName
+serviceAccountOverride: ""
+# schedulerName -- Name of the scheduler to use for scheduling model pods
+# schedulerName: default-scheduler
+
+# Global configuration that can be referenced by subcharts and components
+global:
+  # OpenTelemetry distributed tracing configuration
+  # When enabled, vLLM containers will export traces to the OTLP endpoint
+  tracing:
+    # -- Enable distributed tracing for vLLM containers
+    enabled: false
+    # -- OTLP gRPC endpoint for trace export (e.g., OpenTelemetry Collector)
+    # Override via: export OTEL_COLLECTOR_ENDPOINT="http://your-collector:4317"
+    otlpEndpoint: "http://opentelemetry-collector.monitoring.svc.cluster.local:4317"
+    # -- Trace sampling configuration
+    sampling:
+      # -- OpenTelemetry sampler type (e.g., "parentbased_traceidratio", "always_on", "always_off")
+      sampler: "parentbased_traceidratio"
+      # -- Sampling ratio (0.0 to 1.0). Use 1.0 for 100% sampling (demo/debug), 0.1 for 10% (production)
+      samplerArg: "1.0"
+    # -- Service name overrides for different components
+    serviceNames:
+      # -- Service name for vLLM decode instances
+      vllmDecode: "vllm-decode"
+      # -- Service name for vLLM prefill instances
+      vllmPrefill: "vllm-prefill"
+    # -- vLLM-specific tracing options
+    vllm:
+      # -- Level of trace detail collection (e.g., "all", "model", "scheduler")
+      collectDetailedTraces: "all"
+modelArtifacts:
+  # name is the value of the model parameter in OpenAI requests
+  # Required
+  name: random/model
+  # Labels that will be added to the pods serving the model.
+  # These should match the labels of any associated InferencePool
+  # In addition, the label llm-d.ai/role will be added with the value 'prefill'
+  # or 'decode' depending on the role of the pod.
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
+  labels:
+    llm-d.ai/inference-serving: "true"
+  # model URI. One of:
+  #   hf://model/name - model as defined on Hugging Face
+  #   pvc://pvc_name/path/to/model - model on existing persistant storage volume
+  #   oci:// not yet supported
+  uri: "hf://{{ .Values.modelArtifacts.name }}"
+  # size of volume to create to hold the model
+  size: 5Mi
+  # name of secret containing credentials for accessing the model (e.g., HF_TOKEN)
+  authSecretName: ""
+  # location where model volume will be mounted (used when mountModelVolume: true)
+  mountPath: /model-cache
+# When true, a LeaderWorkerSet is used instead of a Deployment
+multinode: false
+# Global accelerator configuration
+# Supported types: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+accelerator:
+  # Type of accelerator to use
+  type: nvidia
+  # @schema
+  # type: boolean
+  # @schema
+  # Enable Dynamic Resource Allocation (DRA) for accelerators
+  # When true, uses resourceClaimTemplates instead of device plugin resources
+  dra: false
+  # Resource names for different accelerator types (used when dra: false)
+  resources:
+    nvidia: "nvidia.com/gpu"
+    intel-i915: "gpu.intel.com/i915"
+    intel-xe: "gpu.intel.com/xe"
+    intel-gaudi: "habana.ai/gaudi"
+    amd: "amd.com/gpu"
+    google: "google.com/tpu"
+  # Environment variables specific to accelerator types
+  env:
+    intel-i915:
+      - name: VLLM_USE_V1
+        value: "1"
+      - name: TORCH_LLM_ALLREDUCE
+        value: "1"
+      - name: VLLM_WORKER_MULTIPROC_METHOD
+        value: "spawn"
+    intel-xe:
+      - name: VLLM_WORKER_MULTIPROC_METHOD
+        value: "spawn"
+  # ResourceClaimTemplate configurations for DRA (used when dra: true)
+  # Each accelerator type can have its own claim template configuration
+  resourceClaimTemplates:
+    nvidia:
+      name: nvidia-claim-template
+      class: gpu.nvidia.com
+      match: "exactly"
+      # count: 1  # Optional: If not specified, auto-calculated from parallelism (tensor * dataLocal)
+      selectors: []
+    intel-i915:
+      name: intel-i915-claim-template
+      class: gpu.intel.com
+      match: "exactly"
+      selectors: []
+    intel-xe:
+      name: intel-xe-claim-template
+      class: gpu.intel.com
+      match: "exactly"
+      selectors: []
+    intel-gaudi:
+      name: intel-gaudi-claim-template
+      class: gaudi.intel.com
+      match: "exactly"
+      selectors: []
+    amd:
+      name: amd-claim-template
+      class: gpu.amd.com
+      match: "exactly"
+      selectors: []
+    google:
+      name: google-claim-template
+      class: tpu.google.com
+      match: "exactly"
+      selectors: []
+# @schema
+# additionalProperties: true
+# @schema
+# -- Requester configuration part of the dual-pod solution for FMA
+requester:
+  enable: false
+  image:
+    registry: ghcr.m.daocloud.io
+    repository: llm-d-incubation/llm-d-fast-model-actuation/requester
+    tag: latest
+  adminPort: 8081
+  port:
+    probes: 8080
+    spi: 8081
+  readinessProbe:
+    initialDelaySeconds: 2
+    periodSeconds: 5
+  resources:
+    limits:
+      gpus: 1
+      cpus: 1
+      memory: 250Mi
+# Describe routing requirements. In addition to service level routing (OpenAI model name, service port)
+# also describes elements for Gateway API Inference Extension configuration
+routing:
+  # Deprecated
+  # modelName: random/modelId
+  # port the inference engine (vLLM) listens
+  # when a sidecar (proxy) is used it will listen on this port and forward to VLLM on proxy.targetPort
+  servicePort: 8000
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # Configuration of VLLM routing sidecar
+  # cf. https://github.com/llm-d/llm-d-routing-sidecar/
+  proxy:
+    enabled: true
+    image:
+      registry: ghcr.m.daocloud.io
+      repository: llm-d/llm-d-routing-sidecar
+      tag: latest
+    imagePullPolicy: Always
+    # target port on which VLLM should listen
+    targetPort: 8200
+    # Specify a conenctor. For example, `nixl`, `nixlv2`
+    connector: nixlv2
+    # Boolean: adds the `--secure-proxy` flag to the routingSidecar with your chosen value.  Arg is ommitted by default for compatability with legacy sidecar images.
+    secure: false
+    # Boolean: whether to use TLS when sending requests to prefillers. Arg is ommitted by default for compatability with legacy sidecar images.
+    # prefillerUseTLS: true
+
+    # The path to the certificate for secure proxy.  Arg is ommitted by default for compatability with legacy sidecar images.
+    # certPath: "/certs"
+
+    # Zap logging configuration
+    # Boolean: Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+    # @schema
+    # type: boolean
+    # default:false
+    # @schema
+    # zapDevel: false
+
+    # String: Zap log encoding (one of 'json' or 'console')
+    # @schema
+    # default: json
+    # enum: [json,console]
+    # @schema
+    zapEncoder: json
+    # String or integer: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+    # @schema
+    # type: [string, integer]
+    # default: debug
+    # @schema
+    zapLogLevel: debug
+    # String: Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic')
+    # @schema
+    # enum: [info,error,panic]
+    # default: error
+    # @schema
+    # zapStacktraceLevel: error
+# String: Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'
+# @schema
+# enum: [epoch,millis,nano,iso8601,rfc3339,rfc3339nano]
+# default: epoch
+# @schema
+# zapTimeEncoding: epoch
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Decode pod configuration
+decode:
+  create: true
+  autoscaling:
+    enabled: false
+  replicas: 1
+  # @schema
+  # additionalProperties: true
+  # @schema
+  nodeSelector: {}
+  # schedulerName -- Name of the scheduler to use for scheduling decode pods (overrides global schedulerName)
+  # schedulerName: decode-scheduler
+
+  # VLLM parallelism configuration
+  parallelism:
+    tensor: 1
+    data: 1
+    dataLocal: 1
+    workers: 1
+  # accelerator:
+  #   # Optional: Override global accelerator configuration for decode pods
+  #   # When not specified, falls back to global accelerator settings
+  #
+  #   # Override accelerator type for decode pods
+  #   # Supported: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+  #   type: nvidia
+  #
+  #   # Override DRA (Dynamic Resource Allocation) mode for decode pods
+  #   # When not specified, falls back to accelerator.dra
+  #   dra: false
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   required: [name, resourceClaimTemplateName]
+  #   properties:
+  #     name:
+  #       type: string
+  #     resourceClaimTemplateName:
+  #       type: string
+  # @schema
+  # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+  # These will be merged with accelerator claims when accelerator.dra is enabled
+  resourceClaims: []
+  # Example:
+  # - name: llm-d-imex-channel-0
+  #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   required: [name, resourceClaimTemplateName]
+  #   properties:
+  #     name:
+  #       type: string
+  #     resourceClaimTemplateName:
+  #       type: string
+  # @schema
+  # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+  # These will be merged with accelerator claims when accelerator.dra is enabled
+  resourceClaims: []
+  # Example:
+  # - name: llm-d-imex-channel-0
+  #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  containers:
+    - name: "vllm"
+      image:
+        registry: ghcr.m.daocloud.io
+        repository: llm-d/llm-d-inference-sim
+        tag: latest
+      # type of command:
+      #   vllmServe - modelservice will add the command vllm serve to the container
+      #   imageDefault - no command will be added; the default command defined in the image will be used
+      #   custom - use user provided "command"
+      modelCommand: imageDefault
+      # Required when modelCommand is "custom"
+      command: []
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      args: []
+      # @schema
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+      # @schema
+      env: []
+      imagePullPolicy: ""
+      # list of ports exposed by the container
+      # @schema
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ContainerPort
+      # @schema
+      ports: []
+      #   - containerPort: 8200  # matches routing.proxy.targetPort, set for metrics scraping with  monitoring.podmonitor.enabled true
+      #     name: metrics
+      #     protocol: TCP
+      # @schema
+      # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+      # @schema
+      resources:
+        # @schema
+        # additionalProperties: true
+        # @schema
+        limits: {}
+        # @schema
+        # additionalProperties: true
+        # @schema
+        requests: {}
+      # when set, a volumeMount (and volume) is created for model storage
+      mountModelVolume: true
+      # @schema
+      # type: array
+      # items:
+      #   type: object
+      #   additionalProperties: true
+      # @schema
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  volumes:
+    - name: metrics-volume
+      emptyDir: {}
+  # @schema
+  # type: array
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+  # @schema
+  # Additional init containers to run before the main containers
+  # These will be added alongside the routing proxy init container (if enabled)
+  initContainers: []
+  # hostIPC -- Boolean: Use the host's ipc namespace.
+  # -- Not set by default.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+  # hostIPC: false
+
+  # hostPID -- Boolean: Use the host's pid namespace.
+  # -- Not set by default.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+  # hostPID: false
+
+  # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
+  # -- Not set by default (defaults to true if not specified).
+  # enableServiceLinks: false
+
+  # terminationGracePeriodSeconds -- Duration in seconds the pod needs to terminate gracefully.
+  # -- Not set by default (defaults to 30 seconds if not specified).
+  # terminationGracePeriodSeconds: 60
+
+  # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
+  # -- Not set by default
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+  # subGroupPolicy:
+  #   subGroupSize: 8
+
+  # subGroupExclusiveToplogy -- Boolean: Should the `subgroup-exclusive-topology` annotation be added to the LWS
+  # -- Not set by default
+  # -- Only an option for LWS (multinode)
+  # subGroupExclusiveToplogy: true
+
+  # XPU-specific node affinity
+  acceleratorTypes:
+    labelKey: ""
+    # @schema
+    # items:
+    #   type: string
+    # @schema
+    labelValues: []
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # Monitoring configuration for decode pods
+  monitoring:
+    # PodMonitor configuration for Prometheus Operator
+    podmonitor:
+      # enabled -- Create PodMonitor resource for decode deployment
+      enabled: false
+      # portName -- Port name to scrape metrics from (must match container port name)
+      portName: "metrics"
+      # path -- HTTP path to scrape metrics from
+      path: "/metrics"
+      # interval -- Interval at which metrics should be scraped
+      interval: "30s"
+      # scrapeTimeout -- Timeout after which the scrape is ended
+      # scrapeTimeout: "10s"
+      # @schema
+      # additionalProperties: true
+      # @schema
+      # labels -- Additional labels to be added to the PodMonitor
+      labels: {}
+      # annotations -- Additional annotations to be added to the PodMonitor
+      # @schema
+      # additionalProperties: true
+      # @schema
+      annotations: {}
+      # relabelings -- RelabelConfigs to apply to samples before scraping
+      relabelings: []
+      # metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion
+      metricRelabelings: []
+      # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
+      # namespaceSelector: {}
+# @schema
+# additionalProperties: true
+# @schema
+# Prefill pod configuation
+prefill:
+  create: true
+  autoscaling:
+    enabled: false
+  replicas: 0
+  # @schema
+  # additionalProperties: true
+  # @schema
+  nodeSelector: {}
+  # schedulerName -- Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName)
+  # schedulerName: prefill-scheduler
+
+  # VLLM parallelism configuration
+  parallelism:
+    tensor: 1
+    data: 1
+    dataLocal: 1
+    workers: 1
+  # accelerator:
+  #   # Optional: Override global accelerator configuration for prefill pods
+  #   # When not specified, falls back to global accelerator settings
+  #
+  #   # Override accelerator type for prefill pods
+  #   # Supported: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+  #   type: intel-gaudi
+  #
+  #   # Override DRA (Dynamic Resource Allocation) mode for prefill pods
+  #   # When not specified, falls back to accelerator.dra
+  #   dra: false
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   required: [name, resourceClaimTemplateName]
+  #   properties:
+  #     name:
+  #       type: string
+  #     resourceClaimTemplateName:
+  #       type: string
+  # @schema
+  # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+  # These will be merged with accelerator claims when accelerator.dra is enabled
+  resourceClaims: []
+  # Example:
+  # - name: llm-d-imex-channel-0
+  #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   required: [name, resourceClaimTemplateName]
+  #   properties:
+  #     name:
+  #       type: string
+  #     resourceClaimTemplateName:
+  #       type: string
+  # @schema
+  # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+  # These will be merged with accelerator claims when accelerator.dra is enabled
+  resourceClaims: []
+  # Example:
+  # - name: llm-d-imex-channel-0
+  #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  containers:
+    - name: "vllm"
+      image:
+        registry: ghcr.m.daocloud.io
+        repository: llm-d/llm-d-inference-sim
+        tag: latest
+      modelCommand: imageDefault
+      mountModelVolume: true
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      args: []
+      # @schema
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+      # @schema
+      env: []
+      imagePullPolicy: ""
+      command: []
+      # list of ports exposed by the container
+      # @schema
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ContainerPort
+      # @schema
+      ports: []
+      #   - containerPort: 8000  # matches routing.servicePort, set for metrics scraping with  monitoring.podmonitor.enabled true
+      #     name: metrics
+      #     protocol: TCP
+      # @schema
+      # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+      # @schema
+      resources:
+        # @schema
+        # additionalProperties: true
+        # @schema
+        limits: {}
+        # @schema
+        # additionalProperties: true
+        # @schema
+        requests: {}
+      # @schema
+      # type: array
+      # items:
+      #   type: object
+      #   additionalProperties: true
+      # @schema
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  volumes:
+    - name: metrics-volume
+      emptyDir: {}
+  # @schema
+  # type: array
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+  # @schema
+  # Additional init containers to run before the main containers
+  initContainers: []
+  # hostIPC -- Boolean: Use the host's ipc namespace.
+  # -- Not set by default.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+  # hostIPC: false
+
+  # hostPID -- Boolean: Use the host's pid namespace.
+  # -- Not set by default.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+  # hostPID: false
+
+  # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
+  # -- Not set by default (defaults to true if not specified).
+  # enableServiceLinks: false
+
+  # terminationGracePeriodSeconds -- Duration in seconds the pod needs to terminate gracefully.
+  # -- Not set by default (defaults to 30 seconds if not specified).
+  # terminationGracePeriodSeconds: 60
+
+  # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
+  # -- Not set by default
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+  # subGroupPolicy:
+  #   subGroupSize: 8
+
+  # subGroupExclusiveToplogy -- Boolean: Should the `subgroup-exclusive-topology` annotation be added to the LWS
+  # -- Not set by default
+  # -- Only an option for LWS (multinode)
+  # subGroupExclusiveToplogy: true
+
+  # XPU-specific node affinity
+  acceleratorTypes:
+    labelKey: ""
+    # @schema
+    # items:
+    #   type: string
+    # @schema
+    labelValues: []
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # Monitoring configuration for prefill pods
+  monitoring:
+    # PodMonitor configuration for Prometheus Operator
+    podmonitor:
+      # enabled -- Create PodMonitor resource for prefill deployment
+      enabled: false
+      # portName -- Port name to scrape metrics from (must match container port name)
+      portName: "metrics"
+      # path -- HTTP path to scrape metrics from
+      path: "/metrics"
+      # interval -- Interval at which metrics should be scraped
+      interval: "30s"
+      # scrapeTimeout -- Timeout after which the scrape is ended
+      # scrapeTimeout: "10s"
+      # @schema
+      # additionalProperties: true
+      # @schema
+      # labels -- Additional labels to be added to the PodMonitor
+      labels: {}
+      # annotations -- Additional annotations to be added to the PodMonitor
+      # @schema
+      # additionalProperties: true
+      # @schema
+      annotations: {}
+      # relabelings -- RelabelConfigs to apply to samples before scraping
+      relabelings: []
+      # metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion
+      metricRelabelings: []
+      # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
+      # namespaceSelector: {}
+# @schema
+# items:
+#   type: object
+# @schema
+# -- Extra objects to be deployed alongside the main application
+extraObjects: []
+# Example:
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: example-config
+#     data:
+#       key: value

--- a/charts/llm-d-modelservice/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/llm-d-modelservice/values.schema.json
@@ -1,0 +1,741 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "llm-d-modelservice": {
+            "type": "object",
+            "properties": {
+                "accelerator": {
+                    "type": "object",
+                    "properties": {
+                        "dra": {
+                            "type": "boolean"
+                        },
+                        "env": {
+                            "type": "object",
+                            "properties": {
+                                "intel-i915": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "intel-xe": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resourceClaimTemplates": {
+                            "type": "object",
+                            "properties": {
+                                "amd": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "google": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-gaudi": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-i915": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-xe": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "nvidia": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "amd": {
+                                    "type": "string"
+                                },
+                                "google": {
+                                    "type": "string"
+                                },
+                                "intel-gaudi": {
+                                    "type": "string"
+                                },
+                                "intel-i915": {
+                                    "type": "string"
+                                },
+                                "intel-xe": {
+                                    "type": "string"
+                                },
+                                "nvidia": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "common": {
+                    "type": "object"
+                },
+                "decode": {
+                    "type": "object",
+                    "properties": {
+                        "acceleratorTypes": {
+                            "type": "object",
+                            "properties": {
+                                "labelKey": {
+                                    "type": "string"
+                                },
+                                "labelValues": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "autoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "containers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "args": {
+                                        "type": "array"
+                                    },
+                                    "command": {
+                                        "type": "array"
+                                    },
+                                    "env": {
+                                        "type": "array"
+                                    },
+                                    "image": {
+                                        "type": "object",
+                                        "properties": {
+                                            "registry": {
+                                                "type": "string"
+                                            },
+                                            "repository": {
+                                                "type": "string"
+                                            },
+                                            "tag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "imagePullPolicy": {
+                                        "type": "string"
+                                    },
+                                    "modelCommand": {
+                                        "type": "string"
+                                    },
+                                    "mountModelVolume": {
+                                        "type": "boolean"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "ports": {
+                                        "type": "array"
+                                    },
+                                    "resources": {
+                                        "type": "object",
+                                        "properties": {
+                                            "limits": {
+                                                "type": "object"
+                                            },
+                                            "requests": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "volumeMounts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mountPath": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "initContainers": {
+                            "type": "array"
+                        },
+                        "monitoring": {
+                            "type": "object",
+                            "properties": {
+                                "podmonitor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "interval": {
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "type": "object"
+                                        },
+                                        "metricRelabelings": {
+                                            "type": "array"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "portName": {
+                                            "type": "string"
+                                        },
+                                        "relabelings": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "parallelism": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "integer"
+                                },
+                                "dataLocal": {
+                                    "type": "integer"
+                                },
+                                "tensor": {
+                                    "type": "integer"
+                                },
+                                "workers": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resourceClaims": {
+                            "type": "array"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "emptyDir": {
+                                        "type": "object"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraObjects": {
+                    "type": "array"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "object",
+                    "properties": {
+                        "tracing": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "otlpEndpoint": {
+                                    "type": "string"
+                                },
+                                "sampling": {
+                                    "type": "object",
+                                    "properties": {
+                                        "sampler": {
+                                            "type": "string"
+                                        },
+                                        "samplerArg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "serviceNames": {
+                                    "type": "object",
+                                    "properties": {
+                                        "vllmDecode": {
+                                            "type": "string"
+                                        },
+                                        "vllmPrefill": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "vllm": {
+                                    "type": "object",
+                                    "properties": {
+                                        "collectDetailedTraces": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "modelArtifacts": {
+                    "type": "object",
+                    "properties": {
+                        "authSecretName": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "llm-d.ai/inference-serving": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "multinode": {
+                    "type": "boolean"
+                },
+                "prefill": {
+                    "type": "object",
+                    "properties": {
+                        "acceleratorTypes": {
+                            "type": "object",
+                            "properties": {
+                                "labelKey": {
+                                    "type": "string"
+                                },
+                                "labelValues": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "autoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "containers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "args": {
+                                        "type": "array"
+                                    },
+                                    "command": {
+                                        "type": "array"
+                                    },
+                                    "env": {
+                                        "type": "array"
+                                    },
+                                    "image": {
+                                        "type": "object",
+                                        "properties": {
+                                            "registry": {
+                                                "type": "string"
+                                            },
+                                            "repository": {
+                                                "type": "string"
+                                            },
+                                            "tag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "imagePullPolicy": {
+                                        "type": "string"
+                                    },
+                                    "modelCommand": {
+                                        "type": "string"
+                                    },
+                                    "mountModelVolume": {
+                                        "type": "boolean"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "ports": {
+                                        "type": "array"
+                                    },
+                                    "resources": {
+                                        "type": "object",
+                                        "properties": {
+                                            "limits": {
+                                                "type": "object"
+                                            },
+                                            "requests": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "volumeMounts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mountPath": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "initContainers": {
+                            "type": "array"
+                        },
+                        "monitoring": {
+                            "type": "object",
+                            "properties": {
+                                "podmonitor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "interval": {
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "type": "object"
+                                        },
+                                        "metricRelabelings": {
+                                            "type": "array"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "portName": {
+                                            "type": "string"
+                                        },
+                                        "relabelings": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "parallelism": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "integer"
+                                },
+                                "dataLocal": {
+                                    "type": "integer"
+                                },
+                                "tensor": {
+                                    "type": "integer"
+                                },
+                                "workers": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resourceClaims": {
+                            "type": "array"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "emptyDir": {
+                                        "type": "object"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "requester": {
+                    "type": "object",
+                    "properties": {
+                        "adminPort": {
+                            "type": "integer"
+                        },
+                        "enable": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "object",
+                            "properties": {
+                                "probes": {
+                                    "type": "integer"
+                                },
+                                "spi": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpus": {
+                                            "type": "integer"
+                                        },
+                                        "gpus": {
+                                            "type": "integer"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "routing": {
+                    "type": "object",
+                    "properties": {
+                        "proxy": {
+                            "type": "object",
+                            "properties": {
+                                "connector": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "imagePullPolicy": {
+                                    "type": "string"
+                                },
+                                "secure": {
+                                    "type": "boolean"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                },
+                                "zapEncoder": {
+                                    "type": "string"
+                                },
+                                "zapLogLevel": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceAccountOverride": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/charts/llm-d-modelservice/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/llm-d-modelservice/values.yaml
@@ -1,0 +1,673 @@
+# child values
+llm-d-modelservice:
+  # yaml-language-server: $schema=values.schema.json
+  # This values.yaml file is a default values file. It can be overridden using another.
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Common configuration values
+  common: {}
+  # -- Usually used when using llm-d-modelservice as a subchart
+  enabled: true
+  # -- String to fully override common.names.fullname
+  fullnameOverride: ""
+  # -- Override to default pod serviceAccountName
+  serviceAccountOverride: ""
+  # schedulerName -- Name of the scheduler to use for scheduling model pods
+  # schedulerName: default-scheduler
+
+  # Global configuration that can be referenced by subcharts and components
+  global:
+    # OpenTelemetry distributed tracing configuration
+    # When enabled, vLLM containers will export traces to the OTLP endpoint
+    tracing:
+      # -- Enable distributed tracing for vLLM containers
+      enabled: false
+      # -- OTLP gRPC endpoint for trace export (e.g., OpenTelemetry Collector)
+      # Override via: export OTEL_COLLECTOR_ENDPOINT="http://your-collector:4317"
+      otlpEndpoint: "http://opentelemetry-collector.monitoring.svc.cluster.local:4317"
+      # -- Trace sampling configuration
+      sampling:
+        # -- OpenTelemetry sampler type (e.g., "parentbased_traceidratio", "always_on", "always_off")
+        sampler: "parentbased_traceidratio"
+        # -- Sampling ratio (0.0 to 1.0). Use 1.0 for 100% sampling (demo/debug), 0.1 for 10% (production)
+        samplerArg: "1.0"
+      # -- Service name overrides for different components
+      serviceNames:
+        # -- Service name for vLLM decode instances
+        vllmDecode: "vllm-decode"
+        # -- Service name for vLLM prefill instances
+        vllmPrefill: "vllm-prefill"
+      # -- vLLM-specific tracing options
+      vllm:
+        # -- Level of trace detail collection (e.g., "all", "model", "scheduler")
+        collectDetailedTraces: "all"
+  modelArtifacts:
+    # name is the value of the model parameter in OpenAI requests
+    # Required
+    name: random/model
+    # Labels that will be added to the pods serving the model.
+    # These should match the labels of any associated InferencePool
+    # In addition, the label llm-d.ai/role will be added with the value 'prefill'
+    # or 'decode' depending on the role of the pod.
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
+    labels:
+      llm-d.ai/inference-serving: "true"
+    # model URI. One of:
+    #   hf://model/name - model as defined on Hugging Face
+    #   pvc://pvc_name/path/to/model - model on existing persistant storage volume
+    #   oci:// not yet supported
+    uri: "hf://{{ .Values.modelArtifacts.name }}"
+    # size of volume to create to hold the model
+    size: 5Mi
+    # name of secret containing credentials for accessing the model (e.g., HF_TOKEN)
+    authSecretName: ""
+    # location where model volume will be mounted (used when mountModelVolume: true)
+    mountPath: /model-cache
+  # When true, a LeaderWorkerSet is used instead of a Deployment
+  multinode: false
+  # Global accelerator configuration
+  # Supported types: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+  accelerator:
+    # Type of accelerator to use
+    type: nvidia
+    # @schema
+    # type: boolean
+    # @schema
+    # Enable Dynamic Resource Allocation (DRA) for accelerators
+    # When true, uses resourceClaimTemplates instead of device plugin resources
+    dra: false
+    # Resource names for different accelerator types (used when dra: false)
+    resources:
+      nvidia: "nvidia.com/gpu"
+      intel-i915: "gpu.intel.com/i915"
+      intel-xe: "gpu.intel.com/xe"
+      intel-gaudi: "habana.ai/gaudi"
+      amd: "amd.com/gpu"
+      google: "google.com/tpu"
+    # Environment variables specific to accelerator types
+    env:
+      intel-i915:
+        - name: VLLM_USE_V1
+          value: "1"
+        - name: TORCH_LLM_ALLREDUCE
+          value: "1"
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: "spawn"
+      intel-xe:
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: "spawn"
+    # ResourceClaimTemplate configurations for DRA (used when dra: true)
+    # Each accelerator type can have its own claim template configuration
+    resourceClaimTemplates:
+      nvidia:
+        name: nvidia-claim-template
+        class: gpu.nvidia.com
+        match: "exactly"
+        # count: 1  # Optional: If not specified, auto-calculated from parallelism (tensor * dataLocal)
+        selectors: []
+      intel-i915:
+        name: intel-i915-claim-template
+        class: gpu.intel.com
+        match: "exactly"
+        selectors: []
+      intel-xe:
+        name: intel-xe-claim-template
+        class: gpu.intel.com
+        match: "exactly"
+        selectors: []
+      intel-gaudi:
+        name: intel-gaudi-claim-template
+        class: gaudi.intel.com
+        match: "exactly"
+        selectors: []
+      amd:
+        name: amd-claim-template
+        class: gpu.amd.com
+        match: "exactly"
+        selectors: []
+      google:
+        name: google-claim-template
+        class: tpu.google.com
+        match: "exactly"
+        selectors: []
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Requester configuration part of the dual-pod solution for FMA
+  requester:
+    enable: false
+    image:
+      registry: ghcr.m.daocloud.io
+      repository: llm-d-incubation/llm-d-fast-model-actuation/requester
+      tag: latest
+    adminPort: 8081
+    port:
+      probes: 8080
+      spi: 8081
+    readinessProbe:
+      initialDelaySeconds: 2
+      periodSeconds: 5
+    resources:
+      limits:
+        gpus: 1
+        cpus: 1
+        memory: 250Mi
+  # Describe routing requirements. In addition to service level routing (OpenAI model name, service port)
+  # also describes elements for Gateway API Inference Extension configuration
+  routing:
+    # Deprecated
+    # modelName: random/modelId
+    # port the inference engine (vLLM) listens
+    # when a sidecar (proxy) is used it will listen on this port and forward to VLLM on proxy.targetPort
+    servicePort: 8000
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # Configuration of VLLM routing sidecar
+    # cf. https://github.com/llm-d/llm-d-routing-sidecar/
+    proxy:
+      enabled: true
+      image:
+        registry: ghcr.m.daocloud.io
+        repository: llm-d/llm-d-routing-sidecar
+        tag: latest
+      imagePullPolicy: Always
+      # target port on which VLLM should listen
+      targetPort: 8200
+      # Specify a conenctor. For example, `nixl`, `nixlv2`
+      connector: nixlv2
+      # Boolean: adds the `--secure-proxy` flag to the routingSidecar with your chosen value.  Arg is ommitted by default for compatability with legacy sidecar images.
+      secure: false
+      # Boolean: whether to use TLS when sending requests to prefillers. Arg is ommitted by default for compatability with legacy sidecar images.
+      # prefillerUseTLS: true
+
+      # The path to the certificate for secure proxy.  Arg is ommitted by default for compatability with legacy sidecar images.
+      # certPath: "/certs"
+
+      # Zap logging configuration
+      # Boolean: Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+      # @schema
+      # type: boolean
+      # default:false
+      # @schema
+      # zapDevel: false
+
+      # String: Zap log encoding (one of 'json' or 'console')
+      # @schema
+      # default: json
+      # enum: [json,console]
+      # @schema
+      zapEncoder: json
+      # String or integer: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+      # @schema
+      # type: [string, integer]
+      # default: debug
+      # @schema
+      zapLogLevel: debug
+      # String: Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic')
+      # @schema
+      # enum: [info,error,panic]
+      # default: error
+      # @schema
+      # zapStacktraceLevel: error
+  # String: Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'
+  # @schema
+  # enum: [epoch,millis,nano,iso8601,rfc3339,rfc3339nano]
+  # default: epoch
+  # @schema
+  # zapTimeEncoding: epoch
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Decode pod configuration
+  decode:
+    create: true
+    autoscaling:
+      enabled: false
+    replicas: 1
+    # @schema
+    # additionalProperties: true
+    # @schema
+    nodeSelector: {}
+    # schedulerName -- Name of the scheduler to use for scheduling decode pods (overrides global schedulerName)
+    # schedulerName: decode-scheduler
+
+    # VLLM parallelism configuration
+    parallelism:
+      tensor: 1
+      data: 1
+      dataLocal: 1
+      workers: 1
+    # accelerator:
+    #   # Optional: Override global accelerator configuration for decode pods
+    #   # When not specified, falls back to global accelerator settings
+    #
+    #   # Override accelerator type for decode pods
+    #   # Supported: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+    #   type: nvidia
+    #
+    #   # Override DRA (Dynamic Resource Allocation) mode for decode pods
+    #   # When not specified, falls back to accelerator.dra
+    #   dra: false
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   required: [name, resourceClaimTemplateName]
+    #   properties:
+    #     name:
+    #       type: string
+    #     resourceClaimTemplateName:
+    #       type: string
+    # @schema
+    # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+    # These will be merged with accelerator claims when accelerator.dra is enabled
+    resourceClaims: []
+    # Example:
+    # - name: llm-d-imex-channel-0
+    #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   required: [name, resourceClaimTemplateName]
+    #   properties:
+    #     name:
+    #       type: string
+    #     resourceClaimTemplateName:
+    #       type: string
+    # @schema
+    # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+    # These will be merged with accelerator claims when accelerator.dra is enabled
+    resourceClaims: []
+    # Example:
+    # - name: llm-d-imex-channel-0
+    #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   additionalProperties: true
+    # @schema
+    containers:
+      - name: "vllm"
+        image:
+          registry: ghcr.m.daocloud.io
+          repository: llm-d/llm-d-inference-sim
+          tag: latest
+        # type of command:
+        #   vllmServe - modelservice will add the command vllm serve to the container
+        #   imageDefault - no command will be added; the default command defined in the image will be used
+        #   custom - use user provided "command"
+        modelCommand: imageDefault
+        # Required when modelCommand is "custom"
+        command: []
+        # @schema
+        # items:
+        #   type: string
+        # @schema
+        args: []
+        # @schema
+        # items:
+        #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+        # @schema
+        env: []
+        imagePullPolicy: ""
+        # list of ports exposed by the container
+        # @schema
+        # items:
+        #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ContainerPort
+        # @schema
+        ports: []
+        #   - containerPort: 8200  # matches routing.proxy.targetPort, set for metrics scraping with  monitoring.podmonitor.enabled true
+        #     name: metrics
+        #     protocol: TCP
+        # @schema
+        # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+        # @schema
+        resources:
+          # @schema
+          # additionalProperties: true
+          # @schema
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          # @schema
+          # additionalProperties: true
+          # @schema
+          requests: {}
+        # when set, a volumeMount (and volume) is created for model storage
+        mountModelVolume: true
+        # @schema
+        # type: array
+        # items:
+        #   type: object
+        #   additionalProperties: true
+        # @schema
+        volumeMounts:
+          - name: metrics-volume
+            mountPath: /.config
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   additionalProperties: true
+    # @schema
+    volumes:
+      - name: metrics-volume
+        emptyDir: {}
+    # @schema
+    # type: array
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+    # @schema
+    # Additional init containers to run before the main containers
+    # These will be added alongside the routing proxy init container (if enabled)
+    initContainers: []
+    # hostIPC -- Boolean: Use the host's ipc namespace.
+    # -- Not set by default.
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+    # hostIPC: false
+
+    # hostPID -- Boolean: Use the host's pid namespace.
+    # -- Not set by default.
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+    # hostPID: false
+
+    # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
+    # -- Not set by default (defaults to true if not specified).
+    # enableServiceLinks: false
+
+    # terminationGracePeriodSeconds -- Duration in seconds the pod needs to terminate gracefully.
+    # -- Not set by default (defaults to 30 seconds if not specified).
+    # terminationGracePeriodSeconds: 60
+
+    # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
+    # -- Not set by default
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+    # subGroupPolicy:
+    #   subGroupSize: 8
+
+    # subGroupExclusiveToplogy -- Boolean: Should the `subgroup-exclusive-topology` annotation be added to the LWS
+    # -- Not set by default
+    # -- Only an option for LWS (multinode)
+    # subGroupExclusiveToplogy: true
+
+    # XPU-specific node affinity
+    acceleratorTypes:
+      labelKey: ""
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      labelValues: []
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # Monitoring configuration for decode pods
+    monitoring:
+      # PodMonitor configuration for Prometheus Operator
+      podmonitor:
+        # enabled -- Create PodMonitor resource for decode deployment
+        enabled: false
+        # portName -- Port name to scrape metrics from (must match container port name)
+        portName: "metrics"
+        # path -- HTTP path to scrape metrics from
+        path: "/metrics"
+        # interval -- Interval at which metrics should be scraped
+        interval: "30s"
+        # scrapeTimeout -- Timeout after which the scrape is ended
+        # scrapeTimeout: "10s"
+        # @schema
+        # additionalProperties: true
+        # @schema
+        # labels -- Additional labels to be added to the PodMonitor
+        labels: {}
+        # annotations -- Additional annotations to be added to the PodMonitor
+        # @schema
+        # additionalProperties: true
+        # @schema
+        annotations: {}
+        # relabelings -- RelabelConfigs to apply to samples before scraping
+        relabelings: []
+        # metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion
+        metricRelabelings: []
+        # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
+        # namespaceSelector: {}
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # Prefill pod configuation
+  prefill:
+    create: true
+    autoscaling:
+      enabled: false
+    replicas: 0
+    # @schema
+    # additionalProperties: true
+    # @schema
+    nodeSelector: {}
+    # schedulerName -- Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName)
+    # schedulerName: prefill-scheduler
+
+    # VLLM parallelism configuration
+    parallelism:
+      tensor: 1
+      data: 1
+      dataLocal: 1
+      workers: 1
+    # accelerator:
+    #   # Optional: Override global accelerator configuration for prefill pods
+    #   # When not specified, falls back to global accelerator settings
+    #
+    #   # Override accelerator type for prefill pods
+    #   # Supported: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
+    #   type: intel-gaudi
+    #
+    #   # Override DRA (Dynamic Resource Allocation) mode for prefill pods
+    #   # When not specified, falls back to accelerator.dra
+    #   dra: false
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   required: [name, resourceClaimTemplateName]
+    #   properties:
+    #     name:
+    #       type: string
+    #     resourceClaimTemplateName:
+    #       type: string
+    # @schema
+    # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+    # These will be merged with accelerator claims when accelerator.dra is enabled
+    resourceClaims: []
+    # Example:
+    # - name: llm-d-imex-channel-0
+    #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   required: [name, resourceClaimTemplateName]
+    #   properties:
+    #     name:
+    #       type: string
+    #     resourceClaimTemplateName:
+    #       type: string
+    # @schema
+    # Additional resource claims for non-accelerator resources (e.g., IMEX channels)
+    # These will be merged with accelerator claims when accelerator.dra is enabled
+    resourceClaims: []
+    # Example:
+    # - name: llm-d-imex-channel-0
+    #   resourceClaimTemplateName: llm-d-imex-channel-0
+
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   additionalProperties: true
+    # @schema
+    containers:
+      - name: "vllm"
+        image:
+          registry: ghcr.m.daocloud.io
+          repository: llm-d/llm-d-inference-sim
+          tag: latest
+        modelCommand: imageDefault
+        mountModelVolume: true
+        # @schema
+        # items:
+        #   type: string
+        # @schema
+        args: []
+        # @schema
+        # items:
+        #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+        # @schema
+        env: []
+        imagePullPolicy: ""
+        command: []
+        # list of ports exposed by the container
+        # @schema
+        # items:
+        #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ContainerPort
+        # @schema
+        ports: []
+        #   - containerPort: 8000  # matches routing.servicePort, set for metrics scraping with  monitoring.podmonitor.enabled true
+        #     name: metrics
+        #     protocol: TCP
+        # @schema
+        # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+        # @schema
+        resources:
+          # @schema
+          # additionalProperties: true
+          # @schema
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          # @schema
+          # additionalProperties: true
+          # @schema
+          requests: {}
+        # @schema
+        # type: array
+        # items:
+        #   type: object
+        #   additionalProperties: true
+        # @schema
+        volumeMounts:
+          - name: metrics-volume
+            mountPath: /.config
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   additionalProperties: true
+    # @schema
+    volumes:
+      - name: metrics-volume
+        emptyDir: {}
+    # @schema
+    # type: array
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+    # @schema
+    # Additional init containers to run before the main containers
+    initContainers: []
+    # hostIPC -- Boolean: Use the host's ipc namespace.
+    # -- Not set by default.
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+    # hostIPC: false
+
+    # hostPID -- Boolean: Use the host's pid namespace.
+    # -- Not set by default.
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+    # hostPID: false
+
+    # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
+    # -- Not set by default (defaults to true if not specified).
+    # enableServiceLinks: false
+
+    # terminationGracePeriodSeconds -- Duration in seconds the pod needs to terminate gracefully.
+    # -- Not set by default (defaults to 30 seconds if not specified).
+    # terminationGracePeriodSeconds: 60
+
+    # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
+    # -- Not set by default
+    # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+    # subGroupPolicy:
+    #   subGroupSize: 8
+
+    # subGroupExclusiveToplogy -- Boolean: Should the `subgroup-exclusive-topology` annotation be added to the LWS
+    # -- Not set by default
+    # -- Only an option for LWS (multinode)
+    # subGroupExclusiveToplogy: true
+
+    # XPU-specific node affinity
+    acceleratorTypes:
+      labelKey: ""
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      labelValues: []
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # Monitoring configuration for prefill pods
+    monitoring:
+      # PodMonitor configuration for Prometheus Operator
+      podmonitor:
+        # enabled -- Create PodMonitor resource for prefill deployment
+        enabled: false
+        # portName -- Port name to scrape metrics from (must match container port name)
+        portName: "metrics"
+        # path -- HTTP path to scrape metrics from
+        path: "/metrics"
+        # interval -- Interval at which metrics should be scraped
+        interval: "30s"
+        # scrapeTimeout -- Timeout after which the scrape is ended
+        # scrapeTimeout: "10s"
+        # @schema
+        # additionalProperties: true
+        # @schema
+        # labels -- Additional labels to be added to the PodMonitor
+        labels: {}
+        # annotations -- Additional annotations to be added to the PodMonitor
+        # @schema
+        # additionalProperties: true
+        # @schema
+        annotations: {}
+        # relabelings -- RelabelConfigs to apply to samples before scraping
+        relabelings: []
+        # metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion
+        metricRelabelings: []
+        # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
+        # namespaceSelector: {}
+  # @schema
+  # items:
+  #   type: object
+  # @schema
+  # -- Extra objects to be deployed alongside the main application
+  extraObjects: []
+  # Example:
+  # extraObjects:
+  #   - apiVersion: v1
+  #     kind: ConfigMap
+  #     metadata:
+  #       name: example-config
+  #     data:
+  #       key: value

--- a/charts/llm-d-modelservice/parent/charts/llm-d-modelservice/templates/_image.tpl
+++ b/charts/llm-d-modelservice/parent/charts/llm-d-modelservice/templates/_image.tpl
@@ -1,0 +1,11 @@
+{{/*
+Concatenate the full image address
+Receives an image object containing registry, repository, and tag fields
+Returns format: <registry>/<repository>:<tag>
+*/}}
+{{- define "llm-d-modelservice.imageAddress" -}}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $repository := .repository | required "image.repository is required" -}}
+{{- $tag := .tag | default "latest" -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}

--- a/charts/llm-d-modelservice/parent/values.schema.json
+++ b/charts/llm-d-modelservice/parent/values.schema.json
@@ -1,0 +1,741 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "llm-d-modelservice": {
+            "type": "object",
+            "properties": {
+                "accelerator": {
+                    "type": "object",
+                    "properties": {
+                        "dra": {
+                            "type": "boolean"
+                        },
+                        "env": {
+                            "type": "object",
+                            "properties": {
+                                "intel-i915": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "intel-xe": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resourceClaimTemplates": {
+                            "type": "object",
+                            "properties": {
+                                "amd": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "google": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-gaudi": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-i915": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "intel-xe": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "nvidia": {
+                                    "type": "object",
+                                    "properties": {
+                                        "class": {
+                                            "type": "string"
+                                        },
+                                        "match": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "selectors": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "amd": {
+                                    "type": "string"
+                                },
+                                "google": {
+                                    "type": "string"
+                                },
+                                "intel-gaudi": {
+                                    "type": "string"
+                                },
+                                "intel-i915": {
+                                    "type": "string"
+                                },
+                                "intel-xe": {
+                                    "type": "string"
+                                },
+                                "nvidia": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "common": {
+                    "type": "object"
+                },
+                "decode": {
+                    "type": "object",
+                    "properties": {
+                        "acceleratorTypes": {
+                            "type": "object",
+                            "properties": {
+                                "labelKey": {
+                                    "type": "string"
+                                },
+                                "labelValues": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "autoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "containers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "args": {
+                                        "type": "array"
+                                    },
+                                    "command": {
+                                        "type": "array"
+                                    },
+                                    "env": {
+                                        "type": "array"
+                                    },
+                                    "image": {
+                                        "type": "object",
+                                        "properties": {
+                                            "registry": {
+                                                "type": "string"
+                                            },
+                                            "repository": {
+                                                "type": "string"
+                                            },
+                                            "tag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "imagePullPolicy": {
+                                        "type": "string"
+                                    },
+                                    "modelCommand": {
+                                        "type": "string"
+                                    },
+                                    "mountModelVolume": {
+                                        "type": "boolean"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "ports": {
+                                        "type": "array"
+                                    },
+                                    "resources": {
+                                        "type": "object",
+                                        "properties": {
+                                            "limits": {
+                                                "type": "object"
+                                            },
+                                            "requests": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "volumeMounts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mountPath": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "initContainers": {
+                            "type": "array"
+                        },
+                        "monitoring": {
+                            "type": "object",
+                            "properties": {
+                                "podmonitor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "interval": {
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "type": "object"
+                                        },
+                                        "metricRelabelings": {
+                                            "type": "array"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "portName": {
+                                            "type": "string"
+                                        },
+                                        "relabelings": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "parallelism": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "integer"
+                                },
+                                "dataLocal": {
+                                    "type": "integer"
+                                },
+                                "tensor": {
+                                    "type": "integer"
+                                },
+                                "workers": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resourceClaims": {
+                            "type": "array"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "emptyDir": {
+                                        "type": "object"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraObjects": {
+                    "type": "array"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "object",
+                    "properties": {
+                        "tracing": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "otlpEndpoint": {
+                                    "type": "string"
+                                },
+                                "sampling": {
+                                    "type": "object",
+                                    "properties": {
+                                        "sampler": {
+                                            "type": "string"
+                                        },
+                                        "samplerArg": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "serviceNames": {
+                                    "type": "object",
+                                    "properties": {
+                                        "vllmDecode": {
+                                            "type": "string"
+                                        },
+                                        "vllmPrefill": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "vllm": {
+                                    "type": "object",
+                                    "properties": {
+                                        "collectDetailedTraces": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "modelArtifacts": {
+                    "type": "object",
+                    "properties": {
+                        "authSecretName": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "llm-d.ai/inference-serving": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "multinode": {
+                    "type": "boolean"
+                },
+                "prefill": {
+                    "type": "object",
+                    "properties": {
+                        "acceleratorTypes": {
+                            "type": "object",
+                            "properties": {
+                                "labelKey": {
+                                    "type": "string"
+                                },
+                                "labelValues": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "autoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "containers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "args": {
+                                        "type": "array"
+                                    },
+                                    "command": {
+                                        "type": "array"
+                                    },
+                                    "env": {
+                                        "type": "array"
+                                    },
+                                    "image": {
+                                        "type": "object",
+                                        "properties": {
+                                            "registry": {
+                                                "type": "string"
+                                            },
+                                            "repository": {
+                                                "type": "string"
+                                            },
+                                            "tag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "imagePullPolicy": {
+                                        "type": "string"
+                                    },
+                                    "modelCommand": {
+                                        "type": "string"
+                                    },
+                                    "mountModelVolume": {
+                                        "type": "boolean"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "ports": {
+                                        "type": "array"
+                                    },
+                                    "resources": {
+                                        "type": "object",
+                                        "properties": {
+                                            "limits": {
+                                                "type": "object"
+                                            },
+                                            "requests": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "volumeMounts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mountPath": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "initContainers": {
+                            "type": "array"
+                        },
+                        "monitoring": {
+                            "type": "object",
+                            "properties": {
+                                "podmonitor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "interval": {
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "type": "object"
+                                        },
+                                        "metricRelabelings": {
+                                            "type": "array"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "portName": {
+                                            "type": "string"
+                                        },
+                                        "relabelings": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "parallelism": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "integer"
+                                },
+                                "dataLocal": {
+                                    "type": "integer"
+                                },
+                                "tensor": {
+                                    "type": "integer"
+                                },
+                                "workers": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resourceClaims": {
+                            "type": "array"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "emptyDir": {
+                                        "type": "object"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "requester": {
+                    "type": "object",
+                    "properties": {
+                        "adminPort": {
+                            "type": "integer"
+                        },
+                        "enable": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "object",
+                            "properties": {
+                                "probes": {
+                                    "type": "integer"
+                                },
+                                "spi": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpus": {
+                                            "type": "integer"
+                                        },
+                                        "gpus": {
+                                            "type": "integer"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "routing": {
+                    "type": "object",
+                    "properties": {
+                        "proxy": {
+                            "type": "object",
+                            "properties": {
+                                "connector": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "imagePullPolicy": {
+                                    "type": "string"
+                                },
+                                "secure": {
+                                    "type": "boolean"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                },
+                                "zapEncoder": {
+                                    "type": "string"
+                                },
+                                "zapLogLevel": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceAccountOverride": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.defs
 
+SHELL := /bin/bash
 PROJECT ?=
 KIND_CLUSTER_NAME ?= network-chart
 KIND_KUBECONFIG := $(ROOT_DIR)/test/.config
@@ -31,10 +32,13 @@ e2e:
 				make init-kind -e KIND_CONFIG_PATH=$${CONFIG_PATH} || { echo "error, failed to setup kind for $${ITEM}"; exit 1 ;} ; \
 			fi ; \
 			VERSION=`yq ".version"  $(ROOT_DIR)/charts/$${ITEM}/$${ITEM}/Chart.yaml ` || { echo "error, failed to get charts version" ; exit 1 ; } ;\
-			if ( unset NO_IMAGE ;  source $(ROOT_DIR)/charts/$${ITEM}/config && [ "$${NO_IMAGE}" == "true" ] ) ; then \
+			if ( unset NO_IMAGE ;  source "$(ROOT_DIR)/charts/$${ITEM}/config" ; [ "$${NO_IMAGE:-}" = "true" ] ) ; then \
 				echo "ignore sync project $${ITEM}"; \
+			elif ( unset USE_CHARTS_SYNCER_DT ;  source "$(ROOT_DIR)/charts/$${ITEM}/config" ; [ "$${USE_CHARTS_SYNCER_DT:-}" = "true" ] ) ; then \
+				echo "sync project $${ITEM} with charts syncer dt"; \
+				make sync-with-dt -e PROJECT=$${ITEM} -e VERSION=$${VERSION} || { echo "error, failed to sync $${ITEM}" ; FAILED_PROJECT+=" $${ITEM} " ; continue ; } ; \
 			else \
-				echo "sync project $${ITEM}"; \
+				echo "sync project $${ITEM} with charts syncer"; \
 				make sync -e PROJECT=$${ITEM} -e VERSION=$${VERSION} || { echo "error, failed to sync $${ITEM}" ; FAILED_PROJECT+=" $${ITEM} " ; continue ; } ; \
 			fi ; \
 			echo "deploy project $${ITEM}"; \
@@ -97,7 +101,7 @@ init-kind: checkBin clean
 .PHONY: sync
 sync: PROJECT=
 sync: VERSION=
-sync: checkBin
+sync: checkBin checkSyncTools
 	@ echo "sync $(PROJECT) charts and images to local registry"
 	set -x ; CHART_PATH=$(ROOT_DIR)/charts/$(PROJECT) ; \
 	echo "chart move $(PROJECT) $${VERSION}" ; \
@@ -116,15 +120,46 @@ target:  \n \
 	 make checkImages -e PROJECT=$${PROJECT} -e VERSION=$${VERSION} || { echo "error, failed to check $${PROJECT} images registry" ; exit 1 ; } ; \
      rm -rf $${DIR} ;
 
+.PHONY: sync-wiht-dt
+sync-with-dt: PROJECT=
+sync-with-dt: VERSION=
+sync-with-dt: checkBin checkSyncDTTools
+	@ echo "sync dt $(PROJECT) charts and images to local registry"
+	set -x ; CHART_PATH=$(ROOT_DIR)/charts/$(PROJECT) ; \
+	echo "chart move $(PROJECT) $${VERSION}" ; \
+	mkdir -p _tmp && DIR=_tmp; \
+	VERSION_NORMAL=$${VERSION:1}; \
+	helm dt wrap $${CHART_PATH}/$(PROJECT) --output-file $${DIR}/$(PROJECT)-$${VERSION_NORMAL}.wrap.tgz --platforms linux/amd64 || { echo "error, failed to save charts and images to local" ; exit 1 ; } ; \
+	CONFIG="\
+source:\n\
+  repo:\n\
+    kind: LOCAL\n\
+    path: ${ROOT_DIR}/test/$${DIR}\n\
+target:\n\
+  repo:\n\
+    kind: OCI\n\
+    url: http://127.0.0.1:30080" ; \
+	echo -e "$${CONFIG}" > $${DIR}/config.yaml ; \
+	charts-syncer sync --config $${DIR}/config.yaml --use-plain-http || { echo "error, failed to sync charts and images to local registry" ; exit 1 ; } ; \
+	make checkImages -e KIND=OCI -e PROJECT=$${PROJECT} -e VERSION=$${VERSION} || { echo "error, failed to check $${PROJECT} images registry" ; exit 1 ; } ; \
+	rm -rf $${DIR} ;
+
 .PHONY: checkImages
+checkImages: KIND=
 checkImages: PROJECT=
 checkImages: VERSION=
 checkImages: checkBin
 	@ echo "check $(PROJECT) images registry"
-	set -x ; helm repo update chart-museum  --kubeconfig $(KIND_KUBECONFIG) || { echo "error, failed to update helm chart-museum repo " ; exit 1 ; } ; \
-	helm search repo chart-museum --devel -l --kubeconfig $(KIND_KUBECONFIG) ; \
-	helm template test chart-museum/$${PROJECT} --version $${VERSION} --kubeconfig $(KIND_KUBECONFIG) | grep " image: " ; \
-    IMAGE_LIST=` helm template test chart-museum/$${PROJECT} --version $${VERSION} | grep " image: " | tr -d "'" | tr -d '"' | tr -d '-' | grep -v " image: {{ "| awk '{print $$2}' | uniq ` ;\
+	set -x ; \
+	if [ "$(KIND)" = "OCI" ] ; then \
+		CHART=oci://127.0.0.1:30080/$${PROJECT} ; \
+	else \
+		helm repo update chart-museum --kubeconfig $(KIND_KUBECONFIG) || { echo "error, failed to update helm chart-museum repo " ; exit 1 ; } ; \
+		helm search repo chart-museum --devel -l --kubeconfig $(KIND_KUBECONFIG) ; \
+		CHART=chart-museum/$${PROJECT} ; \
+	fi ; \
+	helm template test $${CHART} --version $${VERSION} --kubeconfig $(KIND_KUBECONFIG) | grep " image: " ; \
+	IMAGE_LIST=` helm template test $${CHART} --version $${VERSION} | grep " image: " | tr -d "'" | tr -d '"' | tr -d '-' | grep -v " image: {{ " | awk '{print $$2}' | uniq ` ;\
 	if [ -z "$${IMAGE_LIST}" ] ; then \
 		echo "error, failed to find image from chart template for $(PROJECT)" ; exit 1 ; \
 	else \
@@ -183,10 +218,23 @@ deploy: checkBin
 
 .PHONY: checkBin
 checkBin:
+	which helm &>/dev/null || { echo "error, please install helm" ; exit 1 ; }
 	which kind &>/dev/null || { echo "error, please install kind" ; exit 1 ; }
 	which kubectl &>/dev/null || { echo "error, please install kubectl" ; exit 1 ; }
+
+.PHONY: checkSyncTools
+checkSyncTools:
 	which relok8s &>/dev/null || { make install-relok8s; }
+	which relok8s &>/dev/null || { echo "error, failed to install relok8s" ; exit 1 ; }
 	which charts-syncer &>/dev/null || { make install-charts-syncer; }
+	which charts-syncer &>/dev/null || { echo "error, failed to install charts-syncer" ; exit 1 ; }
+
+.PHONY: checkSyncDTTools
+checkSyncDTTools:
+	helm dt --help &>/dev/null || helm plugin install https://github.com/vmware-labs/distribution-tooling-for-helm
+	helm dt --help &>/dev/null || { echo "error, failed to install helm dt plugin (helm dt)" ; exit 1 ; }
+	which charts-syncer &>/dev/null || { make install-charts-syncer-dt; }
+	which charts-syncer &>/dev/null || { echo "error, failed to install charts-syncer" ; exit 1 ; }
 
 .PHONY: install-relok8s
 install-relok8s:
@@ -198,6 +246,12 @@ install-relok8s:
 install-charts-syncer:
 	VERSION=0.0.23 ; \
 	curl -OL https://github.com/DaoCloud/charts-syncer/releases/download/v$${VERSION}/charts-syncer_$${VERSION}_linux_x86_64.tar.gz ; \
+	tar -zvxf charts-syncer_$${VERSION}_linux_x86_64.tar.gz && mv charts-syncer /usr/local/bin/charts-syncer && rm -rf README.md charts-syncer*.tar.gz
+
+.PHONY: install-charts-syncer-dt
+install-charts-syncer-dt:
+	VERSION=2.2.1 ; \
+	curl -OL https://github.com/bitnami/charts-syncer/releases/download/v$${VERSION}/charts-syncer_$${VERSION}_linux_x86_64.tar.gz ; \
 	tar -zvxf charts-syncer_$${VERSION}_linux_x86_64.tar.gz && mv charts-syncer /usr/local/bin/charts-syncer && rm -rf README.md charts-syncer*.tar.gz
 
 .PHONY: clean

--- a/test/llm-d-modelservice/install.sh
+++ b/test/llm-d-modelservice/install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
+
+KIND_KUBECONFIG=$1
+VERSION=$3
+CHART_DIR=$( cd ${CURRENT_DIR_PATH}/../../charts/llm-d-modelservice/llm-d-modelservice ; pwd )
+
+[ -d "$CHART_DIR" ] || { echo "error, failed to find chart $CHART_DIR " ; exit 1 ; }
+[ -f "$KIND_KUBECONFIG" ] || { echo "error, failed to find kubeconfig $KIND_KUBECONFIG " ; exit 1 ; }
+
+echo "CHART_DIR: $CHART_DIR"
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+
+OCI_REGISTRY="oci://127.0.0.1:30080"
+HELM_MUST_OPTION=" --plain-http --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+#==================== notice, prometheus CRD has been deployed , so you no need to =============
+# !!!!!!!!! this chart is special, it does not contain any image, which make syncer-chart fail !!!!!!!!!
+
+set -x
+
+# deploy llm-d-modelservice
+# shellcheck disable=SC2086
+helm install llm-d-modelservice ${OCI_REGISTRY}/llm-d-modelservice --version ${VERSION}  ${HELM_MUST_OPTION} --namespace kube-system
+
+if (($?==0)) ; then
+ echo "succeeded to deploy $CHART_DIR"
+ exit 0
+else
+ echo "error, failed to deploy $CHART_DIR"
+ exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #