### PR TITLE
ci: avoid unsafe fork PR checkout

### DIFF
--- a/.github/workflows/call-e2e.yml
+++ b/.github/workflows/call-e2e.yml
@@ -19,7 +19,8 @@ on:
         required: true
         type: string
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   e2e:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,12 @@ env:
   IMAGE_HINT_FILE_NAME: ".relok8s-images.yaml"
   SCHEMA_FILE_NAME: "values.schema.json"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -16,8 +20,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: check chart config
         run : |
@@ -62,15 +64,12 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
           
       - name: check change
         id: check_change
         run: |
           set -x
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
+          # Use the GitHub API because git merge-base is unreliable when the branch is behind
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
           files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
           echo "files_changed_data: $files_changed_data"
@@ -260,7 +259,6 @@ jobs:
     with:
       project: ${{ needs.check_change.outputs.project }}
       ref: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit
 
 #  nofity_version_changed:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pull-requests: read
 
+# PR code is untrusted; run it without pull_request_target privileges.
 on:
   pull_request:
     branches:

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -1,7 +1,11 @@
 name: 'Update PR'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -37,13 +41,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          ref: ${{github.event.pull_request.head.ref}}
           path: thisPorject
 
       - name: Execute readme-generator-for-helm
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
+          # Use the GitHub API because git merge-base is unreliable when the branch is behind
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
           files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
           echo "files_changed_data: $files_changed_data"

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   pull-requests: read
 
+# PR code is untrusted; run it without pull_request_target privileges.
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary

- run PR code checks with `pull_request`, not `pull_request_target`
- remove explicit fork-head checkout from PR workflows
- restrict reusable E2E workflow permissions to read-only

The existing `pull_request_target` workflow on `main` refuses fork PR checkout before any job starts. This change must be merged into `main` before PR #4418 can pass; the kcover PR already contains the corresponding workflow changes, but target workflows are loaded from the base branch.

Related PR: #4418