### PR TITLE
fix-inferencepool-httproute

### DIFF
--- a/charts/inferencepool/custom.sh
+++ b/charts/inferencepool/custom.sh
@@ -60,7 +60,7 @@ sed "${SED_INPLACE[@]}" \
  charts/inferencepool/templates/epp-deployment.yaml
 
 sed "${SED_INPLACE[@]}" \
-  's|inference\.networking\.k8s\.io|{{ default "inference.networking.k8s.io" .Values.inferencePool.apiVersion }}|g' \
+  's|inference\.networking\.k8s\.io|{{ default "inference.networking.k8s.io" (split "/" .Values.inferencePool.apiVersion)._0 }}|g' \
  charts/inferencepool/templates/httproute.yaml
 
 yq eval -i '

--- a/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
+++ b/charts/inferencepool/inferencepool/charts/inferencepool/templates/httproute.yaml
@@ -11,7 +11,7 @@ spec:
     name: {{ .Values.experimentalHttpRoute.inferenceGatewayName }}
   rules:
   - backendRefs:
-    - group: {{ default "inference.networking.k8s.io" .Values.inferencePool.apiVersion }}
+    - group: {{ default "inference.networking.k8s.io" (split "/" .Values.inferencePool.apiVersion)._0 }}
       kind: InferencePool
       name: {{ .Release.Name }}
     matches:


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #