### PR TITLE
update iaas-network-provider to v0.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Instructions
+
+## Chart Upgrade Workflow
+
+- For every chart upgrade or new chart, update the chart source `config` first, then run `make build_chart PROJECT=<chart-name>` to regenerate the packaged chart content.
+- After regeneration, check that the generated `charts/<chart-name>/<chart-name>/values.yaml` is consistent with `charts/<chart-name>/<chart-name>/values.schema.json`. If generated values changed and the schema does not match, update the schema accordingly.
+- Review `test/<chart-name>/install.sh` for version-specific settings, renamed values, required install flags, or runtime assumptions introduced by the upgraded chart, and update the test script when needed.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,4 @@
 /Makefile @weizhoublue
 /Makefile.defs @weizhoublue
 /README.md @weizhoublue
+/AGENTS.md @weizhoublue @cyclinder

--- a/charts/iaas-network-provider/config
+++ b/charts/iaas-network-provider/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=oci://ghcr.io/daocloud/charts/iaas-network-provider
 export REPO_NAME=iaas-network-provider
 export CHART_NAME=iaas-network-provider
-export VERSION=0.1.0-rc1
+export VERSION=0.1.0
 export IS_OCI_REPO=true
 export OCI_CHART_REF=oci://ghcr.io/daocloud/charts/iaas-network-provider
 

--- a/charts/iaas-network-provider/iaas-network-provider/Chart.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 0.1.0-rc1
+appVersion: 0.1.0
 description: IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 name: iaas-network-provider
 type: application
-version: 0.1.0-rc1
+version: 0.1.0
 dependencies:
   - name: iaas-network-provider
-    version: "0.1.0-rc1"
+    version: "0.1.0"
     repository: "oci://ghcr.io/daocloud/charts"
 keywords:
   - kubernetes

--- a/charts/iaas-network-provider/iaas-network-provider/README.md
+++ b/charts/iaas-network-provider/iaas-network-provider/README.md
@@ -1,6 +1,6 @@
 # iaas-network-provider
 
-![Version: 0.1.0-rc1](https://img.shields.io/badge/Version-0.1.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0-rc1](https://img.shields.io/badge/AppVersion-0.1.0--rc1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 
@@ -8,7 +8,7 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://ghcr.io/daocloud/charts | iaas-network-provider | 0.1.0-rc1 |
+| oci://ghcr.io/daocloud/charts | iaas-network-provider | 0.1.0 |
 
 ## Values
 
@@ -33,6 +33,7 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 | iaas-network-provider.config.iaasProvider.auth.token.username | string | `""` |  |
 | iaas-network-provider.config.iaasProvider.ecsEndpoint | string | `""` |  |
 | iaas-network-provider.config.iaasProvider.endpoint | string | `""` |  |
+| iaas-network-provider.config.iaasProvider.httpRequestTimeout | string | `"30s"` |  |
 | iaas-network-provider.config.iaasProvider.projectID | string | `""` |  |
 | iaas-network-provider.config.iaasProvider.projectName | string | `""` |  |
 | iaas-network-provider.config.iaasProvider.provider | string | `"huaweicloud"` |  |
@@ -48,6 +49,8 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 | iaas-network-provider.config.leaderElection.renewDeadlineSeconds | int | `40` |  |
 | iaas-network-provider.config.leaderElection.retryPeriodSeconds | int | `15` |  |
 | iaas-network-provider.config.logLevel | string | `"info"` |  |
+| iaas-network-provider.config.pprof.bindAddress | string | `":6060"` |  |
+| iaas-network-provider.config.pprof.enabled | bool | `false` |  |
 | iaas-network-provider.config.rateLimit.maxTransactionTimeoutSeconds | int | `16` |  |
 | iaas-network-provider.config.rateLimit.qps | int | `2` |  |
 | iaas-network-provider.config.rateLimit.queueTimeoutSeconds | int | `30` |  |
@@ -57,7 +60,7 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 | iaas-network-provider.image.pullPolicy | string | `"IfNotPresent"` |  |
 | iaas-network-provider.image.registry | string | `"ghcr.m.daocloud.io"` |  |
 | iaas-network-provider.image.repository | string | `"daocloud/iaas-network-provider/controller"` |  |
-| iaas-network-provider.image.tag | string | `"v0.1.0-rc1"` |  |
+| iaas-network-provider.image.tag | string | `"v0.1.0"` |  |
 | iaas-network-provider.nodeSelector | object | `{}` |  |
 | iaas-network-provider.replicaCount | int | `1` |  |
 | iaas-network-provider.resources.limits.cpu | string | `"500m"` |  |

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/Chart.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.1.0-rc1
+appVersion: 0.1.0
 description: IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 name: iaas-network-provider
 type: application
-version: 0.1.0-rc1
+version: 0.1.0

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/README.md
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/README.md
@@ -1,6 +1,6 @@
 # iaas-network-provider
 
-![Version: 0.1.0-rc1](https://img.shields.io/badge/Version-0.1.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0-rc1](https://img.shields.io/badge/AppVersion-0.1.0--rc1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 
@@ -27,6 +27,7 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 | config.iaasProvider.auth.token.username | string | `""` |  |
 | config.iaasProvider.ecsEndpoint | string | `""` |  |
 | config.iaasProvider.endpoint | string | `""` |  |
+| config.iaasProvider.httpRequestTimeout | string | `"30s"` |  |
 | config.iaasProvider.projectID | string | `""` |  |
 | config.iaasProvider.projectName | string | `""` |  |
 | config.iaasProvider.provider | string | `"huaweicloud"` |  |
@@ -42,6 +43,8 @@ IaaS Network Provider — IPAM bridge between Spiderpool and Huawei Cloud
 | config.leaderElection.renewDeadlineSeconds | int | `40` |  |
 | config.leaderElection.retryPeriodSeconds | int | `15` |  |
 | config.logLevel | string | `"info"` |  |
+| config.pprof.bindAddress | string | `":6060"` |  |
+| config.pprof.enabled | bool | `false` |  |
 | config.rateLimit.maxTransactionTimeoutSeconds | int | `16` |  |
 | config.rateLimit.qps | int | `2` |  |
 | config.rateLimit.queueTimeoutSeconds | int | `30` |  |

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/_helpers.tpl
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/_helpers.tpl
@@ -68,6 +68,21 @@ ServiceAccount name
 {{- end }}
 
 {{/*
+Parse the numeric TCP port from config.pprof.bindAddress for containerPort.
+Supports ":6060", "0.0.0.0:7070", and "127.0.0.1:6060".
+*/}}
+{{- define "iaas-network-provider.pprofPort" -}}
+{{- $addr := .Values.config.pprof.bindAddress | trim -}}
+{{- if hasPrefix ":" $addr -}}
+{{- trimPrefix ":" $addr -}}
+{{- else if contains ":" $addr -}}
+{{- (splitList ":" $addr | last) -}}
+{{- else -}}
+{{- $addr -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate required chart values and fail fast on empty inputs.
 */}}
 {{- define "iaas-network-provider.validateValues" -}}
@@ -88,5 +103,12 @@ Validate required chart values and fail fast on empty inputs.
 {{- $_ := required "values.config.iaasProvider.auth.aksk.credentialsSecret is required when auth.mode=ak-sk" .Values.config.iaasProvider.auth.aksk.credentialsSecret -}}
 {{- else -}}
 {{- fail (printf "values.config.iaasProvider.auth.mode must be either \"token\" or \"ak-sk\", got %q" .Values.config.iaasProvider.auth.mode) -}}
+{{- end -}}
+
+{{- if .Values.config.pprof.enabled -}}
+{{- $port := include "iaas-network-provider.pprofPort" . -}}
+{{- if or (not $port) (not (regexMatch "^[0-9]+$" $port)) (lt (int $port) 1) (gt (int $port) 65535) -}}
+{{- fail (printf "config.pprof.bindAddress %q must contain a valid TCP port (1-65535) when pprof.enabled=true" .Values.config.pprof.bindAddress) -}}
+{{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/configmap.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
         enabled: {{ .Values.tls.enabled }}
         certFile: "{{ .Values.config.tls.certFile }}"
         keyFile: "{{ .Values.config.tls.keyFile }}"
+    pprof:
+      enabled: {{ .Values.config.pprof.enabled }}
+      bindAddress: "{{ .Values.config.pprof.bindAddress }}"
     k8sClientConfig:
       qps: {{ .Values.config.k8sClientConfig.qps }}
       burst: {{ .Values.config.k8sClientConfig.burst }}
@@ -40,6 +43,7 @@ data:
       projectName: "{{ .Values.config.iaasProvider.projectName }}"
       vpcEndpoint: "{{ .Values.config.iaasProvider.vpcEndpoint }}"
       ecsEndpoint: "{{ .Values.config.iaasProvider.ecsEndpoint }}"
+      httpRequestTimeout: "{{ .Values.config.iaasProvider.httpRequestTimeout }}"
       securityGroups:
       {{- range .Values.config.iaasProvider.securityGroups }}
         - {{ . }}

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/deployment.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/templates/deployment.yaml
@@ -45,6 +45,11 @@ spec:
             - name: {{ ternary "https" "http" .Values.tls.enabled }}
               containerPort: {{ ternary 8443 8080 .Values.tls.enabled }}
               protocol: TCP
+            {{- if .Values.config.pprof.enabled }}
+            - name: pprof
+              containerPort: {{ include "iaas-network-provider.pprofPort" . }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /v1/apis/network.iaas.io/healthz

--- a/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/values.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/charts/iaas-network-provider/values.yaml
@@ -37,6 +37,10 @@ service:
 config:
   logLevel: info
   bindAddress: ":8443"   # 监听端口，tls.enabled=true -> 8443 HTTPS, tls.enabled=false-> 8080 HTTP
+  # pprof 性能分析，用于性能优化和调试
+  pprof:
+    enabled: false
+    bindAddress: ":6060" # 同时决定 pprof 进程监听端口与 Deployment containerPort（named port: pprof）
   # 证书挂载路径（容器内路径）
   tls:
     certFile: /etc/iaas-network-provider/tls/tls.crt
@@ -70,6 +74,7 @@ config:
     projectName: ""
     vpcEndpoint: ""
     ecsEndpoint: ""
+    httpRequestTimeout: "30s"  # Single cloud API HTTP round-trip timeout
     # securityGroups:
     #   - securityGroupID1
     securityGroups: []

--- a/charts/iaas-network-provider/iaas-network-provider/values.schema.json
+++ b/charts/iaas-network-provider/iaas-network-provider/values.schema.json
@@ -37,7 +37,7 @@
               "type": "string",
               "title": "Image tag",
               "description": "Container image tag. If empty in the child chart, the chart defaults to v + appVersion.",
-              "default": "v0.1.0-rc1"
+              "default": "v0.1.0"
             }
           }
         },

--- a/charts/iaas-network-provider/iaas-network-provider/values.yaml
+++ b/charts/iaas-network-provider/iaas-network-provider/values.yaml
@@ -4,7 +4,7 @@ iaas-network-provider:
   image:
     registry: ghcr.m.daocloud.io
     repository: daocloud/iaas-network-provider/controller
-    tag: "v0.1.0-rc1"
+    tag: "v0.1.0"
     pullPolicy: IfNotPresent
   serviceAccount:
     create: true
@@ -33,6 +33,10 @@ iaas-network-provider:
   config:
     logLevel: info
     bindAddress: ":8443" # 监听端口，tls.enabled=true -> 8443 HTTPS, tls.enabled=false-> 8080 HTTP
+    # pprof 性能分析，用于性能优化和调试
+    pprof:
+      enabled: false
+      bindAddress: ":6060" # 同时决定 pprof 进程监听端口与 Deployment containerPort（named port: pprof）
     # 证书挂载路径（容器内路径）
     tls:
       certFile: /etc/iaas-network-provider/tls/tls.crt
@@ -66,6 +70,7 @@ iaas-network-provider:
       projectName: ""
       vpcEndpoint: ""
       ecsEndpoint: ""
+      httpRequestTimeout: "30s" # Single cloud API HTTP round-trip timeout
       # securityGroups:
       #   - securityGroupID1
       securityGroups: []

--- a/charts/iaas-network-provider/parent/values.schema.json
+++ b/charts/iaas-network-provider/parent/values.schema.json
@@ -37,7 +37,7 @@
               "type": "string",
               "title": "Image tag",
               "description": "Container image tag. If empty in the child chart, the chart defaults to v + appVersion.",
-              "default": "v0.1.0-rc1"
+              "default": "v0.1.0"
             }
           }
         },


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #