### PR TITLE
Robot Upgrade: spiderpool chart upgrade from 1.1.0 to 1.1.2

### DIFF
--- a/charts/spiderpool/config
+++ b/charts/spiderpool/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/spiderpool
 export REPO_NAME=spiderpool
 export CHART_NAME=spiderpool
-export VERSION=1.1.0
+export VERSION=1.1.2
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/spiderpool/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.1.0
+appVersion: 1.1.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,8 +16,8 @@ name: spiderpool
 sources:
   - https://github.com/spidernet-io/spiderpool
 type: application
-version: 1.1.0
+version: 1.1.2
 dependencies:
   - name: spiderpool
-    version: "1.1.0"
+    version: "1.1.2"
     repository: "https://spidernet-io.github.io/spiderpool"

--- a/charts/spiderpool/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/README.md
@@ -179,7 +179,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `rdma.rdmaSharedDevicePlugin.image.repository`                    | the image repository of rdma shared device plugin       | `mellanox/k8s-rdma-shared-dev-plugin`  |
 | `rdma.rdmaSharedDevicePlugin.image.pullPolicy`                    | the image pullPolicy of rdma shared device plugin       | `IfNotPresent`                         |
 | `rdma.rdmaSharedDevicePlugin.image.digest`                        | the image digest of rdma shared device plugin           | `""`                                   |
-| `rdma.rdmaSharedDevicePlugin.image.tag`                           | the image tag of rdma shared device plugin              | `v1.5.1`                               |
+| `rdma.rdmaSharedDevicePlugin.image.tag`                           | the image tag of rdma shared device plugin              | `v1.5.3`                               |
 | `rdma.rdmaSharedDevicePlugin.image.imagePullSecrets`              | the image imagePullSecrets of rdma shared device plugin | `[]`                                   |
 | `rdma.rdmaSharedDevicePlugin.podAnnotations`                      | the additional annotations                              | `{}`                                   |
 | `rdma.rdmaSharedDevicePlugin.podLabels`                           | the additional label                                    | `{}`                                   |

--- a/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.1.0
+appVersion: 1.1.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,4 +16,4 @@ name: spiderpool
 sources:
 - https://github.com/spidernet-io/spiderpool
 type: application
-version: 1.1.0
+version: 1.1.2

--- a/charts/spiderpool/spiderpool/charts/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/README.md
@@ -179,7 +179,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `rdma.rdmaSharedDevicePlugin.image.repository`                    | the image repository of rdma shared device plugin       | `mellanox/k8s-rdma-shared-dev-plugin`  |
 | `rdma.rdmaSharedDevicePlugin.image.pullPolicy`                    | the image pullPolicy of rdma shared device plugin       | `IfNotPresent`                         |
 | `rdma.rdmaSharedDevicePlugin.image.digest`                        | the image digest of rdma shared device plugin           | `""`                                   |
-| `rdma.rdmaSharedDevicePlugin.image.tag`                           | the image tag of rdma shared device plugin              | `v1.5.1`                               |
+| `rdma.rdmaSharedDevicePlugin.image.tag`                           | the image tag of rdma shared device plugin              | `v1.5.3`                               |
 | `rdma.rdmaSharedDevicePlugin.image.imagePullSecrets`              | the image imagePullSecrets of rdma shared device plugin | `[]`                                   |
 | `rdma.rdmaSharedDevicePlugin.podAnnotations`                      | the additional annotations                              | `{}`                                   |
 | `rdma.rdmaSharedDevicePlugin.podLabels`                           | the additional label                                    | `{}`                                   |

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
@@ -233,8 +233,11 @@ spec:
         {{- end }}
         {{- end }}
           volumeMounts:
-            - name: host-ns
-              mountPath: /var/run
+            - name: host-netns
+              mountPath: /var/run/netns
+              mountPropagation: Bidirectional
+            - name: host-docker-netns
+              mountPath: /var/run/docker/netns
               mountPropagation: Bidirectional
             - name: config-path
               mountPath: /tmp/spiderpool/config-map
@@ -312,10 +315,15 @@ spec:
           hostPath:
             path: {{ dir .Values.global.ipamUNIXSocketHostPath }}
             type: DirectoryOrCreate
-          # multus
-        - name: host-ns
+          # netns paths for RDMA metrics and CNI
+        - name: host-netns
           hostPath:
-            path: /var/run
+            path: /var/run/netns
+            type: DirectoryOrCreate
+        - name: host-docker-netns
+          hostPath:
+            path: /var/run/docker/netns
+            type: DirectoryOrCreate
         {{- if .Values.multus.multusCNI.install }}
         - name: cni
           hostPath:

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/deployment.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       {{- if .Values.spiderpoolController.affinity }}
       affinity:
-      {{- include "tplvalues.render" (dict "value" .Values.spiderpoolController.affinity "context" $) | nindent 6 }}
+      {{- include "tplvalues.render" (dict "value" .Values.spiderpoolController.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAntiAffinity:

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/rdma-shared-dp/rdma-shared-dp.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/rdma-shared-dp/rdma-shared-dp.yaml
@@ -18,11 +18,11 @@ data:
         "periodicUpdateInterval": {{ .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.periodicUpdateInterval }},
         {{- if .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.configList }}
         {{- with .Values.rdma.rdmaSharedDevicePlugin.deviceConfig.configList }}
-        configList:
+        "configList":
         {{- toPrettyJson . | trim | nindent 10 }}
         {{- end }}
         {{- else }}
-        configList: []
+        "configList": []
         {{- end }}
     }
 ---

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/role.yaml
@@ -163,6 +163,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/driver
+  verbs:
+  - "associated-node:patch"
+  - "associated-node:update"
+- apiGroups:
   - spiderpool.spidernet.io
   resources:
   - spiderclaimparameters

--- a/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
@@ -163,7 +163,7 @@ rdma:
       digest: ""
 
       ## @param rdma.rdmaSharedDevicePlugin.image.tag the image tag of rdma shared device plugin
-      tag: v1.5.1
+      tag: v1.5.3
 
       ## @param rdma.rdmaSharedDevicePlugin.image.imagePullSecrets the image imagePullSecrets of rdma shared device plugin
       imagePullSecrets: []
@@ -380,7 +380,7 @@ spiderpoolAgent:
     digest: ""
 
     ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-    tag: v1.1.0
+    tag: v1.1.2
 
     ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
     imagePullSecrets: []
@@ -570,7 +570,7 @@ spiderpoolController:
     digest: ""
 
     ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-    tag: v1.1.0
+    tag: v1.1.2
 
     ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
     imagePullSecrets: []
@@ -819,7 +819,7 @@ spiderpoolInit:
     digest: ""
 
     ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-    tag: v1.1.0
+    tag: v1.1.2
 
     ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
     imagePullSecrets: []

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -122,7 +122,7 @@ spiderpool:
         ## @param rdma.rdmaSharedDevicePlugin.image.digest the image digest of rdma shared device plugin
         digest: ""
         ## @param rdma.rdmaSharedDevicePlugin.image.tag the image tag of rdma shared device plugin
-        tag: v1.5.1
+        tag: v1.5.3
         ## @param rdma.rdmaSharedDevicePlugin.image.imagePullSecrets the image imagePullSecrets of rdma shared device plugin
         imagePullSecrets: []
         # - name: "image-pull-secret"
@@ -287,7 +287,7 @@ spiderpool:
       ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
       digest: ""
       ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-      tag: v1.1.0
+      tag: v1.1.2
       ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -430,7 +430,7 @@ spiderpool:
       ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
       digest: ""
       ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-      tag: v1.1.0
+      tag: v1.1.2
       ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -646,7 +646,7 @@ spiderpool:
       ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
       digest: ""
       ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-      tag: v1.1.0
+      tag: v1.1.2
       ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
       imagePullSecrets: []
       # - name: "image-pull-secret"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #