### PR TITLE
feat: add chart for kcover(-metax)

### DIFF
--- a/charts/kcover-metax/config
+++ b/charts/kcover-metax/config
@@ -1,0 +1,18 @@
+export USE_OPENSOURCE_CHART=false
+
+# must
+export REPO_URL=https://baizeai.github.io/charts
+export REPO_NAME=kcover
+export CHART_NAME=kcover
+# The upstream dependency remains kcover; custom.sh publishes this package as kcover-metax.
+export VERSION=0.12.0
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=izturn
+export TEST_ASSIGNER=liyuerich
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+export CUSTOM_SHELL=custom.sh
+export NO_TRIVY=true

--- a/charts/kcover-metax/config
+++ b/charts/kcover-metax/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://baizeai.github.io/charts
 export REPO_NAME=kcover
 export CHART_NAME=kcover
-# The upstream dependency remains kcover; custom.sh publishes this package as kcover-metax.
+# The upstream chart remains kcover; the published MetaX variant uses chart name kcover-metax.
 export VERSION=0.12.0
 
 # pr, issue, none

--- a/charts/kcover-metax/custom.sh
+++ b/charts/kcover-metax/custom.sh
@@ -16,11 +16,11 @@ APP_VERSION=$(yq e '.appVersion' Chart.yaml)
 
 yq e -i '
   .annotations |= ((. // {}) + {
-    "addon.kpanda.io/release-name": "kcover-metax",
+    "addon.kpanda.io/release-name": "kcover",
     "addon.kpanda.io/namespace": "kcover-system"
   }) |
   .name = "kcover-metax" |
-  .keywords = (["kcover-metax", "kcover"] + (.keywords // []) | unique)
+  .keywords = (["kcover", "kcover-metax"] + (.keywords // []) | unique)
 ' Chart.yaml
 
 yq e -i '
@@ -29,6 +29,7 @@ yq e -i '
   .kcover.agent.flavor = "metax" |
   .kcover.agent.image.repository = "baizeai/kcover-agent-metax" |
   .kcover.agent.image.tag = strenv(APP_VERSION) |
+  .kcover.agent.nodeSelector = {"kubernetes.io/arch": "amd64"} |
   .kcover.controller.image.registry = "ghcr.m.daocloud.io" |
   .kcover.controller.image.tag = strenv(APP_VERSION) |
   .kcover.agent.resources = {
@@ -41,13 +42,17 @@ yq e -i '
   }
 ' values.yaml
 
-yq e -i '.properties.kcover.properties.agent.properties.flavor.default = "metax"' values.schema.json
+yq e -o=json -i '.properties.kcover.properties.agent.properties.flavor.default = "metax" | .properties.kcover.properties.agent.properties.flavor.enum = ["metax"]' values.schema.json
+jq -c . values.schema.json > values.schema.json.tmp && mv values.schema.json.tmp values.schema.json
 
 yq e -i '
   .agent.flavor = "metax" |
   .agent.image.registry = "ghcr.m.daocloud.io" |
   .agent.image.repository = "baizeai/kcover-agent-metax" |
-  .agent.image.tag = strenv(APP_VERSION)
+  .agent.image.tag = strenv(APP_VERSION) |
+  .agent.nodeSelector = {"kubernetes.io/arch": "amd64"}
 ' charts/kcover/values.yaml
 
-yq e -i '.properties.agent.properties.flavor.default = "metax"' charts/kcover/values.schema.json
+yq e -o=json -i '.properties.agent.properties.flavor.default = "metax" | .properties.agent.properties.flavor.enum = ["metax"]' charts/kcover/values.schema.json
+jq -c . charts/kcover/values.schema.json > charts/kcover/values.schema.json.tmp && mv charts/kcover/values.schema.json.tmp charts/kcover/values.schema.json
+sed -i -e 's/# Agent deployment flavor. Supported values: base, metax./# Agent deployment flavor for this MetaX chart. Only metax is supported./' -e '/# base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image/d' -e '/# and enables MetaX-only host mounts./d' values.yaml charts/kcover/values.yaml

--- a/charts/kcover-metax/custom.sh
+++ b/charts/kcover-metax/custom.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CHART_DIRECTORY=${1:-}
+[ -n "${CHART_DIRECTORY}" ] || { echo "custom shell: error, empty CHART_DIRECTORY"; exit 1; }
+[ -d "${CHART_DIRECTORY}" ] || { echo "custom shell: error, missing CHART_DIRECTORY ${CHART_DIRECTORY}"; exit 1; }
+
+cd "${CHART_DIRECTORY}"
+echo "custom shell: CHART_DIRECTORY ${CHART_DIRECTORY}"
+
+export APP_VERSION
+APP_VERSION=$(yq e '.appVersion' Chart.yaml)
+[ -n "${APP_VERSION}" ] && [ "${APP_VERSION}" != "null" ] \
+  || { echo "custom shell: error, missing appVersion in Chart.yaml"; exit 1; }
+
+yq e -i '
+  .annotations |= ((. // {}) + {
+    "addon.kpanda.io/release-name": "kcover-metax",
+    "addon.kpanda.io/namespace": "kcover-system"
+  }) |
+  .name = "kcover-metax" |
+  .keywords = (["kcover-metax", "kcover"] + (.keywords // []) | unique)
+' Chart.yaml
+
+yq e -i '
+  .kcover.global.imageRegistry = "ghcr.m.daocloud.io" |
+  .kcover.agent.image.registry = "ghcr.m.daocloud.io" |
+  .kcover.agent.flavor = "metax" |
+  .kcover.agent.image.repository = "baizeai/kcover-agent-metax" |
+  .kcover.agent.image.tag = strenv(APP_VERSION) |
+  .kcover.controller.image.registry = "ghcr.m.daocloud.io" |
+  .kcover.controller.image.tag = strenv(APP_VERSION) |
+  .kcover.agent.resources = {
+    "limits": {"cpu": "1", "memory": "1Gi"},
+    "requests": {"cpu": "100m", "memory": "256Mi"}
+  } |
+  .kcover.controller.resources = {
+    "limits": {"cpu": "1", "memory": "1Gi"},
+    "requests": {"cpu": "100m", "memory": "256Mi"}
+  }
+' values.yaml
+
+yq e -i '.properties.kcover.properties.agent.properties.flavor.default = "metax"' values.schema.json
+
+yq e -i '
+  .agent.flavor = "metax" |
+  .agent.image.registry = "ghcr.m.daocloud.io" |
+  .agent.image.repository = "baizeai/kcover-agent-metax" |
+  .agent.image.tag = strenv(APP_VERSION)
+' charts/kcover/values.yaml
+
+yq e -i '.properties.agent.properties.flavor.default = "metax"' charts/kcover/values.schema.json

--- a/charts/kcover-metax/custom.sh
+++ b/charts/kcover-metax/custom.sh
@@ -55,4 +55,5 @@ yq e -i '
 
 yq e -o=json -i '.properties.agent.properties.flavor.default = "metax" | .properties.agent.properties.flavor.enum = ["metax"]' charts/kcover/values.schema.json
 jq -c . charts/kcover/values.schema.json > charts/kcover/values.schema.json.tmp && mv charts/kcover/values.schema.json.tmp charts/kcover/values.schema.json
-sed -i -e 's/# Agent deployment flavor. Supported values: base, metax./# Agent deployment flavor for this MetaX chart. Only metax is supported./' -e '/# base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image/d' -e '/# and enables MetaX-only host mounts./d' values.yaml charts/kcover/values.yaml
+sed -i.bak -e 's/# Agent deployment flavor. Supported values: base, metax./# Agent deployment flavor for this MetaX chart. Only metax is supported./' -e '/# base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image/d' -e '/# and enables MetaX-only host mounts./d' values.yaml charts/kcover/values.yaml
+rm -f values.yaml.bak charts/kcover/values.yaml.bak

--- a/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
+++ b/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
@@ -1,4 +1,4 @@
-# MetaX agent v0.12.0 is amd64-only; the chart defaults agent scheduling to amd64 nodes.
+# MetaX agent is amd64-only; the chart defaults agent scheduling to amd64 nodes.
 # Offline packaging scope: this MetaX bundle contains controller and MetaX
 # agent images. agent.flavor=metax is the default for this variant.
 - "{{ .kcover.controller.image.registry }}/{{ .kcover.controller.image.repository }}:{{ .kcover.controller.image.tag }}"

--- a/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
+++ b/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
@@ -1,3 +1,4 @@
+# MetaX agent v0.12.0 is amd64-only; the chart defaults agent scheduling to amd64 nodes.
 # Offline packaging scope: this MetaX bundle contains controller and MetaX
 # agent images. agent.flavor=metax is the default for this variant.
 - "{{ .kcover.controller.image.registry }}/{{ .kcover.controller.image.repository }}:{{ .kcover.controller.image.tag }}"

--- a/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
+++ b/charts/kcover-metax/kcover-metax/.relok8s-images.yaml
@@ -1,0 +1,4 @@
+# Offline packaging scope: this MetaX bundle contains controller and MetaX
+# agent images. agent.flavor=metax is the default for this variant.
+- "{{ .kcover.controller.image.registry }}/{{ .kcover.controller.image.repository }}:{{ .kcover.controller.image.tag }}"
+- "{{ .kcover.agent.image.registry }}/baizeai/kcover-agent-metax:{{ .kcover.agent.image.tag }}"

--- a/charts/kcover-metax/kcover-metax/Chart.yaml
+++ b/charts/kcover-metax/kcover-metax/Chart.yaml
@@ -10,8 +10,8 @@ dependencies:
     version: "0.12.0"
     repository: "https://baizeai.github.io/charts"
 annotations:
-  addon.kpanda.io/release-name: kcover-metax
+  addon.kpanda.io/release-name: kcover
   addon.kpanda.io/namespace: kcover-system
 keywords:
-  - kcover-metax
   - kcover
+  - kcover-metax

--- a/charts/kcover-metax/kcover-metax/Chart.yaml
+++ b/charts/kcover-metax/kcover-metax/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: v0.12.0
+description: A Helm chart for Kubernetes
+kubeVersion: '>=1.25.0-0'
+name: kcover-metax
+type: application
+version: 0.12.0
+dependencies:
+  - name: kcover
+    version: "0.12.0"
+    repository: "https://baizeai.github.io/charts"
+annotations:
+  addon.kpanda.io/release-name: kcover-metax
+  addon.kpanda.io/namespace: kcover-system
+keywords:
+  - kcover-metax
+  - kcover

--- a/charts/kcover-metax/kcover-metax/charts/kcover/.helmignore
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kcover-metax/kcover-metax/charts/kcover/Chart.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+appVersion: v0.12.0
+description: A Helm chart for Kubernetes
+kubeVersion: '>=1.25.0-0'
+name: kcover
+type: application
+version: 0.12.0

--- a/charts/kcover-metax/kcover-metax/charts/kcover/crds/preflightreports.kcover.io.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/crds/preflightreports.kcover.io.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: preflightreports.kcover.io
+spec:
+  group: kcover.io
+  names:
+    kind: PreflightReport
+    listKind: PreflightReportList
+    plural: preflightreports
+    shortNames:
+      - pfr
+    singular: preflightreport
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Workload
+          type: string
+          jsonPath: .spec.workloadName
+        - name: Node
+          type: string
+          jsonPath: .spec.nodeName
+        - name: Rank
+          type: integer
+          jsonPath: .spec.rank
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              x-kubernetes-validations:
+                - rule: self == oldSelf
+                  message: PreflightReport spec is immutable
+              required:
+                - workloadName
+                - workloadUID
+                - nodeName
+                - rank
+                - report
+                - observedAt
+              properties:
+                workloadName:
+                  type: string
+                  minLength: 1
+                workloadUID:
+                  type: string
+                  minLength: 1
+                nodeName:
+                  type: string
+                  minLength: 1
+                rank:
+                  type: integer
+                  format: int32
+                  minimum: 0
+                report:
+                  type: string
+                  minLength: 2
+                observedAt:
+                  type: string
+                  format: date-time

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/_common.tpl
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/_common.tpl
@@ -1,0 +1,21 @@
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .defaultTag  -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if .imageRoot.registry }}
+    {{- $registryName = .imageRoot.registry  -}}
+{{- end -}}
+{{- if .imageRoot.tag }}
+    {{- $tag = .imageRoot.tag  -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/_helpers.tpl
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kcover.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kcover.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kcover.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kcover.labels" -}}
+helm.sh/chart: {{ include "kcover.chart" . }}
+{{ include "kcover.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kcover.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kcover.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Create the name of the agent service account to use. */}}
+{{- define "kcover.agentServiceAccountName" -}}
+{{- default (printf "%s-agent" (include "kcover.fullname" .) | trunc 63 | trimSuffix "-") .Values.agent.serviceAccount.name -}}
+{{- end }}
+
+{{/* Create the name of the controller service account to use. */}}
+{{- define "kcover.controllerServiceAccountName" -}}
+{{- default (printf "%s-controller" (include "kcover.fullname" .) | trunc 63 | trimSuffix "-") .Values.controller.serviceAccount.name -}}
+{{- end }}
+
+{{- define "controller.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global "defaultTag" .Chart.AppVersion) }}
+{{- end -}}
+
+{{- define "kcover.agentFlavor" -}}
+{{- $flavor := default "base" .Values.agent.flavor -}}
+{{- if not (or (eq $flavor "base") (eq $flavor "metax")) -}}
+{{- fail (printf "unsupported agent.flavor %q: supported values are base and metax" $flavor) -}}
+{{- end -}}
+{{- $flavor -}}
+{{- end -}}
+
+{{- define "agent.image" -}}
+{{- $flavor := include "kcover.agentFlavor" . -}}
+{{- $repository := .Values.agent.image.repository -}}
+{{- if not $repository -}}
+  {{- if eq $flavor "metax" -}}
+    {{- $repository = "baizeai/kcover-agent-metax" -}}
+  {{- else -}}
+    {{- $repository = "baizeai/kcover-agent" -}}
+  {{- end -}}
+{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" (dict "registry" .Values.agent.image.registry "repository" $repository "tag" .Values.agent.image.tag) "global" .Values.global "defaultTag" .Chart.AppVersion) }}
+{{- end -}}
+
+{{- define "kcover.agentConfigMapName" -}}
+{{- if .Values.agent.config.existingConfigMap -}}
+{{- .Values.agent.config.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-agent-config" (include "kcover.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-clusterrole.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kcover.fullname" . }}-agent
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: ["kcover.io"]
+    resources: ["preflightreports"]
+    verbs: ["create"]

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-clusterrolebinding.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kcover.fullname" . }}-agent
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kcover.fullname" . }}-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kcover.agentServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-configmap.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/agent-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.agent.config.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kcover.agentConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+data:
+  {{ base .Values.agent.config.path }}: |
+    {{- $config := dict }}
+    {{- if eq (include "kcover.agentFlavor" .) "metax" }}
+    {{- $config = deepCopy .Values.agent.flavors.metax.config }}
+    {{- end }}
+    {{- $config = mergeOverwrite $config (deepCopy .Values.agent.config.data) }}
+{{ toYaml $config | indent 4 }}
+{{- end }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/controller-clusterrole.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/controller-clusterrole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kcover.fullname" . }}-controller
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "deletecollection"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["kcover.io"]
+    resources: ["preflightreports"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kubeflow.org"]
+    resources: ["pytorchjobs", "tfjobs"]
+    verbs: ["get"]

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/controller-clusterrolebinding.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/controller-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kcover.fullname" . }}-controller
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kcover.fullname" . }}-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kcover.controllerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/daemonset.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/daemonset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "kcover.fullname" . }}-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "kcover.fullname" . }}-agent
+  template:
+    metadata:
+      {{- $podLabels := deepCopy (default dict .Values.agent.podLabels) }}
+      {{- $_ := set $podLabels "app" (printf "%s-agent" (include "kcover.fullname" .)) }}
+      {{- with .Values.agent.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- toYaml $podLabels | nindent 8 }}
+    spec:
+      {{- with .Values.agent.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kcover.agentServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          securityContext:
+            {{- $securityContext := deepCopy .Values.agent.securityContext }}
+            {{- if eq (include "kcover.agentFlavor" .) "metax" }}
+            {{- $securityContext = mergeOverwrite $securityContext .Values.agent.flavors.metax.securityContext }}
+            {{- end }}
+            {{- toYaml $securityContext | nindent 12 }}
+          image: {{ template "agent.image" . }}
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          args:
+            - --config={{ .Values.agent.config.path }}
+          {{- with .Values.agent.args }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            # NODE_NAME is the canonical env var. FAST_RECOVERY_NODE_NAME remains
+            # backward-compatible in code for older deployments during migration.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          resources:
+            {{- toYaml .Values.agent.resources | nindent 12 }}
+          volumeMounts:
+            - name: agent-config
+              mountPath: {{ dir .Values.agent.config.path }}
+              readOnly: true
+          {{- with .Values.agent.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if eq (include "kcover.agentFlavor" .) "metax" }}
+          {{- with .Values.agent.flavors.metax.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+      volumes:
+        - name: agent-config
+          configMap:
+            name: {{ include "kcover.agentConfigMapName" . }}
+        {{- with .Values.agent.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if eq (include "kcover.agentFlavor" .) "metax" }}
+        {{- with .Values.agent.flavors.metax.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/deployment.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kcover.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "kcover.fullname" . }}-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      {{- $podLabels := deepCopy (default dict .Values.controller.podLabels) }}
+      {{- $_ := set $podLabels "app" (printf "%s-controller" (include "kcover.fullname" .)) }}
+      {{- with .Values.controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- toYaml $podLabels | nindent 8 }}
+    spec:
+      {{- with .Values.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kcover.controllerServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: controller
+          image: {{ template "controller.image" . }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          {{- with .Values.controller.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.controller.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+            - --leader-elect={{ $.Values.controller.leaderElection.enabled }}
+          {{- end }}
+          {{- if not .Values.controller.args }}
+          args:
+            - --leader-elect={{ .Values.controller.leaderElection.enabled }}
+          {{- end }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/templates/serviceaccount.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kcover.agentServiceAccountName" . }}
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+  {{- with .Values.agent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kcover.controllerServiceAccountName" . }}
+  labels:
+    {{- include "kcover.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/values.schema.json
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/values.schema.json
@@ -1,1 +1,1 @@
-{"$schema": "https://json-schema.org/draft-07/schema#", "type": "object", "properties": {"agent": {"type": "object", "properties": {"flavor": {"type": "string", "enum": ["base", "metax"], "default": "metax"}}}}}
+{"$schema":"https://json-schema.org/draft-07/schema#","type":"object","properties":{"agent":{"type":"object","properties":{"flavor":{"type":"string","enum":["metax"],"default":"metax"}}}}}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/values.schema.json
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/values.schema.json
@@ -1,0 +1,1 @@
+{"$schema": "https://json-schema.org/draft-07/schema#", "type": "object", "properties": {"agent": {"type": "object", "properties": {"flavor": {"type": "string", "enum": ["base", "metax"], "default": "metax"}}}}}

--- a/charts/kcover-metax/kcover-metax/charts/kcover/values.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/values.yaml
@@ -11,9 +11,7 @@ agent:
     # The name of the agent ServiceAccount. A name is generated when empty.
     name: ""
     annotations: {}
-  # Agent deployment flavor. Supported values: base, metax.
-  # base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image
-  # and enables MetaX-only host mounts.
+  # Agent deployment flavor for this MetaX chart. Only metax is supported.
   flavor: metax
   # Additional CLI args for kcover-agent process (for example: ["-v=2"]).
   # --config is always injected by the chart and does not need to be repeated here.
@@ -110,7 +108,8 @@ agent:
         - name: host-localtime
           mountPath: /etc/localtime
           readOnly: true
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   tolerations: []
   affinity: {}
 controller:

--- a/charts/kcover-metax/kcover-metax/charts/kcover/values.yaml
+++ b/charts/kcover-metax/kcover-metax/charts/kcover/values.yaml
@@ -1,0 +1,193 @@
+# Default values for kcover.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+fullnameOverride: ""
+nameOverride: ""
+global:
+  imageRegistry: ghcr.io
+agent:
+  serviceAccount:
+    # The name of the agent ServiceAccount. A name is generated when empty.
+    name: ""
+    annotations: {}
+  # Agent deployment flavor. Supported values: base, metax.
+  # base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image
+  # and enables MetaX-only host mounts.
+  flavor: metax
+  # Additional CLI args for kcover-agent process (for example: ["-v=2"]).
+  # --config is always injected by the chart and does not need to be repeated here.
+  # Default to info-only logs; set -v=2/-v=4 for debug details.
+  args:
+    - -v=0
+  config:
+    existingConfigMap: "" # 留空时自动创建；设置后直接挂载用户自定义 ConfigMap
+    path: /etc/kcover-agent/config.yaml
+    data: {}
+  image:
+    registry: 'ghcr.m.daocloud.io'
+    # Leave empty to select the default repository from agent.flavor.
+    repository: 'baizeai/kcover-agent-metax'
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.12.0"
+  imagePullSecrets: []
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  # fsGroup: 2000
+  securityContext:
+    privileged: false
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  # Additional volumes on the output agent DaemonSet definition.
+  volumes:
+    - name: preflight-report
+      hostPath:
+        path: /var/lib/kcover/preflight
+        type: DirectoryOrCreate
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+  # Additional volumeMounts on the output agent DaemonSet definition.
+  volumeMounts:
+    - name: preflight-report
+      mountPath: /var/lib/kcover/preflight
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
+
+  flavors:
+    metax:
+      # Automatically merged into agent.config.data when agent.flavor=metax.
+      config:
+        metaX:
+          hcaIDs: [] # 需要使用 ibv_devinfo 检查, 状态为 PORT_ACTIVE 的 HCA ID 列表，例如 ["mlx5_0", "mlx5_1"]
+          day2CheckTime: "10:00" # 每天检查时间，24 小时制 HH:MM
+          gpuNum: 8 # 最少可用 GPU 数量阈值
+          temperature: 85 # hotspot 温度上限，单位摄氏度
+          eccMaxCount: 64 # 每张卡允许的 Double Bit ECC 最大值
+      # The MetaX checks require privileged access to host devices.
+      securityContext:
+        privileged: true
+      # Additional host resources used only by the MetaX image.
+      volumes:
+        - name: infiniband
+          hostPath:
+            path: /dev/infiniband
+            type: DirectoryOrCreate
+        - name: host-localtime
+          hostPath:
+            path: /etc/localtime
+            type: File
+      volumeMounts:
+        - name: infiniband
+          mountPath: /dev/infiniband
+        - name: host-localtime
+          mountPath: /etc/localtime
+          readOnly: true
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+controller:
+  serviceAccount:
+    # The name of the controller ServiceAccount. A name is generated when empty.
+    name: ""
+    annotations: {}
+  leaderElection:
+    # Whether the controller should acquire and renew the Lease lock.
+    # Default is true and should be kept for HA or multi-replica deployments.
+    # Set to false only when you explicitly want a single controller instance
+    # to run without leader election.
+    enabled: true
+  image:
+    registry: ''
+    repository: baizeai/kcover-controller
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  replicas: 1
+  # Additional CLI args for kcover-controller process.
+  # The chart injects --leader-elect automatically from
+  # controller.leaderElection.enabled, so do not repeat it here.
+  # Default enables preflight aggregation with the standard timeout and keeps only essential info logs.
+  # Example for day2 debugging:
+  # args:
+  #   - --preflight-report-collection-timeout=30m
+  #   - -v=2
+  command:
+    - /app/kcover-controller
+  args:
+    - --preflight-report-collection-timeout=30m
+    - -v=0
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  # fsGroup: 2000
+  securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  # Additional volumes on the output Deployment definition.
+  volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/kcover-metax/kcover-metax/values.schema.json
+++ b/charts/kcover-metax/kcover-metax/values.schema.json
@@ -1,0 +1,1 @@
+{"$schema": "http://json-schema.org/schema#", "required": ["kcover"], "type": "object", "properties": {"kcover": {"type": "object", "properties": {"agent": {"type": "object", "properties": {"flavor": {"type": "string", "enum": ["base", "metax"], "default": "metax"}}}}}}}

--- a/charts/kcover-metax/kcover-metax/values.schema.json
+++ b/charts/kcover-metax/kcover-metax/values.schema.json
@@ -1,1 +1,1 @@
-{"$schema": "http://json-schema.org/schema#", "required": ["kcover"], "type": "object", "properties": {"kcover": {"type": "object", "properties": {"agent": {"type": "object", "properties": {"flavor": {"type": "string", "enum": ["base", "metax"], "default": "metax"}}}}}}}
+{"$schema":"http://json-schema.org/schema#","required":["kcover"],"type":"object","properties":{"kcover":{"type":"object","properties":{"agent":{"type":"object","properties":{"flavor":{"type":"string","enum":["metax"],"default":"metax"}}}}}}}

--- a/charts/kcover-metax/kcover-metax/values.yaml
+++ b/charts/kcover-metax/kcover-metax/values.yaml
@@ -1,0 +1,206 @@
+# child values
+kcover:
+  # Default values for kcover.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  fullnameOverride: ""
+  nameOverride: ""
+  global:
+    imageRegistry: ghcr.m.daocloud.io
+  agent:
+    serviceAccount:
+      # The name of the agent ServiceAccount. A name is generated when empty.
+      name: ""
+      annotations: {}
+    # Agent deployment flavor. Supported values: base, metax.
+    # base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image
+    # and enables MetaX-only host mounts.
+    flavor: metax
+    # Additional CLI args for kcover-agent process (for example: ["-v=2"]).
+    # --config is always injected by the chart and does not need to be repeated here.
+    # Default to info-only logs; set -v=2/-v=4 for debug details.
+    args:
+      - -v=0
+    config:
+      existingConfigMap: "" # 留空时自动创建；设置后直接挂载用户自定义 ConfigMap
+      path: /etc/kcover-agent/config.yaml
+      data: {}
+    image:
+      registry: 'ghcr.m.daocloud.io'
+      # Leave empty to select the default repository from agent.flavor.
+      repository: 'baizeai/kcover-agent-metax'
+      pullPolicy: IfNotPresent
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "v0.12.0"
+    imagePullSecrets: []
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    # fsGroup: 2000
+    securityContext:
+      privileged: false
+      # capabilities:
+      #   drop:
+      #   - ALL
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
+      # runAsUser: 1000
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+    # Additional volumes on the output agent DaemonSet definition.
+    volumes:
+      - name: preflight-report
+        hostPath:
+          path: /var/lib/kcover/preflight
+          type: DirectoryOrCreate
+    # - name: foo
+    #   secret:
+    #     secretName: mysecret
+    #     optional: false
+
+    # Additional volumeMounts on the output agent DaemonSet definition.
+    volumeMounts:
+      - name: preflight-report
+        mountPath: /var/lib/kcover/preflight
+    # - name: foo
+    #   mountPath: "/etc/foo"
+    #   readOnly: true
+
+    flavors:
+      metax:
+        # Automatically merged into agent.config.data when agent.flavor=metax.
+        config:
+          metaX:
+            hcaIDs: [] # 需要使用 ibv_devinfo 检查, 状态为 PORT_ACTIVE 的 HCA ID 列表，例如 ["mlx5_0", "mlx5_1"]
+            day2CheckTime: "10:00" # 每天检查时间，24 小时制 HH:MM
+            gpuNum: 8 # 最少可用 GPU 数量阈值
+            temperature: 85 # hotspot 温度上限，单位摄氏度
+            eccMaxCount: 64 # 每张卡允许的 Double Bit ECC 最大值
+        # The MetaX checks require privileged access to host devices.
+        securityContext:
+          privileged: true
+        # Additional host resources used only by the MetaX image.
+        volumes:
+          - name: infiniband
+            hostPath:
+              path: /dev/infiniband
+              type: DirectoryOrCreate
+          - name: host-localtime
+            hostPath:
+              path: /etc/localtime
+              type: File
+        volumeMounts:
+          - name: infiniband
+            mountPath: /dev/infiniband
+          - name: host-localtime
+            mountPath: /etc/localtime
+            readOnly: true
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  controller:
+    serviceAccount:
+      # The name of the controller ServiceAccount. A name is generated when empty.
+      name: ""
+      annotations: {}
+    leaderElection:
+      # Whether the controller should acquire and renew the Lease lock.
+      # Default is true and should be kept for HA or multi-replica deployments.
+      # Set to false only when you explicitly want a single controller instance
+      # to run without leader election.
+      enabled: true
+    image:
+      registry: 'ghcr.m.daocloud.io'
+      repository: baizeai/kcover-controller
+      pullPolicy: IfNotPresent
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "v0.12.0"
+    imagePullSecrets: []
+    replicas: 1
+    # Additional CLI args for kcover-controller process.
+    # The chart injects --leader-elect automatically from
+    # controller.leaderElection.enabled, so do not repeat it here.
+    # Default enables preflight aggregation with the standard timeout and keeps only essential info logs.
+    # Example for day2 debugging:
+    # args:
+    #   - --preflight-report-collection-timeout=30m
+    #   - -v=2
+    command:
+      - /app/kcover-controller
+    args:
+      - --preflight-report-collection-timeout=30m
+      - -v=0
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    # fsGroup: 2000
+    securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+    # Additional volumes on the output Deployment definition.
+    volumes: []
+    # - name: foo
+    #   secret:
+    #     secretName: mysecret
+    #     optional: false
+
+    # Additional volumeMounts on the output Deployment definition.
+    volumeMounts: []
+    # - name: foo
+    #   mountPath: "/etc/foo"
+    #   readOnly: true
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}

--- a/charts/kcover-metax/kcover-metax/values.yaml
+++ b/charts/kcover-metax/kcover-metax/values.yaml
@@ -12,9 +12,7 @@ kcover:
       # The name of the agent ServiceAccount. A name is generated when empty.
       name: ""
       annotations: {}
-    # Agent deployment flavor. Supported values: base, metax.
-    # base uses the generic multi-arch agent image; metax uses the MetaX-specific agent image
-    # and enables MetaX-only host mounts.
+    # Agent deployment flavor for this MetaX chart. Only metax is supported.
     flavor: metax
     # Additional CLI args for kcover-agent process (for example: ["-v=2"]).
     # --config is always injected by the chart and does not need to be repeated here.
@@ -117,7 +115,8 @@ kcover:
           - name: host-localtime
             mountPath: /etc/localtime
             readOnly: true
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/arch: amd64
     tolerations: []
     affinity: {}
   controller:

--- a/charts/kcover-metax/parent/.relok8s-images.yaml
+++ b/charts/kcover-metax/parent/.relok8s-images.yaml
@@ -1,3 +1,4 @@
+# MetaX agent is amd64-only; the chart defaults agent scheduling to amd64 nodes.
 # Offline packaging scope: this MetaX bundle contains controller and MetaX
 # agent images. agent.flavor=metax is the default for this variant.
 - "{{ .kcover.controller.image.registry }}/{{ .kcover.controller.image.repository }}:{{ .kcover.controller.image.tag }}"

--- a/charts/kcover-metax/parent/.relok8s-images.yaml
+++ b/charts/kcover-metax/parent/.relok8s-images.yaml
@@ -1,0 +1,4 @@
+# Offline packaging scope: this MetaX bundle contains controller and MetaX
+# agent images. agent.flavor=metax is the default for this variant.
+- "{{ .kcover.controller.image.registry }}/{{ .kcover.controller.image.repository }}:{{ .kcover.controller.image.tag }}"
+- "{{ .kcover.agent.image.registry }}/baizeai/kcover-agent-metax:{{ .kcover.agent.image.tag }}"

--- a/test/kcover-metax/install.sh
+++ b/test/kcover-metax/install.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 
 CURRENT_DIR_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 KIND_KUBECONFIG=${1:-}
+# Arguments: kubeconfig, kind cluster name, chart version.
 CHART_VERSION=${3:-}
 NAMESPACE=kcover-system
 RELEASE=kcover

--- a/test/kcover-metax/install.sh
+++ b/test/kcover-metax/install.sh
@@ -6,7 +6,7 @@ CURRENT_DIR_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 KIND_KUBECONFIG=${1:-}
 CHART_VERSION=${3:-}
 NAMESPACE=kcover-system
-RELEASE=kcover-metax
+RELEASE=kcover
 
 [ -f "${KIND_KUBECONFIG}" ] || { echo "error, failed to find kubeconfig ${KIND_KUBECONFIG}"; exit 1; }
 [ -n "${CHART_VERSION}" ] || { echo "error, failed to find chart version"; exit 1; }
@@ -17,7 +17,7 @@ diagnostics() {
   trap - ERR
   set +e
 
-  echo "kcover-metax installation diagnostics"
+  echo "kcover installation diagnostics"
   helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" status "${RELEASE}"
   kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" get all -o wide
   kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" get events --sort-by=.lastTimestamp
@@ -47,10 +47,10 @@ helm install "${RELEASE}" chart-museum/kcover-metax \
   --kubeconfig "${KIND_KUBECONFIG}"
 
 kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" \
-  rollout status deployment/kcover-metax-controller --timeout=5m
+  rollout status deployment/kcover-controller --timeout=5m
 kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" \
-  rollout status daemonset/kcover-metax-agent --timeout=5m
+  rollout status daemonset/kcover-agent --timeout=5m
 helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" status "${RELEASE}"
 
 trap - ERR
-echo "succeeded to deploy kcover-metax"
+echo "succeeded to deploy kcover"

--- a/test/kcover-metax/install.sh
+++ b/test/kcover-metax/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+CURRENT_DIR_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
+KIND_KUBECONFIG=${1:-}
+CHART_VERSION=${3:-}
+NAMESPACE=kcover-system
+RELEASE=kcover-metax
+
+[ -f "${KIND_KUBECONFIG}" ] || { echo "error, failed to find kubeconfig ${KIND_KUBECONFIG}"; exit 1; }
+[ -n "${CHART_VERSION}" ] || { echo "error, failed to find chart version"; exit 1; }
+
+diagnostics() {
+  local rc=${1:-1}
+
+  trap - ERR
+  set +e
+
+  echo "kcover-metax installation diagnostics"
+  helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" status "${RELEASE}"
+  kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" get all -o wide
+  kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" get events --sort-by=.lastTimestamp
+
+  exit "${rc}"
+}
+trap 'diagnostics "$?"' ERR
+
+echo "CURRENT_DIR_PATH: ${CURRENT_DIR_PATH}"
+echo "KIND_KUBECONFIG: ${KIND_KUBECONFIG}"
+echo "CHART_VERSION: ${CHART_VERSION}"
+echo "helm version: $(helm version)"
+
+helm repo update chart-museum --kubeconfig "${KIND_KUBECONFIG}"
+
+if helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" status "${RELEASE}" >/dev/null 2>&1; then
+  helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" uninstall "${RELEASE}"
+fi
+
+helm install "${RELEASE}" chart-museum/kcover-metax \
+  --version "${CHART_VERSION}" \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  --timeout 10m0s \
+  --wait \
+  --debug \
+  --kubeconfig "${KIND_KUBECONFIG}"
+
+kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" \
+  rollout status deployment/kcover-metax-controller --timeout=5m
+kubectl --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" \
+  rollout status daemonset/kcover-metax-agent --timeout=5m
+helm --kubeconfig "${KIND_KUBECONFIG}" -n "${NAMESPACE}" status "${RELEASE}"
+
+trap - ERR
+echo "succeeded to deploy kcover-metax"


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #