### PR TITLE
skip-check-image-hint-file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,9 @@ jobs:
         run: |
           BASE=$PWD
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do
-              source ${BASE}/charts/${PROJECT}/config && [ "${NO_IMAGE}" == "true" ] && continue
+              source ${BASE}/charts/${PROJECT}/config
+              [ "${NO_IMAGE}" == "true" ] && continue
+              [ "${USE_CHARTS_SYNCER_DT}" == "true" ] && continue
               CHART_PATH=${BASE}/charts/${PROJECT}/${PROJECT}
               [ -f "${CHART_PATH}/${{ env.IMAGE_HINT_FILE_NAME }}" ] \
                   || { echo "error, miss ${{ env.IMAGE_HINT_FILE_NAME }} file in chart ${PROJECT} " ; exit 1 ; }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@
 
 * SKIP_SCHEMA: （可选）true 表示让 CI 跳过 values.schema.json 文件的检测且工程代码也不会自动生成它
 
+* USE_CHARTS_SYNCER_DT:（可选）true 表示在 E2E 测试中使用 charts-syncer dt 的方式同步 charts 和 images 到本地镜像仓库：
+    * Chart 以 OCI 格式推送到镜像仓库（而非 ChartMuseum）
+    * 使用 `helm dt wrap` 打包 chart（而非 `relok8s chart move`）
+
 ### 方案: 自己写做包脚本
 
 准备好 /charts/${PROJECT}/config ：


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

charts‑syncer should support using distribution‑tooling‑for‑helm as the underlying tool instead of relok8s. Support for this will be added in a future PR. For now, update the CI/CD pipeline accordingly — otherwise upcoming PRs will fail due to the absence of a .relok8s‑images.yaml file.

https://github.com/vmware-labs/distribution-tooling-for-helm
https://github.com/bitnami/charts-syncer


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #