### PR TITLE
fix-inferencepool-httproute

### DIFF
--- a/charts/inferencepool/custom.sh
+++ b/charts/inferencepool/custom.sh
@@ -59,6 +59,10 @@ sed "${SED_INPLACE[@]}" \
   's/\.Values\.inferenceExtension\.image\.name/\.Values\.inferenceExtension\.image\.repository/g' \
  charts/inferencepool/templates/epp-deployment.yaml
 
+sed "${SED_INPLACE[@]}" \
+  's|inference\.networking\.k8s\.io|{{ default "inference.networking.k8s.io" .Values.inferencePool.apiVersion }}|g' \
+ charts/inferencepool/templates/httproute.yaml
+
 yq eval -i '
   (.inferenceExtension.image.registry = .inferenceExtension.image.hub) |
   del(.inferenceExtension.image.hub) |
@@ -78,6 +82,9 @@ IMAGE_NAME=$(yq eval '.inferencepool.inferenceExtension.image.repository | sub("
 
 yq eval '.inferencepool.inferenceExtension.image.registry = "k8s.m.daocloud.io"' -i values.yaml
 yq eval ".inferencepool.inferenceExtension.image.repository = \"${REPOSITORY}/${IMAGE_NAME}\"" -i values.yaml
+
+yq eval '.inferenceExtension.image.registry = "k8s.m.daocloud.io"' -i ./charts/inferencepool/values.yaml
+yq eval ".inferenceExtension.image.repository = \"${REPOSITORY}/${IMAGE_NAME}\"" -i ./charts/inferencepool/values.yaml
 
 echo "keywords:" >> Chart.yaml
 echo "- networking" >> Chart.yaml

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
@@ -11,7 +11,7 @@ spec:
     name: {{ .Values.experimentalHttpRoute.inferenceGatewayName }}
   rules:
   - backendRefs:
-    - group: inference.networking.k8s.io
+    - group: {{ default "inference.networking.k8s.io" .Values.inferencePool.apiVersion }}
       kind: InferencePool
       name: {{ .Release.Name }}
     matches:

--- a/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/values.yaml
@@ -3,8 +3,8 @@ inferenceExtension:
   image:
     tag: v1.3.0
     pullPolicy: Always
-    registry: registry.k8s.io/gateway-api-inference-extension
-    repository: epp
+    registry: k8s.m.daocloud.io
+    repository: gateway-api-inference-extension/epp
   extProcPort: 9002
   env: []
   pluginsConfigFile: "default-plugins.yaml"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #