### PR TITLE
inferencepool supports charts-syncer v2

### DIFF
--- a/charts/inferencepool/inferencepool/.relok8s-images.yaml
+++ b/charts/inferencepool/inferencepool/.relok8s-images.yaml
@@ -1,1 +1,1 @@
-- "{{ .inferencepool.inferenceExtension.image.hub }}/{{ .inferencepool.inferenceExtension.image.name }}:{{ .inferencepool.inferenceExtension.image.tag }}"
+- "{{ .inferencepool.inferenceExtension.image.registry }}/{{ .inferencepool.inferenceExtension.image.repository }}:{{ .inferencepool.inferenceExtension.image.tag }}"

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-deployment.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/epp-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- end }}
         {{- end }}
       - name: epp
-        image: {{ .Values.inferenceExtension.image.hub }}/{{ .Values.inferenceExtension.image.name }}:{{ .Values.inferenceExtension.image.tag }}
+        image: {{ .Values.inferenceExtension.image.registry }}/{{ .Values.inferenceExtension.image.repository }}:{{ .Values.inferenceExtension.image.tag }}
         imagePullPolicy: {{ .Values.inferenceExtension.image.pullPolicy | default "IfNotPresent" }}
         args:
         - --pool-name

--- a/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
@@ -1,10 +1,10 @@
 inferenceExtension:
   replicas: 1
   image:
-    name: epp
-    hub: registry.k8s.io/gateway-api-inference-extension
     tag: v1.3.0
     pullPolicy: Always
+    registry: registry.k8s.io/gateway-api-inference-extension
+    repository: epp
   extProcPort: 9002
   env: []
   pluginsConfigFile: "default-plugins.yaml"

--- a/charts/inferencepool/inferencepool/values.yaml
+++ b/charts/inferencepool/inferencepool/values.yaml
@@ -3,10 +3,10 @@ inferencepool:
   inferenceExtension:
     replicas: 1
     image:
-      name: gateway-api-inference-extension/epp
-      hub: k8s.m.daocloud.io
       tag: v1.3.0
       pullPolicy: Always
+      registry: k8s.m.daocloud.io
+      repository: gateway-api-inference-extension/epp
     extProcPort: 9002
     env: []
     pluginsConfigFile: "default-plugins.yaml"
@@ -163,9 +163,9 @@ inferencepool:
     targetPortNumber: 8000
     modelServers:
       matchLabels:
-        app: vllm-llama3-8b-instruct
+        app: inferx
   # Options: ["gke", "istio", "none"]
-  provider: # REQUIRED
+  provider:
     name: none
     # GKE-specific configuration.
     # This block is only used if name is "gke".

--- a/charts/inferencepool/parent/.relok8s-images.yaml
+++ b/charts/inferencepool/parent/.relok8s-images.yaml
@@ -1,1 +1,1 @@
-- "{{ .inferencepool.inferenceExtension.image.hub }}/{{ .inferencepool.inferenceExtension.image.name }}:{{ .inferencepool.inferenceExtension.image.tag }}"
+- "{{ .inferencepool.inferenceExtension.image.registry }}/{{ .inferencepool.inferenceExtension.image.repository }}:{{ .inferencepool.inferenceExtension.image.tag }}"

--- a/scripts/generateChart.sh
+++ b/scripts/generateChart.sh
@@ -59,8 +59,13 @@ fi
 if [ "$USE_OPENSOURCE_CHART" == true ] ; then
     echo "generate $PROJECT_NAME chart from opensource chart"
     rm -rf $CHART_DEST_DIR
-    helm repo add $REPO_NAME $REPO_URL
-    helm repo update $REPO_NAME
+    if [[ "$REPO_URL" == oci://* ]]; then
+        REPO_NAME=${REPO_URL}
+        echo "REPO_URL is OCI-based, skipping helm repo operations"
+    else
+        helm repo add $REPO_NAME $REPO_URL
+        helm repo update $REPO_NAME
+    fi
     cd ${PROJECT_SRC_DIR}
     helm pull ${REPO_NAME}/${CHART_NAME} --untar --version $VERSION
     echo "succeeded to generate chart to $CHART_DEST_DIR"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #