### PR TITLE
upgrade gateway-api to 1.4.1

### DIFF
--- a/charts/gateway-api/gateway-api/Chart.yaml
+++ b/charts/gateway-api/gateway-api/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.0"
+appVersion: "1.4.1"
 keywords:
   - network
   - gateway-api

--- a/charts/gateway-api/gateway-api/README.md
+++ b/charts/gateway-api/gateway-api/README.md
@@ -1,6 +1,6 @@
 # gateway-api
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 A Helm chart for Gateway API
 

--- a/charts/gateway-api/gateway-api/templates/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/charts/gateway-api/gateway-api/templates/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -111,6 +111,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -774,6 +780,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -1349,6 +1361,8 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/gateway-api/gateway-api/templates/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/charts/gateway-api/gateway-api/templates/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -111,6 +111,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -756,6 +762,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -1313,6 +1325,8 @@ spec:
         type: object
     served: false
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kgateway/kgateway/charts/gateway-api/Chart.yaml
+++ b/charts/kgateway/kgateway/charts/gateway-api/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.0"
+appVersion: "1.4.1"
 keywords:
   - network
   - gateway-api

--- a/charts/kgateway/kgateway/charts/gateway-api/README.md
+++ b/charts/kgateway/kgateway/charts/gateway-api/README.md
@@ -1,6 +1,6 @@
 # gateway-api
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Gateway API CRDs
 

--- a/charts/kgateway/kgateway/charts/gateway-api/templates/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/charts/kgateway/kgateway/charts/gateway-api/templates/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -111,6 +111,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -774,6 +780,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -1349,6 +1361,8 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kgateway/kgateway/charts/gateway-api/templates/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/charts/kgateway/kgateway/charts/gateway-api/templates/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -111,6 +111,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -756,6 +762,12 @@ spec:
                   implementation MUST ensure the `Accepted` Condition is set to
                   `status: False`, with Reason `Conflicted`.
 
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -1313,6 +1325,8 @@ spec:
         type: object
     served: false
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade the `gateway-api` chart from 1.4.0 to **1.4.1**, and sync the copy bundled inside the `kgateway` chart (`charts/kgateway/custom.sh` copies `charts/gateway-api/gateway-api` into `charts/kgateway/kgateway/charts/gateway-api` at build time).

`charts/gateway-api/config` has `UPGRADE_METHOD=none`, so `scripts/generateChart.sh` exits early for this chart — the chart content is hand-maintained and was updated directly. `helm-docs`/`gsed` are not available locally, so the kgateway sub-chart was synced by hand following exactly what `custom.sh` does.

**What actually changed upstream between v1.4.0 and v1.4.1**

Comparing upstream `config/crd` at both tags, the only content change is in **BackendTLSPolicy** (standard + experimental):

- `targetRefs` description gains a note that implementations SHOULD NOT support more than one `targetRef` for now
- the `v1alpha3` version gains the missing `subresources: status: {}` — without it the status subresource is not served

Every other CRD differs only by the `gateway.networking.k8s.io/bundle-version` annotation, which this chart replaces with `helm.sh/resource-policy: keep`, so those files are unchanged.

**Verification**

Rebuilt all 18 CRDs from a fresh `git clone --branch v1.4.1` (annotated tag → commit `477d172e`) and compared byte-for-byte against both copies in the repo:

- CRD file sets identical (standard 6 + experimental 12)
- **16 / 18 byte-identical** after the chart's two systematic transforms (template wrapper + the annotation swap above)
- `helm lint` passes for both charts; `helm template` renders 6 CRDs for `specification=standard` and 12 for `experimental`, with `subresources: status: {}` present in the output
- `helm template` on the kgateway parent chart with `installK8sGatewayAPI=true` still renders
- also confirmed upstream's `config/crd` matches the v1.4.1 `standard-install.yaml` release asset (differs only by a source-path comment), so the CRD source is the right one

**Pre-existing divergence left untouched (2 / 18 files)**

`standard` and `experimental` httproutes carry 36 lines that are not in v1.4.x:

- redirect `statusCode` enum extended with `303/307/308` (4 sites per channel)
- three `maxItems: 64` markers on the ext_authz `allowedHeaders` / `allowedResponseHeaders` lists

These are **not** hand-written patches. When the chart was first imported in 6f7b7079 (`add gateway api`, #3694, 2025-10-23), the CRDs were taken from upstream `main` rather than the `v1.4.0` tag — v1.4.0 had been released on 2025-10-06 and these two changes landed on `main` shortly after:

- kubernetes-sigs/gateway-api#3823 (`a80406e81`, 2025-10-14) — `Enum=301;302` → `Enum=301;302;303;307;308`
- kubernetes-sigs/gateway-api#4158 (`fefb2037d`, 2025-10-09) — three `MaxItems=64` markers

Both shipped upstream in v1.5.0. Reverting them to strict v1.4.1 would narrow the enum from 5 values back to 2, which would fail validation for any existing HTTPRoute already using 303/307/308 under the current 1.4.0 chart — so this PR deliberately keeps them. Restoring the chart's httproutes back to `bundle-version: v1.4.0` reproduces upstream `main@a80406e81` byte-for-byte, confirming the origin.

No values changes, so `values.yaml` / `values.schema.json` stay consistent and `test/gateway-api/install.sh` needs no update.

#### Which issue(s) this PR fixes:

Fixes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)