### PR TITLE
fix(spiderpool): schema structure fix

### DIFF
--- a/charts/spiderpool/parent/values.schema.json
+++ b/charts/spiderpool/parent/values.schema.json
@@ -29,11 +29,13 @@
                     "required": [
                         "install"
                     ],
-                    "install": {
-                        "type": "boolean",
-                        "title": "Install GrafanaDashboard",
-                        "description": "Install GrafanaDashboard for spiderpool, This requires the grafana operator CRDs to be available. Default to false",
-                        "default": false
+                    "properties": {
+                        "install": {
+                            "type": "boolean",
+                            "title": "Install GrafanaDashboard",
+                            "description": "Install GrafanaDashboard for spiderpool, This requires the grafana operator CRDs to be available. Default to false",
+                            "default": false
+                        }
                     }
                 },
                 "spiderpoolAgent": {
@@ -171,7 +173,7 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean",
-                                    "default": "true"
+                                    "default": true
                                 }
                             }
                         }

--- a/charts/spiderpool/spiderpool/values.schema.json
+++ b/charts/spiderpool/spiderpool/values.schema.json
@@ -29,11 +29,13 @@
                     "required": [
                         "install"
                     ],
-                    "install": {
-                        "type": "boolean",
-                        "title": "Install GrafanaDashboard",
-                        "description": "Install GrafanaDashboard for spiderpool, This requires the grafana operator CRDs to be available. Default to false",
-                        "default": false
+                    "properties": {
+                        "install": {
+                            "type": "boolean",
+                            "title": "Install GrafanaDashboard",
+                            "description": "Install GrafanaDashboard for spiderpool, This requires the grafana operator CRDs to be available. Default to false",
+                            "default": false
+                        }
                     }
                 },
                 "spiderpoolAgent": {
@@ -171,7 +173,7 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean",
-                                    "default": "true"
+                                    "default": true
                                 }
                             }
                         }


### PR DESCRIPTION
### English
This PR fixes two schema issues in Spiderpool values.schema.json:

1. Move grafanaDashboard.install under properties.install so the object schema is valid.
2. Change podResourceInject.enabled.default from "true" to true to match boolean type.

Updated files:
1. charts/spiderpool/spiderpool/values.schema.json
2. charts/spiderpool/parent/values.schema.json

Impact: schema-only fix, no runtime logic change.

### 中文
这个 PR 修复了 Spiderpool values.schema.json 的两个问题：

1. 将 grafanaDashboard.install 移到 properties.install 下，保证 object schema 结构正确。
2. 将 podResourceInject.enabled.default 从 "true" 改为 true，和 boolean 类型一致。

更新文件：
1. charts/spiderpool/spiderpool/values.schema.json
2. charts/spiderpool/parent/values.schema.json

影响范围：仅 schema 修复，不涉及运行时逻辑。