### PR TITLE
fix: set higress global.local to false

### DIFF
--- a/charts/higress/custom.sh
+++ b/charts/higress/custom.sh
@@ -86,7 +86,7 @@ yq -i '
   .higress.higress-core.pilot.image = "higress/pilot" |
   .higress.higress-core.pluginServer.image = "higress/plugin-server" |
   .higress.higress-core.global.ingressClass="" |
-  .higress.higress-core.global.local=true |
+  .higress.higress-core.global.local=false |
   .higress.higress-core.global.enableGatewayAPI=false |
   .higress.higress-core.global.multiCluster.enabled=false |
   .higress.higress-core.gateway.tag=strenv(CHART_VERSION) |

--- a/charts/higress/higress/values.yaml
+++ b/charts/higress/higress/values.yaml
@@ -43,7 +43,7 @@ higress:
       # for internal usage only, not to be configured by users.
       autoscalingv2API: true
       # -- When deploying to a local cluster (e.g.: kind cluster), set this to true.
-      local: true
+      local: false
       kind: false # Deprecated. Please use "global.local" instead. Will be removed later.
       # -- If true, Higress Controller will monitor istio resources as well
       enableIstioAPI: true


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/DaoCloud/dce-charts-repackage/issues/4313