### PR TITLE
robot: project spiderpool chart upgrades from 1.2.0 to 1.2.2

### DIFF
--- a/charts/spiderpool/config
+++ b/charts/spiderpool/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://spidernet-io.github.io/spiderpool
 export REPO_NAME=spiderpool
 export CHART_NAME=spiderpool
-export VERSION=1.2.0
+export VERSION=1.2.2
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/spiderpool/custom.sh
+++ b/charts/spiderpool/custom.sh
@@ -64,6 +64,9 @@ yq -i '
     .spiderpool.clusterDefaultPool.ipv6IPRanges = ["fd00::10-fd00::100"] + .spiderpool.clusterDefaultPool.ipv6IPRanges |
     .spiderpool.spiderpoolAgent.prometheus.serviceMonitor.labels."operator.insight.io/managed-by"="insight" |
     .spiderpool.spiderpoolAgent.image.registry="ghcr.m.daocloud.io" |
+    .spiderpool.spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector.matchLabels."kubernetes.io/os"="linux" |
+    .spiderpool.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules=[{"resourceName":"spidernet.io/sub-eni","defaultMaxCount":256,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}}}] |
+    .spiderpool.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules=[{"defaultMaxCount":10000,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}},"includeInterfaces":["eth*"],"excludeInterfaces":[]}] |
     .spiderpool.spiderpoolAgent.resources.requests.cpu=strenv(CUSTOM_SPIDERPOOL_AGENT_CPU) |
     .spiderpool.spiderpoolAgent.resources.requests.memory=strenv(CUSTOM_SPIDERPOOL_AGENT_MEMORY) |
     .spiderpool.spiderpoolController.image.registry="ghcr.m.daocloud.io" |
@@ -80,6 +83,37 @@ yq -i '
     .spiderpool.sriov.image.resourcesInjector.tag="v1.5" |
     .spiderpool.spiderpoolController.podResourceInject.enabled=true
 ' ${CHART_DIRECTORY}/values.yaml
+
+yq -i '
+    .spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector={"matchLabels":{"kubernetes.io/os":"linux"}} |
+    .spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules=[{"resourceName":"spidernet.io/sub-eni","defaultMaxCount":256,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}}}] |
+    .spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules=[{"defaultMaxCount":10000,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}},"includeInterfaces":["eth*"],"excludeInterfaces":[]}]
+' ${CHART_DIRECTORY}/charts/spiderpool/values.yaml
+
+for VALUES_FILE in ${CHART_DIRECTORY}/values.yaml ${CHART_DIRECTORY}/charts/spiderpool/values.yaml; do
+    ${SED_COMMAND} -i 's/node label selector for nodes that advertise Spiderpool network resources\. Empty selector matches all nodes\./node label selector for nodes that advertise Spiderpool network resources./' ${VALUES_FILE}
+    ${SED_COMMAND} -i 's/auxiliary ENI slot advertisement rules\. Empty rules disable sub-ENI advertisement\./auxiliary ENI slot advertisement rules./' ${VALUES_FILE}
+    ${SED_COMMAND} -i 's/node\/interface selection rules for advertised master NIC resources\. Empty rules disable master NIC advertisement\./node\/interface selection rules for advertised master NIC resources./' ${VALUES_FILE}
+done
+
+for README_FILE in ${CHART_DIRECTORY}/README.md ${CHART_DIRECTORY}/charts/spiderpool/README.md; do
+    awk '
+        index($0, "`spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector`") {
+            print "| `spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector`            | node label selector for nodes that advertise Spiderpool network resources.                                                                                                       | `{\"matchLabels\":{\"kubernetes.io/os\":\"linux\"}}` |"
+            next
+        }
+        index($0, "`spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules`") {
+            print "| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules`           | auxiliary ENI slot advertisement rules.                                                                                                                                         | `[{\"resourceName\":\"spidernet.io/sub-eni\",\"defaultMaxCount\":256,\"nodeSelector\":{\"matchLabels\":{\"kubernetes.io/os\":\"linux\"}}}]` |"
+            next
+        }
+        index($0, "`spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules`") {
+            print "| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules`        | node/interface selection rules for advertised master NIC resources.                                                                                                             | `[{\"defaultMaxCount\":10000,\"nodeSelector\":{\"matchLabels\":{\"kubernetes.io/os\":\"linux\"}},\"includeInterfaces\":[\"eth*\"],\"excludeInterfaces\":[]}]` |"
+            next
+        }
+        { print }
+    ' ${README_FILE} >${README_FILE}.tmp
+    mv ${README_FILE}.tmp ${README_FILE}
+done
 
 # spiderpool.sriov.image.resourcesInjector.tag="v1.5" is used as a fallback
 # because resourcesInjector v1.6.0 does not include an ARM64 image

--- a/charts/spiderpool/parent/values.schema.json
+++ b/charts/spiderpool/parent/values.schema.json
@@ -75,6 +75,61 @@
                                     "default": false
                                 }
                             }
+                        },
+                        "networkResourcePlugin": {
+                            "title": "Spiderpool Agent Network Resource Plugin Setting",
+                            "description": "Configure spiderpool-agent network resource advertisement through the kubelet device plugin API.",
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "title": "Enable",
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "resourceAdvertisement": {
+                                    "type": "object",
+                                    "properties": {
+                                        "subENI": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rules": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "resourceName": {
+                                                                "type": "string",
+                                                                "default": "spidernet.io/sub-eni"
+                                                            },
+                                                            "defaultMaxCount": {
+                                                                "type": "integer",
+                                                                "default": 256
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "masterNIC": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rules": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "defaultMaxCount": {
+                                                                "type": "integer",
+                                                                "default": 10000
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -442,6 +497,18 @@
                                     "fd00::10-fd00::200"
                                 ]
                             ]
+                        }
+                    }
+                },
+                "iaasNetworkProvider": {
+                    "title": "IaaS Network Provider Integration",
+                    "type": "object",
+                    "properties": {
+                        "serverUrl": {
+                            "title": "IaaS Provider Server URL",
+                            "description": "The URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled. For example: https://iaas-network-provider.iaas-network-provider-system.svc:443",
+                            "type": "string",
+                            "default": ""
                         }
                     }
                 }

--- a/charts/spiderpool/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.2.0
+appVersion: 1.2.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,8 +16,8 @@ name: spiderpool
 sources:
   - https://github.com/spidernet-io/spiderpool
 type: application
-version: 1.2.0
+version: 1.2.2
 dependencies:
   - name: spiderpool
-    version: "1.2.0"
+    version: "1.2.2"
     repository: "https://spidernet-io.github.io/spiderpool"

--- a/charts/spiderpool/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/README.md
@@ -169,7 +169,9 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `coordinator.detectIPConflict` | detect IP address conflicts                                                                                                              | `false`              |
 | `coordinator.tunePodRoutes`    | tune Pod routes                                                                                                                          | `true`               |
 | `coordinator.hijackCIDR`       | Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS | `["169.254.0.0/16"]` |
+| `coordinator.policyRoutes`     | Additional routes installed into the coordinator interface policy routing table, for example: [{"dst":"10.10.0.0/16","gw":"172.18.0.1"}] | `[]`                 |
 | `coordinator.vethLinkAddress`  | configure an link-local address for veth0 device. empty means disable. default is empty. Format is like 169.254.100.1                    | `""`                 |
+| `coordinator.vethMTU`          | configure the MTU of veth0 device                                                                                                        | `1500`               |
 
 ### rdma parameters
 
@@ -229,7 +231,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `plugins.image.repository`       | the image repository of plugins                            | `spidernet-io/spiderpool/spiderpool-plugins` |
 | `plugins.image.pullPolicy`       | the image pullPolicy of plugins                            | `IfNotPresent`                               |
 | `plugins.image.digest`           | the image digest of plugins                                | `""`                                         |
-| `plugins.image.tag`              | the image tag of plugins                                   | `bbd68a1183524257baae9c7456bbdcbfdbd9cb1e`   |
+| `plugins.image.tag`              | the image tag of plugins                                   | `87fd4a400858705c208d5a4b7059423b33a551aa`   |
 | `plugins.image.imagePullSecrets` | the image imagePullSecrets of plugins                      | `[]`                                         |
 
 ### clusterDefaultPool parameters
@@ -278,6 +280,11 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `spiderpoolAgent.resources.requests.cpu`                                             | the cpu requests of spiderpoolAgent pod                                                                                                                                          | `100m`                                     |
 | `spiderpoolAgent.resources.requests.memory`                                          | the memory requests of spiderpoolAgent pod                                                                                                                                       | `128Mi`                                    |
 | `spiderpoolAgent.tuneSysctlConfig`                                                   | enable to set required sysctl on each node to run spiderpool. refer to [Spiderpool-agent](https://spidernet-io.github.io/spiderpool/dev/reference/spiderpool-agent/) for details | `true`                                     |
+| `spiderpoolAgent.networkResourcePlugin.enabled`                                      | enable spiderpool-agent network resource advertisement through the kubelet device plugin API.                                                                                    | `false`                                    |
+| `spiderpoolAgent.networkResourcePlugin.kubeletRootDir`                               | kubelet root directory used to derive device-plugin and plugin-registration host paths.                                                                                          | `/var/lib/kubelet`                         |
+| `spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector`            | node label selector for nodes that advertise Spiderpool network resources.                                                                                                       | `{"matchLabels":{"kubernetes.io/os":"linux"}}` |
+| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules`           | auxiliary ENI slot advertisement rules.                                                                                                                                         | `[{"resourceName":"spidernet.io/sub-eni","defaultMaxCount":256,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}}}]` |
+| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules`        | node/interface selection rules for advertised master NIC resources.                                                                                                             | `[{"defaultMaxCount":10000,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}},"includeInterfaces":["eth*"],"excludeInterfaces":[]}]` |
 | `spiderpoolAgent.securityContext`                                                    | the security Context of spiderpoolAgent pod                                                                                                                                      | `{}`                                       |
 | `spiderpoolAgent.httpPort`                                                           | the http Port for spiderpoolAgent, for health checking                                                                                                                           | `5710`                                     |
 | `spiderpoolAgent.healthChecking.startupProbe.failureThreshold`                       | the failure threshold of startup probe for spiderpoolAgent health checking                                                                                                       | `60`                                       |
@@ -463,6 +470,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### IaaS Network Provider Integration
 
-| Name                            | Description                                                                                                                 | Value |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `iaasNetworkProvider.serverUrl` | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled. | `""`  |
+| Name                                     | Description                                                                                                                                                                                                                       | Value |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `iaasNetworkProvider.serverUrl`          | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.                                                                                                       | `""`  |
+| `iaasNetworkProvider.httpRequestTimeout` | the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin. | `50s` |

--- a/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.2.0
+appVersion: 1.2.2
 description: underlay CNI solution for kubernetes
 home: https://spidernet-io.github.io/spiderpool
 icon: https://raw.githubusercontent.com/spidernet-io/spiderpool/main/docs/images/spider.svg
@@ -16,4 +16,4 @@ name: spiderpool
 sources:
 - https://github.com/spidernet-io/spiderpool
 type: application
-version: 1.2.0
+version: 1.2.2

--- a/charts/spiderpool/spiderpool/charts/spiderpool/README.md
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/README.md
@@ -169,7 +169,9 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `coordinator.detectIPConflict` | detect IP address conflicts                                                                                                              | `false`              |
 | `coordinator.tunePodRoutes`    | tune Pod routes                                                                                                                          | `true`               |
 | `coordinator.hijackCIDR`       | Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS | `["169.254.0.0/16"]` |
+| `coordinator.policyRoutes`     | Additional routes installed into the coordinator interface policy routing table, for example: [{"dst":"10.10.0.0/16","gw":"172.18.0.1"}] | `[]`                 |
 | `coordinator.vethLinkAddress`  | configure an link-local address for veth0 device. empty means disable. default is empty. Format is like 169.254.100.1                    | `""`                 |
+| `coordinator.vethMTU`          | configure the MTU of veth0 device                                                                                                        | `1500`               |
 
 ### rdma parameters
 
@@ -229,7 +231,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `plugins.image.repository`       | the image repository of plugins                            | `spidernet-io/spiderpool/spiderpool-plugins` |
 | `plugins.image.pullPolicy`       | the image pullPolicy of plugins                            | `IfNotPresent`                               |
 | `plugins.image.digest`           | the image digest of plugins                                | `""`                                         |
-| `plugins.image.tag`              | the image tag of plugins                                   | `bbd68a1183524257baae9c7456bbdcbfdbd9cb1e`   |
+| `plugins.image.tag`              | the image tag of plugins                                   | `87fd4a400858705c208d5a4b7059423b33a551aa`   |
 | `plugins.image.imagePullSecrets` | the image imagePullSecrets of plugins                      | `[]`                                         |
 
 ### clusterDefaultPool parameters
@@ -278,6 +280,11 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `spiderpoolAgent.resources.requests.cpu`                                             | the cpu requests of spiderpoolAgent pod                                                                                                                                          | `100m`                                     |
 | `spiderpoolAgent.resources.requests.memory`                                          | the memory requests of spiderpoolAgent pod                                                                                                                                       | `128Mi`                                    |
 | `spiderpoolAgent.tuneSysctlConfig`                                                   | enable to set required sysctl on each node to run spiderpool. refer to [Spiderpool-agent](https://spidernet-io.github.io/spiderpool/dev/reference/spiderpool-agent/) for details | `true`                                     |
+| `spiderpoolAgent.networkResourcePlugin.enabled`                                      | enable spiderpool-agent network resource advertisement through the kubelet device plugin API.                                                                                    | `false`                                    |
+| `spiderpoolAgent.networkResourcePlugin.kubeletRootDir`                               | kubelet root directory used to derive device-plugin and plugin-registration host paths.                                                                                          | `/var/lib/kubelet`                         |
+| `spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector`            | node label selector for nodes that advertise Spiderpool network resources.                                                                                                       | `{"matchLabels":{"kubernetes.io/os":"linux"}}` |
+| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules`           | auxiliary ENI slot advertisement rules.                                                                                                                                         | `[{"resourceName":"spidernet.io/sub-eni","defaultMaxCount":256,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}}}]` |
+| `spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules`        | node/interface selection rules for advertised master NIC resources.                                                                                                             | `[{"defaultMaxCount":10000,"nodeSelector":{"matchLabels":{"kubernetes.io/os":"linux"}},"includeInterfaces":["eth*"],"excludeInterfaces":[]}]` |
 | `spiderpoolAgent.securityContext`                                                    | the security Context of spiderpoolAgent pod                                                                                                                                      | `{}`                                       |
 | `spiderpoolAgent.httpPort`                                                           | the http Port for spiderpoolAgent, for health checking                                                                                                                           | `5710`                                     |
 | `spiderpoolAgent.healthChecking.startupProbe.failureThreshold`                       | the failure threshold of startup probe for spiderpoolAgent health checking                                                                                                       | `60`                                       |
@@ -463,6 +470,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### IaaS Network Provider Integration
 
-| Name                            | Description                                                                                                                 | Value |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `iaasNetworkProvider.serverUrl` | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled. | `""`  |
+| Name                                     | Description                                                                                                                                                                                                                       | Value |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `iaasNetworkProvider.serverUrl`          | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.                                                                                                       | `""`  |
+| `iaasNetworkProvider.httpRequestTimeout` | the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin. | `50s` |

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
@@ -92,6 +92,21 @@ spec:
                   number>/0/1/2. negative number means leave it as it is. the default
                   value is 0.'
                 type: integer
+              policyRoutes:
+                description: PolicyRoutes configures static routes that coordinator
+                  installs into the policy routing table of the interface where coordinator
+                  is running.
+                items:
+                  properties:
+                    dst:
+                      type: string
+                    gw:
+                      type: string
+                  required:
+                  - dst
+                  - gw
+                  type: object
+                type: array
               tunePodRoutes:
                 default: true
                 description: TunePodRoutes specifies whether to tune pod routes of
@@ -108,6 +123,10 @@ spec:
                   veth0 device. empty means disable. default is empty. Format is like
                   169.254.100.1
                 type: string
+              vethMTU:
+                description: VethMTU configures the MTU of veth0 device.
+                minimum: 1
+                type: integer
             type: object
           status:
             description: CoordinationStatus defines the observed state of SpiderCoordinator.

--- a/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -113,6 +113,21 @@ spec:
                       number>/0/1/2. negative number means leave it as it is. the
                       default value is 0.'
                     type: integer
+                  policyRoutes:
+                    description: PolicyRoutes configures static routes that coordinator
+                      installs into the policy routing table of the interface where
+                      coordinator is running.
+                    items:
+                      properties:
+                        dst:
+                          type: string
+                        gw:
+                          type: string
+                      required:
+                      - dst
+                      - gw
+                      type: object
+                    type: array
                   tunePodRoutes:
                     default: true
                     description: TunePodRoutes specifies whether to tune pod routes
@@ -129,6 +144,10 @@ spec:
                       for veth0 device. empty means disable. default is empty. Format
                       is like 169.254.100.1
                     type: string
+                  vethMTU:
+                    description: VethMTU configures the MTU of veth0 device.
+                    minimum: 1
+                    type: integer
                 type: object
               customCNI:
                 description: OtherCniTypeConfig only used for CniType custom, valid
@@ -542,11 +561,20 @@ spec:
                     type: string
                   vlanID:
                     description: 'The VLAN ID for the CNI configuration and must be
-                      within the specified range: [0,4094].'
+                      within the specified range: [0,4094]. Required when vlanMode
+                      is manual and forbidden when vlanMode is auto.'
                     format: int32
                     maximum: 4094
                     minimum: 0
                     type: integer
+                  vlanMode:
+                    default: manual
+                    description: VlanMode controls how the vlan CNI obtains vlanID.
+                      manual requires vlanID, auto forbids vlanID.
+                    enum:
+                    - manual
+                    - auto
+                    type: string
                 required:
                 - master
                 type: object

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/configmap.yaml
@@ -36,8 +36,54 @@ data:
       enabled: {{ .Values.spiderpoolController.podResourceInject.enabled }}
       namespacesExclude: {{ toJson .Values.spiderpoolController.podResourceInject.namespacesExclude }}
       namespacesInclude: {{ toJson .Values.spiderpoolController.podResourceInject.namespacesInclude }}
+    agent:
+      networkResourcePlugin:
+        enabled: {{ .Values.spiderpoolAgent.networkResourcePlugin.enabled }}
+        kubeletRootDir: {{ .Values.spiderpoolAgent.networkResourcePlugin.kubeletRootDir | quote }}
+        devicePluginAffinity:
+{{- if .Values.spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector | indent 12 }}
+{{- else }}
+          nodeSelector: {}
+{{- end }}
+        resourceAdvertisement:
+          subENI:
+{{- if .Values.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules }}
+            rules:
+{{- range .Values.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules }}
+              - resourceName: {{ default "spidernet.io/sub-eni" .resourceName }}
+                defaultMaxCount: {{ default 0 .defaultMaxCount }}
+{{- if .nodeSelector }}
+                nodeSelector:
+{{ toYaml .nodeSelector | indent 18 }}
+{{- else }}
+                nodeSelector: {}
+{{- end }}
+{{- end }}
+{{- else }}
+            rules: []
+{{- end }}
+          masterNIC:
+{{- if .Values.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules }}
+            rules:
+{{- range .Values.spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules }}
+              - defaultMaxCount: {{ default 10000 .defaultMaxCount }}
+{{- if .nodeSelector }}
+                nodeSelector:
+{{ toYaml .nodeSelector | indent 18 }}
+{{- else }}
+                nodeSelector: {}
+{{- end }}
+                includeInterfaces: {{ toJson (default list .includeInterfaces) }}
+                excludeInterfaces: {{ toJson (default list .excludeInterfaces) }}
+{{- end }}
+{{- else }}
+            rules: []
+{{- end }}
     iaasNetworkProvider:
       serverUrl: {{ (.Values.iaasNetworkProvider).serverUrl | default "" | quote }}
+      httpRequestTimeout: {{ (.Values.iaasNetworkProvider).httpRequestTimeout | default "30s" | quote }}
 {{- if .Values.multus.multusCNI.install }}
 ---
 kind: ConfigMap

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/daemonset.yaml
@@ -248,6 +248,12 @@ spec:
               mountPath: /host{{ .Values.global.cniBinHostPath }}
             - name: ipam-unix-socket-dir
               mountPath: {{ dir .Values.global.ipamUNIXSocketHostPath }}
+        {{- if .Values.spiderpoolAgent.networkResourcePlugin.enabled }}
+            - name: kubelet-device-plugins
+              mountPath: {{ printf "%s/device-plugins" .Values.spiderpoolAgent.networkResourcePlugin.kubeletRootDir | quote }}
+            - name: kubelet-plugins-registry
+              mountPath: {{ printf "%s/plugins_registry" .Values.spiderpoolAgent.networkResourcePlugin.kubeletRootDir | quote }}
+        {{- end }}
         {{- if .Values.multus.multusCNI.uninstall }}
             - name: cni
               mountPath: /host/etc/cni/net.d
@@ -326,6 +332,16 @@ spec:
           hostPath:
             path: /var/run/docker/netns
             type: DirectoryOrCreate
+        {{- if .Values.spiderpoolAgent.networkResourcePlugin.enabled }}
+        - name: kubelet-device-plugins
+          hostPath:
+            path: {{ printf "%s/device-plugins" .Values.spiderpoolAgent.networkResourcePlugin.kubeletRootDir | quote }}
+            type: DirectoryOrCreate
+        - name: kubelet-plugins-registry
+          hostPath:
+            path: {{ printf "%s/plugins_registry" .Values.spiderpoolAgent.networkResourcePlugin.kubeletRootDir | quote }}
+            type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.multus.multusCNI.install }}
         - name: cni
           hostPath:

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
@@ -47,8 +47,12 @@ spec:
           value: {{ .Values.coordinator.tunePodRoutes | quote }}
         - name: SPIDERPOOL_INIT_DEFAULT_COORDINATOR_HIJACK_CIDR
           value: {{ toJson .Values.coordinator.hijackCIDR | quote }}
+        - name: SPIDERPOOL_INIT_DEFAULT_COORDINATOR_POLICY_ROUTES
+          value: {{ toJson .Values.coordinator.policyRoutes | quote }}
         - name: SPIDERPOOL_INIT_DEFAULT_COORDINATOR_VETH_LINK_ADDRESS
           value: {{ .Values.coordinator.vethLinkAddress | quote }}
+        - name: SPIDERPOOL_INIT_DEFAULT_COORDINATOR_VETH_MTU
+          value: {{ .Values.coordinator.vethMTU | quote }}
         {{- end }}
         {{- if and .Values.clusterDefaultPool.installIPv4IPPool .Values.ipam.enableIPv4 }}
         - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_NAME
@@ -115,4 +119,3 @@ metadata:
     {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolInit.serviceAccount.annotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
-  

--- a/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/values.yaml
@@ -7,17 +7,13 @@
 global:
   ## @param global.imageRegistryOverride Global image registry for all images, which is used for offline environment
   imageRegistryOverride: ""
-
   ## @param global.nameOverride instance name
   ## default spiderpool
   nameOverride: ""
-
   ## @param global.clusterDnsDomain cluster dns domain
   clusterDnsDomain: "cluster.local"
-
   ## @param global.commonAnnotations Annotations to add to all deployed objects
   commonAnnotations: {}
-
   ## @param global.commonLabels Labels to add to all deployed objects
   commonLabels: {}
   #  label1: v1
@@ -25,175 +21,131 @@ global:
 
   ## @param global.cniBinHostPath the host path of the IPAM plugin directory.
   cniBinHostPath: /opt/cni/bin
-
   ## @param global.cniConfHostPath the host path of the cni config directory
   cniConfHostPath: /etc/cni/net.d
-
   ## @param global.ipamUNIXSocketHostPath the host path of unix domain socket for ipam plugin
   ipamUNIXSocketHostPath: /var/run/spidernet/spiderpool.sock
-
   ## @param global.configName the configmap name
   configName: "spiderpool-conf"
-
   ## @param global.ciliumConfigMap the cilium's configMap, default is kube-system/cilium-config
   ciliumConfigMap: kube-system/cilium-config
-
 ## @section ipam parameters
 ##
 ipam:
   ## @param ipam.enableIPv4 enable ipv4
   enableIPv4: true
-
   ## @param ipam.enableIPv6 enable ipv6
   enableIPv6: true
-
   ## @param ipam.enableStatefulSet the network mode
   enableStatefulSet: true
-
   ## @param ipam.enableKubevirtStaticIP the feature to keep kubevirt vm pod static IP
   enableKubevirtStaticIP: true
-
   ## @param ipam.enableIPConflictDetection enable IP conflict detection
   enableIPConflictDetection: false
-
   ## @param ipam.enableGatewayDetection enable gateway detection
   enableGatewayDetection: false
-
   ## @param ipam.enableCleanOutdatedEndpoint enable clean outdated endpoint
   enableCleanOutdatedEndpoint: false
-
   spiderSubnet:
     ## @param ipam.spiderSubnet.enable SpiderSubnet feature.
     enable: true
-
     autoPool:
       ## @param ipam.spiderSubnet.autoPool.enable SpiderSubnet Auto IPPool feature.
       enable: true
-
       ## @param ipam.spiderSubnet.autoPool.defaultRedundantIPNumber the default redundant IP number of SpiderSubnet feature auto-created IPPools
       defaultRedundantIPNumber: 1
-
   gc:
     ## @param ipam.gc.enabled enable retrieve IP in spiderippool CR
     enabled: true
-
     gcAll:
       ## @param ipam.gc.gcAll.intervalInSecond the gc all interval duration
       intervalInSecond: 600
-
     statelessPod:
       ## @param ipam.gc.statelessPod.zombieOnReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node
       zombieOnReadyNode: true
-
       ## @param ipam.gc.statelessPod.zombieOnNotReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node
       zombieOnNotReadyNode: true
-
       ## @param ipam.gc.statelessPod.enableGcRunningPodOnEmptyPodStatusIPs enable reclaim IP for the stateless pod who is running and empty pod status IPs
       enableGcRunningPodOnEmptyPodStatusIPs: false
-
     ## @param ipam.gc.gcDeletingTimeOutPodDelay the gc delay seconds after the pod times out of deleting graceful period
     gcDeletingTimeOutPodDelay: 0
-
 ## @section grafanaDashboard parameters
 ##
 grafanaDashboard:
   ## @param grafanaDashboard.install install grafanaDashboard for spiderpool. This requires the grafana operator CRDs to be available
   install: false
-
   ## @param grafanaDashboard.namespace the grafanaDashboard namespace. Default to the namespace of helm instance
   namespace: ""
-
   ## @param grafanaDashboard.annotations the additional annotations of spiderpool grafanaDashboard
   annotations: {}
-
   ## @param grafanaDashboard.labels the additional label of spiderpool grafanaDashboard
   labels: {}
-
   ## @param grafanaDashboard.allowCrossNamespaceImport allow cross namespace import for Grafana dashboards
   ## default true
   allowCrossNamespaceImport: true
-
   instanceSelector:
     ## @param grafanaDashboard.instanceSelector.matchLabels Match labels for Grafana dashboards. If set to `null`, it defaults to matching `operator.insight.io/managed-by: insight`.
     matchLabels: null
-
 ## @section coordinator parameters
 ##
 coordinator:
   ## @param coordinator.enabled enable SpiderCoordinator
   enabled: true
-
   ## @param coordinator.name the name of the default SpiderCoordinator CR
   name: "default"
-
   ## @param coordinator.mode optional network mode, ["auto","underlay", "overlay", "disabled"]
   mode: "auto"
-
   ## @param coordinator.podCIDRType Pod CIDR type that should be collected, [ "auto", "cluster", "calico", "cilium", "none" ]
   podCIDRType: "auto"
-
   ## @param coordinator.detectGateway detect the reachability of the gateway
   detectGateway: false
-
   ## @param coordinator.detectIPConflict detect IP address conflicts
   detectIPConflict: false
-
   ## @param coordinator.tunePodRoutes tune Pod routes
   tunePodRoutes: true
-
   ## @param coordinator.hijackCIDR Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS
   hijackCIDR: ["169.254.0.0/16"]
-
+  ## @param coordinator.policyRoutes Additional routes installed into the coordinator interface policy routing table, for example: [{"dst":"10.10.0.0/16","gw":"172.18.0.1"}]
+  policyRoutes: []
   ## @param coordinator.vethLinkAddress configure an link-local address for veth0 device. empty means disable. default is empty. Format is like 169.254.100.1
   vethLinkAddress: ""
-
+  ## @param coordinator.vethMTU configure the MTU of veth0 device
+  vethMTU: 1500
 ## @section rdma parameters
 ##
 rdma:
   rdmaSharedDevicePlugin:
     ## @param rdma.rdmaSharedDevicePlugin.install install rdma shared device plugin for macvlan cni
     install: false
-
     ## @param rdma.rdmaSharedDevicePlugin.name the name of rdma shared device plugin
     name: "spiderpool-rdma-shared-device-plugin"
-
     image:
       ## @param rdma.rdmaSharedDevicePlugin.image.registry the image registry of rdma shared device plugin
       registry: ghcr.io
-
       ## @param rdma.rdmaSharedDevicePlugin.image.repository the image repository of rdma shared device plugin
       repository: mellanox/k8s-rdma-shared-dev-plugin
-
       ## @param rdma.rdmaSharedDevicePlugin.image.pullPolicy the image pullPolicy of rdma shared device plugin
       pullPolicy: IfNotPresent
-
       ## @param rdma.rdmaSharedDevicePlugin.image.digest the image digest of rdma shared device plugin
       digest: ""
-
       ## @param rdma.rdmaSharedDevicePlugin.image.tag the image tag of rdma shared device plugin
       tag: v1.5.3
-
       ## @param rdma.rdmaSharedDevicePlugin.image.imagePullSecrets the image imagePullSecrets of rdma shared device plugin
       imagePullSecrets: []
       # - name: "image-pull-secret"
-
     ## @skip rdma.rdmaSharedDevicePlugin.updateStrategy.rollingUpdate.maxUnavailable
     ## @skip rdma.rdmaSharedDevicePlugin.updateStrategy.type
     updateStrategy:
       rollingUpdate:
         maxUnavailable: 2
       type: RollingUpdate
-
     ## @skip rdma.rdmaSharedDevicePlugin.tolerations
     tolerations:
       - operator: Exists
-
     ## @param rdma.rdmaSharedDevicePlugin.podAnnotations the additional annotations
     podAnnotations: {}
-
     ## @param rdma.rdmaSharedDevicePlugin.podLabels the additional label
     podLabels: {}
-
     resources:
       limits:
         ## @param rdma.rdmaSharedDevicePlugin.resources.limits.cpu the cpu limit
@@ -205,249 +157,185 @@ rdma:
         cpu: 100m
         ## @param rdma.rdmaSharedDevicePlugin.resources.requests.memory the memory requests
         memory: 50Mi
-
     deviceConfig:
       ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.periodicUpdateInterval periodic Update Interval
       periodicUpdateInterval: 300
-
       ## @param rdma.rdmaSharedDevicePlugin.deviceConfig.configList configure the network card for the rdma resource
       configList: []
-        # [{
-        #  resourcePrefix: "spidernet.io",
-        #  resourceName: "hca_shared_devices",
-        #  rdmaHcaMax: 500,
-        #  selectors: {
-        #      "vendors": "15b3",
-        #      "deviceIDs": "1017",
-        #      "ifNames": ["enp11s0f0np0"]
-        #  }
-        # }]
-
+      # [{
+      #  resourcePrefix: "spidernet.io",
+      #  resourceName: "hca_shared_devices",
+      #  rdmaHcaMax: 500,
+      #  selectors: {
+      #      "vendors": "15b3",
+      #      "deviceIDs": "1017",
+      #      "ifNames": ["enp11s0f0np0"]
+      #  }
+      # }]
 ## @section multus parameters
 ##
 multus:
   ## @param multus.enableMultusConfig enable SpiderMultusConfig
   enableMultusConfig: true
-
   multusCNI:
     ## @param multus.multusCNI.install enable install multus-CNI
     install: true
-
     ## @param multus.multusCNI.uninstall enable remove multus-CNI configuration and binary files on multus-ds pod shutdown. Enable this if you uninstall multus from your cluster. Disable this in the multus upgrade phase to prevent CNI configuration file from being removed, which may cause pods start failure
     uninstall: false
-
     ## @param multus.multusCNI.name the name of spiderpool multus
     name: "spiderpool-multus"
-
     image:
       ## @param multus.multusCNI.image.registry the multus-CNI image registry
       registry: ghcr.io
-
       ## @param multus.multusCNI.image.repository the multus-CNI image repository
       repository: k8snetworkplumbingwg/multus-cni
-
       ## @param multus.multusCNI.image.pullPolicy the multus-CNI image pullPolicy
       pullPolicy: IfNotPresent
-
       ## @param multus.multusCNI.image.digest the multus-CNI image digest
       digest: ""
-
       ## @param multus.multusCNI.image.tag the multus-CNI image tag
       tag: v4.1.4
-
       ## @param multus.multusCNI.image.imagePullSecrets the multus-CNI image imagePullSecrets
       imagePullSecrets: []
       # - name: "image-pull-secret"
-
     ## @param multus.multusCNI.defaultCniCRName if this value is empty, multus will automatically get default CNI according to the existed CNI conf file in /etc/cni/net.d/, if no cni files found in /etc/cni/net.d, A Spidermultusconfig CR named default will be created, please update the related SpiderMultusConfig for default CNI after installation. The namespace of defaultCniCRName follows with the release namespace of spdierpool
     defaultCniCRName: ""
-
     securityContext:
       ## @param multus.multusCNI.securityContext.privileged the securityContext privileged of multus-CNI daemonset pod
       privileged: true
-
     ## @param multus.multusCNI.extraEnv the additional environment variables of multus-CNI daemonset pod container
     extraEnv: []
-
     ## @param multus.multusCNI.extraVolumes the additional volumes of multus-CNI daemonset pod container
     extraVolumes: []
-      # - name: test-val
+    # - name: test-val
     #   mountPath: /host/tmp
 
     ## @param multus.multusCNI.extraVolumeMounts the additional hostPath mounts of multus-CNI daemonset pod container
     extraVolumeMounts: []
-      # - name: test-val
+    # - name: test-val
     #   mountPath: /tmp
 
     log:
       ## @param multus.multusCNI.log.logLevel the multus-CNI daemonset pod log level
       logLevel: "debug"
-
       ## @param multus.multusCNI.log.logFile the multus-CNI daemonset pod log file
       logFile: "/var/log/multus.log"
-
 ## @section plugins parameters
 ##
 plugins:
   ## @param plugins.installCNI install all cni plugins to each node
   installCNI: false
-
   ## @param plugins.installRdmaCNI install rdma cni used to isolate rdma device for sriov cni
   installRdmaCNI: true
-
   ## @param plugins.installOvsCNI install ovs cni to each node
   installOvsCNI: true
-
   ## @param plugins.installSriovCNI install sriov cni to each node
   installSriovCNI: true
-
   ## @param plugins.installibSriovCNI install ib-sriov cni to each node
   installibSriovCNI: true
-
   ## @param plugins.installIpoibCNI install ipoib cni to each node
   installIpoibCNI: true
-
   ## @param plugins.installVlanCNI install vlan cni to each node
   installVlanCNI: true
-
   image:
     ## @param plugins.image.registry the image registry of plugins
     registry: ghcr.io
-
     ## @param plugins.image.repository the image repository of plugins
     repository: spidernet-io/spiderpool/spiderpool-plugins
-
     ## @param plugins.image.pullPolicy the image pullPolicy of plugins
     pullPolicy: IfNotPresent
-
     ## @param plugins.image.digest the image digest of plugins
     digest: ""
-
     ## @param plugins.image.tag the image tag of plugins
-    tag: 19f19457ae7cec86457b0411543a3cf21dd9f95a
-
+    tag: 87fd4a400858705c208d5a4b7059423b33a551aa
     ## @param plugins.image.imagePullSecrets the image imagePullSecrets of plugins
     imagePullSecrets: []
-
 ## @section clusterDefaultPool parameters
 ##
 clusterDefaultPool:
   ## @param clusterDefaultPool.installIPv4IPPool install ipv4 spiderpool instance. It is required to set ipam.enableIPv4=true
   installIPv4IPPool: false
-
   ## @param clusterDefaultPool.installIPv6IPPool install ipv6 spiderpool instance. It is required to set ipam.enableIPv6=true
   installIPv6IPPool: false
-
   ## @param clusterDefaultPool.ipv4IPPoolName the name of ipv4 spiderpool instance
   ipv4IPPoolName: "default-v4-ippool"
-
   ## @param clusterDefaultPool.ipv6IPPoolName the name of ipv6 spiderpool instance
   ipv6IPPoolName: "default-v6-ippool"
-
   ## @param clusterDefaultPool.ipv4SubnetName the name of ipv4 spidersubnet instance
   ipv4SubnetName: "default-v4-subnet"
-
   ## @param clusterDefaultPool.ipv6SubnetName the name of ipv6 spidersubnet instance
   ipv6SubnetName: "default-v6-subnet"
-
   ## @param clusterDefaultPool.ipv4Subnet the subnet of ipv4 spiderpool instance
   ipv4Subnet: ""
-
   ## @param clusterDefaultPool.ipv6Subnet the subnet of ipv6 spiderpool instance
   ipv6Subnet: ""
-
   ## @param clusterDefaultPool.ipv4IPRanges the available IP of ipv4 spiderpool instance
   ipv4IPRanges: []
-
   ## @param clusterDefaultPool.ipv6IPRanges the available IP of ipv6 spiderpool instance
   ipv6IPRanges: []
-
   ## @param clusterDefaultPool.ipv4Gateway the gateway of ipv4 subnet
   ipv4Gateway: ""
-
   ## @param clusterDefaultPool.ipv6Gateway the gateway of ipv6 subnet
   ipv6Gateway: ""
-
 ## @section spiderpoolAgent parameters
 ##
 spiderpoolAgent:
   ## @param spiderpoolAgent.name the spiderpoolAgent name
   name: "spiderpool-agent"
-
   ## @param spiderpoolAgent.binName the binName name of spiderpoolAgent
   binName: "/usr/bin/spiderpool-agent"
-
   image:
     ## @param spiderpoolAgent.image.registry the image registry of spiderpoolAgent
     registry: ghcr.io
-
     ## @param spiderpoolAgent.image.repository the image repository of spiderpoolAgent
     repository: spidernet-io/spiderpool/spiderpool-agent
-
     ## @param spiderpoolAgent.image.pullPolicy the image pullPolicy of spiderpoolAgent
     pullPolicy: IfNotPresent
-
     ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
     digest: ""
-
     ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-    tag: v1.2.0
-
+    tag: v1.2.2
     ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
     imagePullSecrets: []
     # - name: "image-pull-secret"
-
   ## @skip spiderpoolAgent.nodeSelector.kubernetes.io/os
   nodeSelector:
     kubernetes.io/os: linux
-
   serviceAccount:
     ## @param spiderpoolAgent.serviceAccount.create create the service account for the spiderpoolAgent
     create: true
     ## @param spiderpoolAgent.serviceAccount.annotations the annotations of spiderpoolAgent service account
     annotations: {}
-
   ## @skip spiderpoolAgent.updateStrategy.rollingUpdate.maxUnavailable
   ## @skip spiderpoolAgent.updateStrategy.type
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 2
     type: RollingUpdate
-
   service:
     ## @param spiderpoolAgent.service.annotations the annotations for spiderpoolAgent service
     annotations: {}
     ## @param spiderpoolAgent.service.type the type for spiderpoolAgent service
     type: ClusterIP
-
   ## @skip spiderpoolAgent.tolerations
   tolerations:
     - operator: Exists
-
   ## @param spiderpoolAgent.priorityClassName the priority Class Name for spiderpoolAgent
   priorityClassName: "system-node-critical"
-
   ## @param spiderpoolAgent.affinity the affinity of spiderpoolAgent
   affinity: {}
-
   ## @param spiderpoolAgent.extraArgs the additional arguments of spiderpoolAgent container
   extraArgs: []
-
   ## @param spiderpoolAgent.extraEnv the additional environment variables of spiderpoolAgent container
   extraEnv: []
-
   ## @param spiderpoolAgent.extraVolumes the additional volumes of spiderpoolAgent container
   extraVolumes: []
-
   ## @param spiderpoolAgent.extraVolumeMounts the additional hostPath mounts of spiderpoolAgent container
   extraVolumeMounts: []
-
   ## @param spiderpoolAgent.podAnnotations the additional annotations of spiderpoolAgent pod
   podAnnotations: {}
-
   ## @param spiderpoolAgent.podLabels the additional label of spiderpoolAgent pod
   podLabels: {}
-
   resources:
     limits:
       ## @param spiderpoolAgent.resources.limits.cpu the cpu limit of spiderpoolAgent pod
@@ -459,183 +347,184 @@ spiderpoolAgent:
       cpu: 100m
       ## @param spiderpoolAgent.resources.requests.memory the memory requests of spiderpoolAgent pod
       memory: 128Mi
-
   ## @param spiderpoolAgent.tuneSysctlConfig enable to set required sysctl on each node to run spiderpool. refer to [Spiderpool-agent](https://spidernet-io.github.io/spiderpool/dev/reference/spiderpool-agent/) for details
   tuneSysctlConfig: true
-
+  ## @param spiderpoolAgent.networkResourcePlugin.enabled enable spiderpool-agent network resource advertisement through the kubelet device plugin API.
+  networkResourcePlugin:
+    enabled: false
+    ## @param spiderpoolAgent.networkResourcePlugin.kubeletRootDir kubelet root directory used to derive device-plugin and plugin-registration host paths.
+    kubeletRootDir: /var/lib/kubelet
+    devicePluginAffinity:
+      ## @param spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector node label selector for nodes that advertise Spiderpool network resources.
+      nodeSelector:
+        matchLabels:
+          kubernetes.io/os: linux
+      ## Example:
+      # matchLabels:
+      #   kubernetes.io/os: linux
+    resourceAdvertisement:
+      subENI:
+        ## @param spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules auxiliary ENI slot advertisement rules.
+        rules:
+          - resourceName: spidernet.io/sub-eni
+            defaultMaxCount: 256
+            nodeSelector:
+              matchLabels:
+                kubernetes.io/os: linux
+        ## Example:
+        # - resourceName: spidernet.io/sub-eni
+        #   defaultMaxCount: 256
+        #   nodeSelector:
+        #     matchLabels:
+        #       kubernetes.io/os: linux
+      masterNIC:
+        ## @param spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules node/interface selection rules for advertised master NIC resources.
+        rules:
+          - defaultMaxCount: 10000
+            nodeSelector:
+              matchLabels:
+                kubernetes.io/os: linux
+            includeInterfaces:
+              - eth*
+            excludeInterfaces: []
+        # - nodeSelector:
+        #     matchLabels:
+        #       kubernetes.io/os: linux
+        #   defaultMaxCount: 10000
+        #   includeInterfaces:
+        #     - eth*
+        #   excludeInterfaces: []
   ## @param spiderpoolAgent.securityContext the security Context of spiderpoolAgent pod
   securityContext: {}
   # runAsUser: 0
 
   ## @param spiderpoolAgent.httpPort the http Port for spiderpoolAgent, for health checking
   httpPort: 5710
-
   healthChecking:
     startupProbe:
       ## @param spiderpoolAgent.healthChecking.startupProbe.failureThreshold the failure threshold of startup probe for spiderpoolAgent health checking
       failureThreshold: 60
       ## @param spiderpoolAgent.healthChecking.startupProbe.periodSeconds the period seconds of startup probe for spiderpoolAgent health checking
       periodSeconds: 2
-
     livenessProbe:
       ## @param spiderpoolAgent.healthChecking.livenessProbe.failureThreshold the failure threshold of startup probe for spiderpoolAgent health checking
       failureThreshold: 6
       ## @param spiderpoolAgent.healthChecking.livenessProbe.periodSeconds the period seconds of startup probe for spiderpoolAgent health checking
       periodSeconds: 10
-
     readinessProbe:
       ## @param spiderpoolAgent.healthChecking.readinessProbe.failureThreshold the failure threshold of startup probe for spiderpoolAgent health checking
       failureThreshold: 3
       ## @param spiderpoolAgent.healthChecking.readinessProbe.periodSeconds the period seconds of startup probe for spiderpoolAgent health checking
       periodSeconds: 10
-
   prometheus:
     ## @param spiderpoolAgent.prometheus.enabled enable spiderpool agent to collect metrics
     enabled: false
-
     ## @param spiderpoolAgent.prometheus.enabledRdmaMetric enable spiderpool agent to collect RDMA metrics
     enabledRdmaMetric: false
-
     ## @param spiderpoolAgent.prometheus.enabledDebugMetric enable spiderpool agent to collect debug level metrics
     enabledDebugMetric: false
-
     ## @param spiderpoolAgent.prometheus.port the metrics port of spiderpool agent
     port: 5711
-
     serviceMonitor:
       ## @param spiderpoolAgent.prometheus.serviceMonitor.install install serviceMonitor for spiderpool agent. This requires the prometheus CRDs to be available
       install: false
-
       ## @param spiderpoolAgent.prometheus.serviceMonitor.namespace the serviceMonitor namespace. Default to the namespace of helm instance
       namespace: ""
-
       ## @param spiderpoolAgent.prometheus.serviceMonitor.annotations the additional annotations of spiderpoolAgent serviceMonitor
       annotations: {}
-
       ## @param spiderpoolAgent.prometheus.serviceMonitor.labels the additional label of spiderpoolAgent serviceMonitor
       labels: {}
-
       ## @param spiderpoolAgent.prometheus.serviceMonitor.interval represents the interval of spiderpoolAgent serviceMonitor's scraping action
       interval: "5s"
-
     prometheusRule:
       ## @param spiderpoolAgent.prometheus.prometheusRule.install install prometheusRule for spiderpool agent. This requires the prometheus CRDs to be available
       install: false
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.namespace the prometheusRule namespace. Default to the namespace of helm instance
       namespace: ""
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.annotations the additional annotations of spiderpoolAgent prometheusRule
       annotations: {}
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.labels the additional label of spiderpoolAgent prometheusRule
       labels: {}
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.enableWarningIPAMAllocationFailure the additional rule of spiderpoolAgent prometheusRule
       enableWarningIPAMAllocationFailure: true
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.enableWarningIPAMAllocationOverTime the additional rule of spiderpoolAgent prometheusRule
       enableWarningIPAMAllocationOverTime: true
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.enableWarningIPAMHighAllocationDurations the additional rule of spiderpoolAgent prometheusRule
       enableWarningIPAMHighAllocationDurations: true
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.enableWarningIPAMReleaseFailure the additional rule of spiderpoolAgent prometheusRule
       enableWarningIPAMReleaseFailure: true
-
       ## @param spiderpoolAgent.prometheus.prometheusRule.enableWarningIPAMReleaseOverTime the additional rule of spiderpoolAgent prometheusRule
       enableWarningIPAMReleaseOverTime: true
-
   debug:
     ## @param spiderpoolAgent.debug.logLevel the log level of spiderpool agent [debug, info, warn, error, fatal, panic]
     logLevel: "info"
     ## @param spiderpoolAgent.debug.gopsPort the gops port of spiderpool agent
     gopsPort: 5712
-
 ## @section spiderpoolController parameters
 ##
 spiderpoolController:
   ## @param spiderpoolController.name the spiderpoolController name
   name: "spiderpool-controller"
-
   ## @param spiderpoolController.replicas the replicas number of spiderpoolController pod
   replicas: 1
-
   ## @param spiderpoolController.binName the binName name of spiderpoolController
   binName: "/usr/bin/spiderpool-controller"
-
   ## @param spiderpoolController.hostnetwork enable hostnetwork mode of spiderpoolController pod. Notice, if no CNI available before spiderpool installation, must enable this
   hostnetwork: true
-
   image:
     ## @param spiderpoolController.image.registry the image registry of spiderpoolController
     registry: ghcr.io
-
     ## @param spiderpoolController.image.repository the image repository of spiderpoolController
     repository: spidernet-io/spiderpool/spiderpool-controller
-
     ## @param spiderpoolController.image.pullPolicy the image pullPolicy of spiderpoolController
     pullPolicy: IfNotPresent
-
     ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
     digest: ""
-
     ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-    tag: v1.2.0
-
+    tag: v1.2.2
     ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
     imagePullSecrets: []
     # - name: "image-pull-secret"
-
   ## @skip spiderpoolController.nodeSelector.kubernetes.io/os
   nodeSelector:
     kubernetes.io/os: linux
-
   serviceAccount:
     ## @param spiderpoolController.serviceAccount.create create the service account for the spiderpoolController
     create: true
     ## @param spiderpoolController.serviceAccount.annotations the annotations of spiderpoolController service account
     annotations: {}
-
   service:
     ## @param spiderpoolController.service.annotations the annotations for spiderpoolController service
     annotations: {}
     ## @param spiderpoolController.service.type the type for spiderpoolController service
     type: ClusterIP
-
   ## @skip spiderpoolController.tolerations
   tolerations:
     - operator: Exists
-
   ## @param spiderpoolController.priorityClassName the priority Class Name for spiderpoolController
   priorityClassName: "system-node-critical"
-
   ## @param spiderpoolController.affinity the affinity of spiderpoolController
   affinity: {}
-
   ## @param spiderpoolController.extraArgs the additional arguments of spiderpoolController container
   extraArgs: []
-
   ## @param spiderpoolController.extraEnv the additional environment variables of spiderpoolController container
   extraEnv: []
-
   ## @param spiderpoolController.extraVolumes the additional volumes of spiderpoolController container
   extraVolumes: []
-    # - name: test-val
-    #   mountPath: /host/tmp
+  # - name: test-val
+  #   mountPath: /host/tmp
 
   ## @param spiderpoolController.extraVolumeMounts the additional hostPath mounts of spiderpoolController container
   extraVolumeMounts: []
-    # - name: test-val
-    #   mountPath: /tmp
+  # - name: test-val
+  #   mountPath: /tmp
 
   ## @param spiderpoolController.podAnnotations the additional annotations of spiderpoolController pod
   podAnnotations: {}
-    # test: 100
+  # test: 100
 
   ## @param spiderpoolController.podLabels the additional label of spiderpoolController pod
   podLabels: {}
-
   ## @param spiderpoolController.securityContext the security Context of spiderpoolController pod
   securityContext: {}
   # runAsUser: 0
@@ -651,108 +540,78 @@ spiderpoolController:
       cpu: 100m
       ## @param spiderpoolController.resources.requests.memory the memory requests of spiderpoolController pod
       memory: 128Mi
-
   podDisruptionBudget:
     ## @param spiderpoolController.podDisruptionBudget.enabled enable podDisruptionBudget for spiderpoolController pod
     enabled: false
-
     ## @param spiderpoolController.podDisruptionBudget.minAvailable minimum number/percentage of pods that should remain scheduled.
     minAvailable: 1
-
   ## @param spiderpoolController.httpPort the http Port for spiderpoolController, for health checking and http service
   httpPort: 5720
-
   healthChecking:
     startupProbe:
       ## @param spiderpoolController.healthChecking.startupProbe.failureThreshold the failure threshold of startup probe for spiderpoolController health checking
       failureThreshold: 30
-
       ## @param spiderpoolController.healthChecking.startupProbe.periodSeconds the period seconds of startup probe for spiderpoolController health checking
       periodSeconds: 2
-
     livenessProbe:
       ## @param spiderpoolController.healthChecking.livenessProbe.failureThreshold the failure threshold of startup probe for spiderpoolController health checking
       failureThreshold: 6
-
       ## @param spiderpoolController.healthChecking.livenessProbe.periodSeconds the period seconds of startup probe for spiderpoolController health checking
       periodSeconds: 10
-
     readinessProbe:
       ## @param spiderpoolController.healthChecking.readinessProbe.failureThreshold the failure threshold of startup probe for spiderpoolController health checking
       failureThreshold: 3
-
       ## @param spiderpoolController.healthChecking.readinessProbe.periodSeconds the period seconds of startup probe for spiderpoolController health checking
       periodSeconds: 10
-
   ## @param spiderpoolController.webhookPort the http port for spiderpoolController webhook
   webhookPort: 5722
-
   ## @param spiderpoolController.enableValidatingResourcesDeletedWebhook enable validating resources deleted webhook for spiderpoolController
   enableValidatingResourcesDeletedWebhook: false
-
   podResourceInject:
     ## @param spiderpoolController.podResourceInject.enabled enable pod resource inject
     enabled: false
-
     ## @param spiderpoolController.podResourceInject.namespacesExclude exclude the namespaces of the pod resource inject
     namespacesExclude:
       - kube-system
       - spiderpool
       - metallb-system
       - istio-system
-
     ## @param spiderpoolController.podResourceInject.namespacesInclude include the namespaces of the pod resource inject, empty means all namespaces but exclude the namespaces in namespacesExclude, not empty means only include the namespaces in namespacesInclude
     namespacesInclude: []
-
   prometheus:
     ## @param spiderpoolController.prometheus.enabled enable spiderpool Controller to collect metrics
     enabled: false
-
     ## @param spiderpoolController.prometheus.enabledDebugMetric enable spiderpool Controller to collect debug level metrics
     enabledDebugMetric: false
-
     ## @param spiderpoolController.prometheus.port the metrics port of spiderpool Controller
     port: 5721
-
     serviceMonitor:
       ## @param spiderpoolController.prometheus.serviceMonitor.install install serviceMonitor for spiderpool agent. This requires the prometheus CRDs to be available
       install: false
-
       ## @param spiderpoolController.prometheus.serviceMonitor.namespace the serviceMonitor namespace. Default to the namespace of helm instance
       namespace: ""
-
       ## @param spiderpoolController.prometheus.serviceMonitor.annotations the additional annotations of spiderpoolController serviceMonitor
       annotations: {}
-
       ## @param spiderpoolController.prometheus.serviceMonitor.labels the additional label of spiderpoolController serviceMonitor
       labels: {}
-
       ## @param spiderpoolController.prometheus.serviceMonitor.interval represents the interval of spiderpoolController serviceMonitor's scraping action
       interval: "10s"
-
     prometheusRule:
       ## @param spiderpoolController.prometheus.prometheusRule.install install prometheusRule for spiderpool agent. This requires the prometheus CRDs to be available
       install: false
-
       ## @param spiderpoolController.prometheus.prometheusRule.namespace the prometheusRule namespace. Default to the namespace of helm instance
       namespace: ""
-
       ## @param spiderpoolController.prometheus.prometheusRule.annotations the additional annotations of spiderpoolController prometheusRule
       annotations: {}
-
       ## @param spiderpoolController.prometheus.prometheusRule.labels the additional label of spiderpoolController prometheusRule
       labels: {}
-
       ## @param spiderpoolController.prometheus.prometheusRule.enableWarningIPGCFailureCounts the additional rule of spiderpoolController prometheusRule
       enableWarningIPGCFailureCounts: true
-
   debug:
     ## @param spiderpoolController.debug.logLevel the log level of spiderpool Controller [debug, info, warn, error, fatal, panic]
     logLevel: "info"
-
     ## @param spiderpoolController.debug.gopsPort the gops port of spiderpool Controller
     gopsPort: 5724
-
   ## TLS configuration for webhook
   tls:
     ## @param spiderpoolController.tls.method the method for generating TLS certificates. [ provided , certmanager , auto]
@@ -760,24 +619,18 @@ spiderpoolController:
     ## - certmanager:  This method use cert-manager to generate & rotate certificates.
     ## - auto:         Auto generate cert.
     method: auto
-
     ## @param spiderpoolController.tls.secretName the secret name for storing TLS certificates
     secretName: "spiderpool-controller-server-certs"
-
     ## for certmanager method
     certmanager:
       ## @param spiderpoolController.tls.certmanager.certValidityDuration generated certificates validity duration in days for 'certmanager' method
       certValidityDuration: 36500
-
       ## @param spiderpoolController.tls.certmanager.issuerName issuer name of cert manager 'certmanager'. If not specified, a CA issuer will be created.
       issuerName: ""
-
       ## @param spiderpoolController.tls.certmanager.extraDnsNames extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
-
       ## @param spiderpoolController.tls.certmanager.extraIPAddresses extra IP addresses added to certificate when it's auto generated
       extraIPAddresses: []
-
     ## for provided method
     provided:
       ## @param spiderpoolController.tls.provided.tlsCert encoded tls certificate for provided method
@@ -786,62 +639,46 @@ spiderpoolController:
       tlsCert: ""
       tlsKey: ""
       tlsCa: ""
-
     ## for auto method
     auto:
       ## @param spiderpoolController.tls.auto.caExpiration ca expiration for auto method
       # in day , default 200 years
       caExpiration: '73000'
-
       ## @param spiderpoolController.tls.auto.certExpiration server cert expiration for auto method
       # in day, default 200 years
       certExpiration: '73000'
-
       ## @param spiderpoolController.tls.auto.extraIpAddresses extra IP addresses of server certificate for auto method
       extraIpAddresses: []
-
       ## @param spiderpoolController.tls.auto.extraDnsNames extra DNS names of server cert for auto method
       extraDnsNames: []
-
   cleanup:
     ## @param spiderpoolController.cleanup.enable clean up resources when helm uninstall
     enable: true
-
 ## @section spiderpoolInit parameters
 ##
 spiderpoolInit:
   ## @param spiderpoolInit.name the init job for installing default spiderippool
   name: "spiderpool-init"
-
   ## @param spiderpoolInit.binName the binName name of spiderpoolInit
   binName: "/usr/bin/spiderpool-init"
-
   image:
     ## @param spiderpoolInit.image.registry the image registry of spiderpoolInit
     registry: ghcr.io
-
     ## @param spiderpoolInit.image.repository the image repository of spiderpoolInit
     repository: spidernet-io/spiderpool/spiderpool-controller
-
     ## @param spiderpoolInit.image.pullPolicy the image pullPolicy of spiderpoolInit
     pullPolicy: IfNotPresent
-
     ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
     digest: ""
-
     ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-    tag: v1.2.0
-
+    tag: v1.2.2
     ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
     imagePullSecrets: []
     # - name: "image-pull-secret"
-
   ## @param spiderpoolInit.extraArgs the additional arguments of spiderpoolInit container
   extraArgs: []
-
   ## @param spiderpoolInit.extraEnv the additional environment variables of spiderpoolInit container
   extraEnv: []
-
   ## @param spiderpoolInit.securityContext the security Context of spiderpoolInit pod
   securityContext: {}
   # runAsUser: 0
@@ -849,39 +686,29 @@ spiderpoolInit:
   serviceAccount:
     ## @param spiderpoolInit.serviceAccount.annotations the annotations of spiderpoolInit service account
     annotations: {}
-
 ## @section sriov network operator parameters
 ##
 sriov:
   ## @param sriov.install install sriov network operator
   install: false
-
   ## @param sriov.name the name of sriov network operator
   name: "spiderpool-sriov-operator"
-
   ## @skip sriov.tolerations
   tolerations:
     - operator: Exists
-
   ## @skip sriov.nodeSelector.kubernetes.io/os
   nodeSelector:
     kubernetes.io/os: linux
-
   ## @param sriov.affinity the affinity
   affinity: {}
-
   ## @param sriov.hostnetwork enable hostnetwork mode. Notice, if no CNI available before spiderpool installation, must enable this
   hostnetwork: true
-
   ## @param sriov.replicas the replicas number
   replicas: 1
-
   ## @param sriov.resourcePrefix the resource prefix
   resourcePrefix: "spidernet.io"
-
   ## @param sriov.priorityClassName the priority Class Name
   priorityClassName: "system-node-critical"
-
   resources:
     limits:
       ## @param sriov.resources.limits.cpu the cpu limit
@@ -893,35 +720,26 @@ sriov:
       cpu: 100m
       ## @param sriov.resources.requests.memory the memory requests
       memory: 128Mi
-
   operatorConfig:
     ## @param sriov.operatorConfig.enableInjector Flag to control whether the network resource injector webhook shall be deployed
     enableInjector: false
-
     ## @param sriov.operatorConfig.enableOperatorWebhook Flag to control whether the operator admission controller webhook shall be deployed
     enableOperatorWebhook: true
-
     configDaemonNodeSelector:
       ## @skip sriov.operatorConfig.configDaemonNodeSelector.configDaemonNodeSelector.kubernetes.io/os
       ## @skip sriov.operatorConfig.configDaemonNodeSelector.kubernetes.io/os
       kubernetes.io/os: "linux"
-
     ## @param sriov.operatorConfig.logLevel Flag to control the log verbose level of the operator
     logLevel: 2
-
     ## @param sriov.operatorConfig.disableDrain Flag to disable nodes drain during debugging
     disableDrain: true
-
     ## @param sriov.operatorConfig.configurationMode Flag to enable the sriov-network-config-daemon to use a systemd service to configure SR-IOV devices on boot
     configurationMode: daemon
-
   image:
     ## @param sriov.image.registry registry for all images
     registry: ghcr.io
-
     ## @param sriov.image.pullPolicy the image pullPolicy for all images
     pullPolicy: IfNotPresent
-
     ## @param sriov.image.imagePullSecrets the image imagePullSecrets for all images
     imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -929,38 +747,28 @@ sriov:
     operator:
       ## @param sriov.image.operator.repository the image repository
       repository: spidernet-io/sriov-network-operator
-
       ## @param sriov.image.operator.tag the image tag
       tag: v1.3.0
-
     sriovConfigDaemon:
       ## @param sriov.image.sriovConfigDaemon.repository the image repository
       repository: spidernet-io/sriov-network-operator-config-daemon
-
       ## @param sriov.image.sriovConfigDaemon.tag the image tag
       tag: v1.3.0
-
     sriovDevicePlugin:
       ## @param sriov.image.sriovDevicePlugin.repository the image repository
       repository: k8snetworkplumbingwg/sriov-network-device-plugin
-
       ## @param sriov.image.sriovDevicePlugin.tag the image tag
       tag: v3.7.0
-
     resourcesInjector:
       ## @param sriov.image.resourcesInjector.repository the image repository
       repository: k8snetworkplumbingwg/network-resources-injector
-
       ## @param sriov.image.resourcesInjector.tag the image tag
       tag: v1.6.0
-
     webhook:
       ## @param sriov.image.webhook.repository the image repository
       repository: k8snetworkplumbingwg/sriov-network-operator-webhook
-
       ## @param sriov.image.webhook.tag the image tag
       tag: v1.3.0
-
   ## TLS configuration for operator webhook
   webhooktls:
     ## @param sriov.webhooktls.method the method for generating TLS certificates. [ provided , certmanager , auto]
@@ -968,27 +776,20 @@ sriov:
     ## - certmanager:  This method use cert-manager to generate & rotate certificates.
     ## - auto:         Auto generate cert.
     method: auto
-
     ## @param sriov.webhooktls.secretName the secret name for storing TLS certificates
     secretName: "sriov-operator-webhook"
-
     ## @param sriov.webhooktls.serviceName the service name of webhook. Do not modify this !!!
     serviceName: "operator-webhook-service"
-
     ## for certmanager method
     certmanager:
       ## @param sriov.webhooktls.certmanager.certValidityDuration generated certificates validity duration in days for 'certmanager' method
       certValidityDuration: 365
-
       ## @param sriov.webhooktls.certmanager.issuerName issuer name of cert manager 'certmanager'. If not specified, a CA issuer will be created.
       issuerName: ""
-
       ## @param sriov.webhooktls.certmanager.extraDnsNames extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
-
       ## @param sriov.webhooktls.certmanager.extraIPAddresses extra IP addresses added to certificate when it's auto generated
       extraIPAddresses: []
-
     ## for provided method
     provided:
       ## @param sriov.webhooktls.provided.tlsCert encoded tls certificate for provided method
@@ -997,23 +798,18 @@ sriov:
       tlsCert: ""
       tlsKey: ""
       tlsCa: ""
-
     ## for auto method
     auto:
       ## @param sriov.webhooktls.auto.caExpiration ca expiration for auto method
       # in day , default 200 years
       caExpiration: '73000'
-
       ## @param sriov.webhooktls.auto.certExpiration server cert expiration for auto method
       # in day, default 200 years
       certExpiration: '73000'
-
       ## @param sriov.webhooktls.auto.extraIpAddresses extra IP addresses of server certificate for auto method
       extraIpAddresses: []
-
       ## @param sriov.webhooktls.auto.extraDnsNames extra DNS names of server cert for auto method
       extraDnsNames: []
-
   ## TLS configuration for injector webhook
   injectortls:
     ## @param sriov.injectortls.method the method for generating TLS certificates. [ provided , certmanager , auto]
@@ -1021,27 +817,20 @@ sriov:
     ## - certmanager:  This method use cert-manager to generate & rotate certificates.
     ## - auto:         Auto generate cert.
     method: auto
-
     ## @param sriov.injectortls.secretName the secret name for storing TLS certificates
     secretName: "sriov-injector"
-
     ## @param sriov.injectortls.serviceName the service name of webhook. Do not modify this !!!
     serviceName: "network-resources-injector-service"
-
     ## for certmanager method
     certmanager:
       ## @param sriov.injectortls.certmanager.certValidityDuration generated certificates validity duration in days for 'certmanager' method
       certValidityDuration: 36500
-
       ## @param sriov.injectortls.certmanager.issuerName issuer name of cert manager 'certmanager'. If not specified, a CA issuer will be created.
       issuerName: ""
-
       ## @param sriov.injectortls.certmanager.extraDnsNames extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
-
       ## @param sriov.injectortls.certmanager.extraIPAddresses extra IP addresses added to certificate when it's auto generated
       extraIPAddresses: []
-
     ## for provided method
     provided:
       ## @param sriov.injectortls.provided.tlsCert encoded tls certificate for provided method
@@ -1050,25 +839,22 @@ sriov:
       tlsCert: ""
       tlsKey: ""
       tlsCa: ""
-
     ## for auto method
     auto:
       ## @param sriov.injectortls.auto.caExpiration ca expiration for auto method
       # in day , default 200 years
       caExpiration: '73000'
-
       ## @param sriov.injectortls.auto.certExpiration server cert expiration for auto method
       # in day, default 200 years
       certExpiration: '73000'
-
       ## @param sriov.injectortls.auto.extraIpAddresses extra IP addresses of server certificate for auto method
       extraIpAddresses: []
-
       ## @param sriov.injectortls.auto.extraDnsNames extra DNS names of server cert for auto method
       extraDnsNames: []
-
 ## @section IaaS Network Provider Integration
 ##
 iaasNetworkProvider:
   ## @param iaasNetworkProvider.serverUrl the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.
   serverUrl: ""
+  ## @param iaasNetworkProvider.httpRequestTimeout the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin.
+  httpRequestTimeout: "50s"

--- a/charts/spiderpool/spiderpool/values.schema.json
+++ b/charts/spiderpool/spiderpool/values.schema.json
@@ -75,6 +75,61 @@
                                     "default": false
                                 }
                             }
+                        },
+                        "networkResourcePlugin": {
+                            "title": "Spiderpool Agent Network Resource Plugin Setting",
+                            "description": "Configure spiderpool-agent network resource advertisement through the kubelet device plugin API.",
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "title": "Enable",
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "resourceAdvertisement": {
+                                    "type": "object",
+                                    "properties": {
+                                        "subENI": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rules": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "resourceName": {
+                                                                "type": "string",
+                                                                "default": "spidernet.io/sub-eni"
+                                                            },
+                                                            "defaultMaxCount": {
+                                                                "type": "integer",
+                                                                "default": 256
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "masterNIC": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rules": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "defaultMaxCount": {
+                                                                "type": "integer",
+                                                                "default": 10000
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -442,6 +497,18 @@
                                     "fd00::10-fd00::200"
                                 ]
                             ]
+                        }
+                    }
+                },
+                "iaasNetworkProvider": {
+                    "title": "IaaS Network Provider Integration",
+                    "type": "object",
+                    "properties": {
+                        "serverUrl": {
+                            "title": "IaaS Provider Server URL",
+                            "description": "The URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled. For example: https://iaas-network-provider.iaas-network-provider-system.svc:443",
+                            "type": "string",
+                            "default": ""
                         }
                     }
                 }

--- a/charts/spiderpool/spiderpool/values.yaml
+++ b/charts/spiderpool/spiderpool/values.yaml
@@ -108,8 +108,12 @@ spiderpool:
     tunePodRoutes: true
     ## @param coordinator.hijackCIDR Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS
     hijackCIDR: ["169.254.0.0/16"]
+    ## @param coordinator.policyRoutes Additional routes installed into the coordinator interface policy routing table, for example: [{"dst":"10.10.0.0/16","gw":"172.18.0.1"}]
+    policyRoutes: []
     ## @param coordinator.vethLinkAddress configure an link-local address for veth0 device. empty means disable. default is empty. Format is like 169.254.100.1
     vethLinkAddress: ""
+    ## @param coordinator.vethMTU configure the MTU of veth0 device
+    vethMTU: 1500
   ## @section rdma parameters
   ##
   rdma:
@@ -246,7 +250,7 @@ spiderpool:
       ## @param plugins.image.digest the image digest of plugins
       digest: ""
       ## @param plugins.image.tag the image tag of plugins
-      tag: 19f19457ae7cec86457b0411543a3cf21dd9f95a
+      tag: 87fd4a400858705c208d5a4b7059423b33a551aa
       ## @param plugins.image.imagePullSecrets the image imagePullSecrets of plugins
       imagePullSecrets: []
   ## @section clusterDefaultPool parameters
@@ -295,7 +299,7 @@ spiderpool:
       ## @param spiderpoolAgent.image.digest the image digest of spiderpoolAgent, which takes preference over tag
       digest: ""
       ## @param spiderpoolAgent.image.tag the image tag of spiderpoolAgent, overrides the image tag whose default is the chart appVersion.
-      tag: v1.2.0
+      tag: v1.2.2
       ## @param spiderpoolAgent.image.imagePullSecrets the image imagePullSecrets of spiderpoolAgent
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -350,6 +354,51 @@ spiderpool:
         memory: 32Mi
     ## @param spiderpoolAgent.tuneSysctlConfig enable to set required sysctl on each node to run spiderpool. refer to [Spiderpool-agent](https://spidernet-io.github.io/spiderpool/dev/reference/spiderpool-agent/) for details
     tuneSysctlConfig: true
+    ## @param spiderpoolAgent.networkResourcePlugin.enabled enable spiderpool-agent network resource advertisement through the kubelet device plugin API.
+    networkResourcePlugin:
+      enabled: false
+      ## @param spiderpoolAgent.networkResourcePlugin.kubeletRootDir kubelet root directory used to derive device-plugin and plugin-registration host paths.
+      kubeletRootDir: /var/lib/kubelet
+      devicePluginAffinity:
+        ## @param spiderpoolAgent.networkResourcePlugin.devicePluginAffinity.nodeSelector node label selector for nodes that advertise Spiderpool network resources.
+        nodeSelector:
+          matchLabels:
+            kubernetes.io/os: linux
+        ## Example:
+        # matchLabels:
+        #   kubernetes.io/os: linux
+      resourceAdvertisement:
+        subENI:
+          ## @param spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.subENI.rules auxiliary ENI slot advertisement rules.
+          rules:
+            - resourceName: spidernet.io/sub-eni
+              defaultMaxCount: 256
+              nodeSelector:
+                matchLabels:
+                  kubernetes.io/os: linux
+          ## Example:
+          # - resourceName: spidernet.io/sub-eni
+          #   defaultMaxCount: 256
+          #   nodeSelector:
+          #     matchLabels:
+          #       kubernetes.io/os: linux
+        masterNIC:
+          ## @param spiderpoolAgent.networkResourcePlugin.resourceAdvertisement.masterNIC.rules node/interface selection rules for advertised master NIC resources.
+          rules:
+            - defaultMaxCount: 10000
+              nodeSelector:
+                matchLabels:
+                  kubernetes.io/os: linux
+              includeInterfaces:
+                - eth*
+              excludeInterfaces: []
+          # - nodeSelector:
+          #     matchLabels:
+          #       kubernetes.io/os: linux
+          #   defaultMaxCount: 10000
+          #   includeInterfaces:
+          #     - eth*
+          #   excludeInterfaces: []
     ## @param spiderpoolAgent.securityContext the security Context of spiderpoolAgent pod
     securityContext: {}
     # runAsUser: 0
@@ -438,7 +487,7 @@ spiderpool:
       ## @param spiderpoolController.image.digest the image digest of spiderpoolController, which takes preference over tag
       digest: ""
       ## @param spiderpoolController.image.tag the image tag of spiderpoolController, overrides the image tag whose default is the chart appVersion.
-      tag: v1.2.0
+      tag: v1.2.2
       ## @param spiderpoolController.image.imagePullSecrets the image imagePullSecrets of spiderpoolController
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -654,7 +703,7 @@ spiderpool:
       ## @param spiderpoolInit.image.digest the image digest of spiderpoolInit, which takes preference over tag
       digest: ""
       ## @param spiderpoolInit.image.tag the image tag of spiderpoolInit, overrides the image tag whose default is the chart appVersion.
-      tag: v1.2.0
+      tag: v1.2.2
       ## @param spiderpoolInit.image.imagePullSecrets the image imagePullSecrets of spiderpoolInit
       imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -839,3 +888,5 @@ spiderpool:
   iaasNetworkProvider:
     ## @param iaasNetworkProvider.serverUrl the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.
     serverUrl: ""
+    ## @param iaasNetworkProvider.httpRequestTimeout the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin.
+    httpRequestTimeout: "50s"

--- a/test/spiderpool/install.sh
+++ b/test/spiderpool/install.sh
@@ -50,6 +50,7 @@ helm install spiderpool chart-museum/spiderpool ${HELM_MUST_OPTION} \
   --set rdma.rdmaSharedDevicePlugin.install=true \
   --set plugins.installCNI=true --set plugins.installRdmaCNI=true --set plugins.installOvsCNI=true \
   --set spiderpool.ipam.enableIPv4=true --set spiderpool.ipam.enableIPv6=true \
+  --set spiderpool.spiderpoolAgent.networkResourcePlugin.enabled=true \
   --set spiderpool.clusterDefaultPool.installIPv4IPPool=true --set spiderpool.clusterDefaultPool.installIPv6IPPool=true \
   --set spiderpool.clusterDefaultPool.ipv4Subnet=${Ipv4Subnet} --set spiderpool.clusterDefaultPool.ipv4IPRanges={${Ipv4Range}} --set spiderpool.clusterDefaultPool.ipv4Gateway=${Ipv4GW} \
   --set spiderpool.clusterDefaultPool.ipv6Subnet=${Ipv6Subnet} --set spiderpool.clusterDefaultPool.ipv6IPRanges={${Ipv6Range}} --set spiderpool.clusterDefaultPool.ipv6Gateway=${Ipv6GW}


### PR DESCRIPTION
- bump chart and app versions to 1.2.2
- update plugins image tag to 87fd4a400858705c208d5a4b7059423b33a551aa
- add networkResourcePlugin configuration with device plugin affinity and resource advertisement rules for subENI and masterNIC
- set default nodeSelector kubernetes.io/os=linux for network resource plugin
- add coordinator policyRoutes and vethMTU configuration options
- add iaasNetworkProvider httpRequestTimeout parameter (default 50s)
- add vlanMode field to v

<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #