### PR TITLE
add llm-d-router-gateway

### DIFF
--- a/charts/llm-d-router-gateway/config
+++ b/charts/llm-d-router-gateway/config
@@ -1,0 +1,23 @@
+export USE_OPENSOURCE_CHART=false
+
+export REPO_URL=oci://ghcr.io/llm-d/charts
+export REPO_NAME=llm-d-router-gateway
+export CHART_NAME=llm-d-router-gateway
+export VERSION=v0.10.0
+
+# pr, issue, none
+export UPGRADE_METHOD=pr
+export UPGRADE_REVIWER=learner0810
+export TEST_ASSIGNER=learner0810
+
+# push to daocloud repo
+export DAOCLOUD_REPO_PROJECT=addon
+
+# optional, for wrapper chart
+export CUSTOM_SHELL=custom.sh
+
+# SKIP_SCHEMA
+export SKIP_SCHEMA=true
+
+# Use charts-syncer v2(dt) in the e2e pipeline
+export USE_CHARTS_SYNCER_DT=false

--- a/charts/llm-d-router-gateway/custom.sh
+++ b/charts/llm-d-router-gateway/custom.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+CHART_DIRECTORY=${1:-}
+[ ! -d "$CHART_DIRECTORY" ] && echo "custom shell: error, miss CHART_DIRECTORY $CHART_DIRECTORY " && exit 1
+
+cd "$CHART_DIRECTORY"
+echo "custom shell: CHART_DIRECTORY $CHART_DIRECTORY"
+echo "CHART_DIRECTORY $(ls)"
+
+#========================= add your customize bellow ====================
+#===============================
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#==============================
+CHILD_CHART_DIR="./charts/llm-d-router-gateway"
+ROUTER_CHART_DIR="${CHILD_CHART_DIR}/charts/router"
+ROUTER_DEPLOYMENT_TEMPLATE="${ROUTER_CHART_DIR}/templates/_deployment.yaml"
+ROUTER_LEADER_ELECTION_TEMPLATE="${ROUTER_CHART_DIR}/templates/_leader-election-rbac.yaml"
+
+[ -f "${CHILD_CHART_DIR}/values.yaml" ] || {
+  echo "custom shell: error, missing child values.yaml at ${CHILD_CHART_DIR}/values.yaml"
+  exit 1
+}
+[ -f "${ROUTER_CHART_DIR}/values.yaml" ] || {
+  echo "custom shell: error, missing router values.yaml at ${ROUTER_CHART_DIR}/values.yaml"
+  exit 1
+}
+[ -f "${ROUTER_DEPLOYMENT_TEMPLATE}" ] || {
+  echo "custom shell: error, missing router deployment template at ${ROUTER_DEPLOYMENT_TEMPLATE}"
+  exit 1
+}
+[ -f "${ROUTER_LEADER_ELECTION_TEMPLATE}" ] || {
+  echo "custom shell: error, missing router leader election template at ${ROUTER_LEADER_ELECTION_TEMPLATE}"
+  exit 1
+}
+
+yq eval -i '
+  .llm-d-router-gateway.router.modelServers.matchLabels.app = "inferx" |
+  .llm-d-router-gateway.router.epp.resources = {
+    "requests": {
+      "cpu": "1",
+      "memory": "1Gi"
+    },
+    "limits": {
+      "cpu": "1",
+      "memory": "1Gi"
+    }
+  } |
+  .llm-d-router-gateway.router.epp.ha.enableLeaderElection = false |
+  (.llm-d-router-gateway.router.epp.image | select(.registry == "ghcr.io/llm-d" and (.repository | test("^llm-d/") | not))) |= (
+    .registry = "ghcr.m.daocloud.io" |
+    .repository = "llm-d/" + .repository
+  ) |
+  (.llm-d-router-gateway.router.epp.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io" |
+  (.llm-d-router-gateway.router.latencyPredictor.trainingServer.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io/llm-d" |
+  (.llm-d-router-gateway.router.latencyPredictor.predictionServers.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io/llm-d"
+' values.yaml
+
+yq eval -i '
+  .router.modelServers.matchLabels.app = "inferx" |
+  .router.epp.resources = {
+    "requests": {
+      "cpu": "1",
+      "memory": "1Gi"
+    },
+    "limits": {
+      "cpu": "1",
+      "memory": "1Gi"
+    }
+  } |
+  .router.epp.ha.enableLeaderElection = false |
+  (.router.epp.image | select(.registry == "ghcr.io/llm-d" and (.repository | test("^llm-d/") | not))) |= (
+    .registry = "ghcr.m.daocloud.io" |
+    .repository = "llm-d/" + .repository
+  ) |
+  (.router.epp.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io" |
+  (.router.latencyPredictor.trainingServer.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io/llm-d" |
+  (.router.latencyPredictor.predictionServers.image.registry | select(. == "ghcr.io/llm-d")) = "ghcr.m.daocloud.io/llm-d"
+' "${CHILD_CHART_DIR}/values.yaml"
+
+if [ "$(uname)" = "Darwin" ]; then
+  SED_INPLACE=(-i '')
+else
+  SED_INPLACE=(-i)
+fi
+
+# deployment strategy: make spec.strategy fully configurable from values
+tmp_deployment_template=$(mktemp)
+awk '
+  /^  strategy:$/ && !patched {
+    print "  strategy:"
+    print "    {{- with .Values.router.epp.deploymentStrategy }}"
+    print "    {{- toYaml . | nindent 4 }}"
+    print "    {{- else }}"
+    print "    # The current recommended EPP deployment pattern is to have a single active replica. This ensures"
+    print "    # optimal performance of the stateful operations such prefix cache aware scorer."
+    print "    # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to"
+    print "    # quickly take over. This is particularly important in the high availability set up with leader"
+    print "    # election, as the rolling update strategy would prevent the old leader being killed because"
+    print "    # otherwise the maxUnavailable would be 100%."
+    print "    #"
+    print "    # With replicas > 1 this also means the Deployment never reports Available=True,"
+    print "    # because standby replicas stay NotReady by design. Set router.epp.deploymentStrategy"
+    print "    # if that blocks your tooling; see \"Multi-replica EPP and Helm --wait\" in the chart README."
+    print "    type: Recreate"
+    print "    {{- end }}"
+    skipping = 1
+    patched = 1
+    next
+  }
+  skipping && /^  selector:$/ {
+    skipping = 0
+  }
+  !skipping {
+    print
+  }
+  END {
+    if (!patched) {
+      exit 42
+    }
+  }
+' "${ROUTER_DEPLOYMENT_TEMPLATE}" > "${tmp_deployment_template}" || {
+  rm -f "${tmp_deployment_template}"
+  echo "custom shell: error, failed to patch router deployment strategy in ${ROUTER_DEPLOYMENT_TEMPLATE}"
+  exit 1
+}
+mv "${tmp_deployment_template}" "${ROUTER_DEPLOYMENT_TEMPLATE}"
+
+if ! grep -q '{{- with .Values.router.epp.deploymentStrategy }}' "${ROUTER_DEPLOYMENT_TEMPLATE}"; then
+  echo "custom shell: error, failed to patch router deployment strategy in ${ROUTER_DEPLOYMENT_TEMPLATE}"
+  exit 1
+fi
+
+# leader election: make --ha-enable-leader-election configurable from values instead of replica count
+sed "${SED_INPLACE[@]}" \
+  's/if and (gt (\.Values\.router\.epp\.replicas | int) 1) (not \$gkePB.enabled)/if and (.Values.router.epp.ha.enableLeaderElection | default false) (not $gkePB.enabled)/g' \
+  "${ROUTER_DEPLOYMENT_TEMPLATE}"
+
+sed "${SED_INPLACE[@]}" \
+  's/if gt (\.Values\.router\.epp\.replicas | int) 1/if (.Values.router.epp.ha.enableLeaderElection | default false)/g' \
+  "${ROUTER_LEADER_ELECTION_TEMPLATE}"
+
+yq eval -i '.keywords |= ((. // []) + ["inference"] | unique)' Chart.yaml

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/.relok8s-images.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .llm-d-router-gateway.router.epp.image.registry }}/{{ .llm-d-router-gateway.router.epp.image.repository }}:{{ .llm-d-router-gateway.router.epp.image.tag }}"

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/Chart.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: v0.10.0
+description: A Helm chart for llm-d-router-gateway
+name: llm-d-router-gateway
+type: application
+version: v0.10.0
+dependencies:
+  - name: llm-d-router-gateway
+    version: "v0.10.0"
+    repository: "oci://ghcr.io/llm-d/charts"
+keywords:
+  - inference

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/.helmignore
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/Chart.lock
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: router
+  repository: file://../routerlib
+  version: 0.0.0
+digest: sha256:9e81a4a4f4a2a5e4a602108bddada94687fe41f069b061be9990d096623a1fa4
+generated: "2026-08-17T21:10:57.727130334Z"

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/Chart.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: v0.10.0
+dependencies:
+- alias: router
+  name: router
+  repository: file://../routerlib
+  version: 0.0.0
+description: A Helm chart for llm-d-router-gateway
+name: llm-d-router-gateway
+type: application
+version: v0.10.0

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/.helmignore
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/Chart.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.0.0
+description: A library Helm chart for Endpoint Picker
+name: router
+type: library
+version: 0.0.0

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_config.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_config.yaml
@@ -1,0 +1,151 @@
+{{- define "llm-d-epp.config" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  default-plugins.yaml: |
+    {{- $modelServerProtocol := .Values.router.modelServers.protocol | default "http" }}
+    {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
+    {{- $parsers := list }}
+    {{- if and (eq (lower $modelServerType) "vllm") (eq (lower $modelServerProtocol) "grpc") }}
+      {{- $parsers = append $parsers "vllmgrpc-parser" }}
+    {{- else if .Values.router.epp.parsers }}
+      {{- $parsers = .Values.router.epp.parsers }}
+    {{- else if eq (lower $modelServerType) "triton" }}
+      {{- $parsers = append $parsers "passthrough-parser" }}
+    {{- end }}
+    apiVersion: llm-d.ai/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: queue-scorer
+    - type: kv-cache-utilization-scorer
+    - type: prefix-cache-scorer
+    - type: metrics-data-source
+      parameters:
+        scheme: {{ .Values.router.epp.metricsDataSource.scheme | default "http" | quote }}
+        path: {{ .Values.router.epp.metricsDataSource.path | default "/metrics" | quote }}
+        insecureSkipVerify: {{ .Values.router.epp.metricsDataSource.insecureSkipVerify | default true }}
+    - type: core-metrics-extractor
+      {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
+      {{- if ne $modelServerType "vllm" }}
+      parameters:
+        defaultEngine: {{ $modelServerType | quote }}
+      {{- end }}
+    {{- range $p := $parsers }}
+    - type: {{ $p }}
+    {{- end }}
+    {{- if .Values.router.latencyPredictor.enabled }}
+    - type: predicted-latency-producer
+    # Two-gate prefix cache affinity: strict (0.99) runs before the SLO tier
+    # filter to prefer near-exact cache matches across all endpoints; loose
+    # (0.80) runs after the tier filter to prefer partial matches within the
+    # SLO-qualified tier.
+    - name: strict-affinity-filter
+      type: prefix-cache-affinity-filter
+      parameters:
+        affinityThreshold: 0.99
+        ttftSource: latencyPredictor
+        maxTTFTPenaltyMs: 5000
+    - name: loose-affinity-filter
+      type: prefix-cache-affinity-filter
+      parameters:
+        affinityThreshold: 0.80
+        ttftSource: latencyPredictor
+        maxTTFTPenaltyMs: 5000
+    - type: latency-scorer
+    - type: weighted-random-picker
+    - type: slo-headroom-tier-filter
+    - type: latency-slo-admitter
+    {{- end }}
+    schedulingProfiles:
+    {{- if .Values.router.latencyPredictor.enabled }}
+    - name: default
+      plugins:
+      - pluginRef: predicted-latency-producer
+      - pluginRef: strict-affinity-filter
+      - pluginRef: slo-headroom-tier-filter
+      - pluginRef: loose-affinity-filter
+      - pluginRef: latency-scorer
+      - pluginRef: weighted-random-picker
+    {{- else }}
+    - name: default
+      plugins:
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+    {{- end }}
+    {{- if $parsers }}
+    requestHandler:
+      parsers:
+      {{- range $p := $parsers }}
+      - pluginRef: {{ $p }}
+      {{- end }}
+    {{- end }}
+  payload-agnostic.yaml: |
+    # Request-format agnostic routing. Use this when the request format is
+    # unknown or unsupported, so the EPP cannot rely on scorers that read the
+    # request body (e.g. the prefix-cache scorer). The passthrough parser does
+    # not parse the body, and routing falls back to backend-state scorers:
+    #   - active-request-scorer  : prefers the least busy endpoint
+    #   - session-affinity-scorer: keeps a session pinned to the same endpoint
+    # Select it by setting router.epp.pluginsConfigFile: payload-agnostic.yaml
+    apiVersion: llm-d.ai/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: passthrough-parser
+    - type: active-request-scorer
+    - type: session-affinity-scorer
+    requestHandler:
+      parsers:
+      - pluginRef: passthrough-parser
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: active-request-scorer
+        weight: 1
+      - pluginRef: session-affinity-scorer
+        weight: 1
+  {{- if .Values.router.epp.pluginsCustomConfig }}
+  {{- .Values.router.epp.pluginsCustomConfig | toYaml | nindent 2 }}
+  {{- end }}
+  
+---
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
+{{- if and $proxy.enabled $proxy.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $proxy.configMap.name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- include "llm-d-router.proxyConfigMapData" . | nindent 2 }}
+{{- end }}
+---
+{{- if .Values.router.latencyPredictor.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-d-router.name" . }}-latency-predictor-training
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range $key, $value := .Values.router.latencyPredictor.trainingServer.config }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-d-router.name" . }}-latency-predictor-prediction
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range $key, $value := .Values.router.latencyPredictor.predictionServers.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_deployment.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_deployment.yaml
@@ -1,0 +1,370 @@
+{{- define "llm-d-epp.deployment-pod-spec" -}}
+      {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
+      {{- $proxyType := include "llm-d-router.proxyType" . | trim }}
+      {{- $proxyMode := include "llm-d-router.proxyMode" . | trim }}
+      {{- $proxySidecar := and $proxy.enabled (eq $proxyMode "sidecar") }}
+      {{- $proxyConfigMap := index $proxy "configMap" | default dict }}
+      {{- $proxyConfigMapName := index $proxyConfigMap "name" | default "" }}
+      {{- $eppFlags := deepCopy (.Values.router.epp.flags | default dict) }}
+      {{- if and (eq $proxyType "agentgateway") (not (hasKey $eppFlags "secure-serving")) }}
+        {{- $_ := set $eppFlags "secure-serving" false }}
+      {{- end }}
+      serviceAccountName: {{ include "llm-d-router.name" . }}
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
+      {{- if and .Values.router.tokenizer.enabled .Values.router.tokenizer.initContainers }}
+      initContainers:
+        {{- toYaml .Values.router.tokenizer.initContainers | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- if $proxySidecar }}
+        - name: {{ $proxy.name }}
+          image: {{ $proxy.image }}
+          imagePullPolicy: {{ $proxy.imagePullPolicy | default "IfNotPresent" }}
+        {{- with $proxy.command }}
+          command:
+            - {{ . | quote }}
+        {{- end }}
+        {{- with $proxy.args }}
+          args:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+        {{- end }}
+        {{- with $proxy.env }}
+          env:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with $proxy.ports }}
+          ports:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $proxy.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.startupProbe }}
+          startupProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- if or (and (eq $proxyType "agentgateway") $proxyConfigMapName) $proxy.volumeMounts }}
+          volumeMounts:
+          {{- if and (eq $proxyType "agentgateway") $proxyConfigMapName }}
+            - name: agentgateway-config-template
+              mountPath: /config
+              readOnly: true
+          {{- end }}
+          {{- with $proxy.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
+        - name: epp
+          image: {{ .Values.router.epp.image.registry }}/{{ .Values.router.epp.image.repository }}:{{ .Values.router.epp.image.tag }}
+          imagePullPolicy: {{ .Values.router.epp.image.pullPolicy | default "IfNotPresent" }}
+          args:
+          {{- /* 1. Determine Mode Logic */ -}}
+          {{- $useInferencePool := ne .Values.router.inferencePool.create false }}
+          {{- /* 2. Determine Model Server Type */ -}}
+          {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
+          {{- /* 3. Mode Specific Flags */ -}}
+          {{- if not $useInferencePool }}
+              - --endpoint-selector
+              {{- $selector := "" }}
+              {{- if and .Values.router.modelServers .Values.router.modelServers.matchLabels }}
+                {{- $labels := list }}
+                {{- range $k, $v := .Values.router.modelServers.matchLabels }}
+                  {{- $labels = append $labels (printf "%s=%s" $k $v) }}
+                {{- end }}
+                {{- $selector = join "," $labels }}
+              {{- end }}
+              - {{ $selector | quote }}
+              - --endpoint-target-ports
+              - {{ include "llm-d-router.standaloneEndpointTargetPorts" . | quote }}
+          {{- else }}
+              - --pool-name
+              - {{ .Release.Name }}
+              # The pool namespace is optional because EPP can default to the NAMESPACE env var.
+              - --pool-namespace
+              - {{ .Release.Namespace }}
+              - --pool-group
+              - "inference.networking.k8s.io"
+          {{- end }}
+              - --zap-encoder
+              - "json"
+              - --config-file
+              - "/config/{{ .Values.router.epp.pluginsConfigFile }}"
+          {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+          {{- if and (.Values.router.epp.ha.enableLeaderElection | default false) (not $gkePB.enabled) }}
+              - --ha-enable-leader-election
+          {{- end }}
+          {{- $grpcHealthPort := .Values.router.epp.grpcHealthPort | default 9003 }}
+              - --grpc-health-port
+              - "{{ $grpcHealthPort }}"
+              # Pass additional flags via the router.epp.flags field in values.yaml.
+              # Render them as --flag=value so boolean values are parsed correctly.
+          {{- range $key, $value := $eppFlags }}
+              - {{ printf "--%s=%v" $key $value | quote }}
+          {{- end }}
+          {{- if .Values.router.tracing.enabled }}
+              - --tracing=true
+          {{- else }}
+              - --tracing=false
+          {{- end }}
+          {{- if not .Values.router.monitoring.prometheus.auth.enabled }}
+              - --metrics-endpoint-auth=false
+          {{- end }}
+          {{- with .Values.router.epp.resources }}
+          resources:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: grpc
+              containerPort: 9002
+            - name: grpc-health
+              containerPort: {{ $grpcHealthPort }}
+            - name: metrics
+              containerPort: 9090
+        {{- if .Values.router.epp.extraContainerPorts }}
+            {{- toYaml .Values.router.epp.extraContainerPorts | nindent 12 }}
+        {{- end }}
+          livenessProbe:
+          {{- if gt (.Values.router.epp.replicas | int) 1 }}
+            grpc:
+              port: {{ $grpcHealthPort }}
+              service: liveness
+          {{- else }}
+            grpc:
+              port: {{ $grpcHealthPort }}
+              service: inference-extension
+          {{- end }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+          {{- if gt (.Values.router.epp.replicas | int) 1 }}
+            grpc:
+              port: {{ $grpcHealthPort }}
+              service: readiness
+          {{- else }}
+            grpc:
+              port: {{ $grpcHealthPort }}
+              service: inference-extension
+          {{- end }}
+            periodSeconds: 2
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        {{- include "llm-d-router.latencyPredictor.env" . | nindent 12 }}
+        {{- if .Values.router.tracing.enabled }}
+            - name: OTEL_SERVICE_NAME
+              value: "llm-d-router/epp"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.router.tracing.otelExporterEndpoint | quote }}
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: 'k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)'
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ .Values.router.tracing.sampling.sampler | quote }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ .Values.router.tracing.sampling.samplerArg | quote }}
+        {{- end }}
+        {{- if .Values.router.epp.env }}
+        {{- toYaml .Values.router.epp.env | nindent 12 }}
+        {{- end }}
+          volumeMounts:
+            - name: plugins-config-volume
+              mountPath: "/config"
+        {{- if .Values.router.epp.volumeMounts }}
+        {{- toYaml .Values.router.epp.volumeMounts | nindent 12 }}
+        {{- end }}
+        {{- if .Values.router.tokenizer.enabled }}
+        {{- $tokenizer := .Values.router.tokenizer }}
+        {{- $renderPort := $tokenizer.port | default 8000 | int }}
+        - name: vllm-render
+          image: {{ $tokenizer.image.registry }}/{{ $tokenizer.image.repository }}:{{ $tokenizer.image.tag }}
+          imagePullPolicy: {{ $tokenizer.image.pullPolicy | default "IfNotPresent" }}
+          command:
+          {{- if $tokenizer.command }}
+          {{- toYaml $tokenizer.command | nindent 12 }}
+          {{- else }}
+            - vllm
+            - launch
+            - render
+          {{- end }}
+          args:
+          {{- if $tokenizer.args }}
+          {{- toYaml $tokenizer.args | nindent 12 }}
+          {{- else }}
+            - {{ $tokenizer.modelName | quote }}
+            - {{ printf "--port=%d" $renderPort | quote }}
+          {{- end }}
+          {{- with $tokenizer.extraArgs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: render-http
+              containerPort: {{ $renderPort }}
+          {{- with $tokenizer.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $tokenizer.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $tokenizer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /root/.cache/huggingface
+              name: model-cache
+            {{- with $tokenizer.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+      {{- include "llm-d-router.latencyPredictor.containers" . | nindent 8 }}
+      volumes:
+      {{- if .Values.router.epp.volumes }}
+      {{- toYaml .Values.router.epp.volumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.router.tokenizer.enabled }}
+        - name: model-cache
+          emptyDir: {}
+        {{- with .Values.router.tokenizer.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if and $proxySidecar (eq $proxyType "agentgateway") $proxyConfigMapName }}
+        - name: agentgateway-config-template
+          configMap:
+            name: {{ $proxyConfigMapName }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+      {{- end }}
+      {{- if $proxySidecar }}
+      {{- with $proxy.volumes }}
+      {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- end }}
+        - name: plugins-config-volume
+          configMap:
+            name: {{ include "llm-d-router.name" . }}
+      {{- include "llm-d-router.latencyPredictor.volumes" . | nindent 8 }}
+      {{- if .Values.router.epp.affinity }}
+      affinity:
+        {{- toYaml .Values.router.epp.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.router.epp.tolerations }}
+      tolerations:
+        {{- toYaml .Values.router.epp.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}
+
+{{- define "llm-d-epp.deployment" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.modeLabels" . | nindent 4 }}
+spec:
+  replicas: {{ $totalReplicas }}
+  serviceName: {{ include "llm-d-router.name" . }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
+        {{- include "llm-d-router.modeLabels" . | nindent 8 }}
+      {{- with .Values.router.epp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+{{ include "llm-d-epp.deployment-pod-spec" . }}
+---
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.modeLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.router.epp.replicas | default 1 }}
+  strategy:
+    {{- with .Values.router.epp.deploymentStrategy }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    # The current recommended EPP deployment pattern is to have a single active replica. This ensures
+    # optimal performance of the stateful operations such prefix cache aware scorer.
+    # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to
+    # quickly take over. This is particularly important in the high availability set up with leader
+    # election, as the rolling update strategy would prevent the old leader being killed because
+    # otherwise the maxUnavailable would be 100%.
+    #
+    # With replicas > 1 this also means the Deployment never reports Available=True,
+    # because standby replicas stay NotReady by design. Set router.epp.deploymentStrategy
+    # if that blocks your tooling; see "Multi-replica EPP and Helm --wait" in the chart README.
+    type: Recreate
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
+        {{- include "llm-d-router.modeLabels" . | nindent 8 }}
+      {{- with .Values.router.epp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+{{ include "llm-d-epp.deployment-pod-spec" . }}
+---
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_gke.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_gke.yaml
@@ -1,0 +1,109 @@
+{{- define "llm-d-router.gke" -}}
+{{- $monitoringProvider := include "llm-d-router.monitoring.provider" . | fromYaml | default dict -}}
+{{- if and $monitoringProvider (eq (lower (index $monitoringProvider "name" | default "")) "gmp") }}
+{{- if and .Values.router.monitoring.prometheus.enabled .Values.router.monitoring.prometheus.auth.enabled }}
+{{- $metricsReadSA := printf "%s-metrics-reader-sa" .Release.Name -}}
+{{- $metricsReadSecretName := printf "%s-metrics-reader-secret" .Release.Name -}}
+{{- $metricsReadRoleName := printf "%s-%s-metrics-reader" .Release.Namespace .Release.Name -}}
+{{- $metricsReadRoleBindingName := printf "%s-%s-metrics-reader-role-binding" .Release.Namespace .Release.Name -}}
+{{- $secretReadRoleName := printf "%s-metrics-reader-secret-read" .Release.Name -}}
+{{- $gmpNamespace := "gmp-system" -}}
+{{- $isAutopilot := false -}}
+{{- with (index $monitoringProvider "gmp") }}
+  {{- $isAutopilot = .autopilot | default false -}}
+{{- end }}
+{{- if $isAutopilot -}}
+{{-   $gmpNamespace = "gke-gmp-system" -}}
+{{- end -}}
+{{- $gmpCollectorRoleBindingName := printf "%s:collector:%s-%s-metrics-reader-secret-read" $gmpNamespace .Release.Namespace .Release.Name -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $metricsReadSA }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $metricsReadSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $metricsReadSA }}
+type: kubernetes.io/service-account-token
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: metrics
+      scheme: http
+      interval: {{ .Values.router.monitoring.interval }}
+      path: /metrics
+      authorization:
+        type: Bearer
+        credentials:
+          secret:
+            name: {{ $metricsReadSecretName }}
+            key: token
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $metricsReadRoleName }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $metricsReadRoleBindingName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $metricsReadSA }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $metricsReadRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $secretReadRoleName }}
+rules:
+  - resources:
+      - secrets
+    apiGroups: [""]
+    verbs: ["get", "list", "watch"]
+    resourceNames: [{{ $metricsReadSecretName | quote }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $gmpCollectorRoleBindingName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ $secretReadRoleName }}
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: collector
+    namespace: {{ $gmpNamespace }}
+    kind: ServiceAccount
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_helpers.tpl
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_helpers.tpl
@@ -1,0 +1,518 @@
+{{/*
+Common labels
+*/}}
+{{- define "llm-d-router.labels" -}}
+app.kubernetes.io/name: {{ include "llm-d-router.name" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Router deployment name
+*/}}
+{{- define "llm-d-router.name" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
+{{ $base }}-epp
+{{- end -}}
+
+{{/*
+Cluster RBAC unique name
+*/}}
+{{- define "llm-d-router.cluster-rbac-name" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 }}
+{{- $ns := .Release.Namespace | default "default" | lower | trim | trunc 40 }}
+{{- printf "%s-%s-epp" $base $ns | quote | trunc 84 }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "llm-d-router.selectorLabels" -}}
+{{- if eq .Values.router.inferencePool.create false -}}
+{{- /* LOGIC FOR STANDALONE EPP MODE */ -}}
+llm-d-router-standalone: {{ include "llm-d-router.name" . }}
+{{- else -}}
+{{- /* LOGIC FOR PARENT (LLM-D-ROUTER-GATEWAY) MODE */ -}}
+llm-d-router-gateway: {{ include "llm-d-router.name" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Mode labels
+*/}}
+{{- define "llm-d-router.modeLabels" -}}
+{{- if eq .Values.router.inferencePool.create false -}}
+llm-d.ai/igw-mode: llm-d-router-standalone
+{{- else -}}
+llm-d.ai/igw-mode: llm-d-router-gateway
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the monitoring provider name.
+
+If router.monitoring.provider.name is unset/empty, default to
+prometheusoperator. For backwards compatibility, provider.name=gke still maps
+to gmp when no monitoring provider is explicitly set.
+*/}}
+{{- define "llm-d-router.monitoring.provider.name" -}}
+{{- $monitoring := .Values.router.monitoring | default dict -}}
+{{- $mp := index $monitoring "provider" | default dict -}}
+{{- $mpName := index $mp "name" | default "" -}}
+{{- $gatewayProvider := .Values.provider | default dict -}}
+{{- $gatewayProviderName := index $gatewayProvider "name" | default "" -}}
+{{- if and (kindIs "string" $mpName) (ne (trim $mpName) "") -}}
+{{- $mpName -}}
+{{- else if eq (lower $gatewayProviderName) "gke" -}}
+gmp
+{{- else -}}
+prometheusoperator
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the monitoring provider config object.
+
+When router.monitoring.provider.name is unset/empty, use defaults.
+For backwards compatibility, provider.gke.autopilot is still honored when
+provider.name=gke and no monitoring provider is explicitly set.
+*/}}
+{{- define "llm-d-router.monitoring.provider" -}}
+{{- $monitoring := .Values.router.monitoring | default dict -}}
+{{- $mp := index $monitoring "provider" | default dict -}}
+{{- $mpName := include "llm-d-router.monitoring.provider.name" . -}}
+{{- $gatewayProvider := .Values.provider | default dict -}}
+{{- $gatewayProviderName := index $gatewayProvider "name" | default "" -}}
+{{- $resolved := dict "name" $mpName -}}
+{{- if eq (lower $mpName) "gmp" -}}
+  {{- $gmp := index $mp "gmp" | default dict -}}
+  {{- $legacyGke := dict -}}
+  {{- if and (eq (lower $gatewayProviderName) "gke") (index $gatewayProvider "gke") -}}
+    {{- $legacyGke = index $gatewayProvider "gke" -}}
+  {{- end -}}
+  {{- $_ := set $resolved "gmp" (mergeOverwrite (deepCopy $legacyGke) (deepCopy $gmp)) -}}
+{{- else -}}
+  {{- $_ := set $resolved "prometheusoperator" (index $mp "prometheusoperator" | default dict) -}}
+{{- end -}}
+{{- toYaml $resolved -}}
+{{- end -}}
+
+{{/*
+Return the standalone proxy type.
+*/}}
+{{- define "llm-d-router.proxyType" -}}
+{{- $proxy := .Values.router.proxy | default dict -}}
+{{- default "envoy" ($proxy.proxyType | default "envoy") | lower -}}
+{{- end -}}
+
+{{/*
+Return the standalone proxy deployment mode: "sidecar" (proxy runs in the EPP
+pod) or "service" (proxy runs as its own horizontally scalable Deployment).
+*/}}
+{{- define "llm-d-router.proxyMode" -}}
+{{- $proxy := .Values.router.proxy | default dict -}}
+{{- default "sidecar" ($proxy.mode | default "sidecar") | lower -}}
+{{- end -}}
+
+{{/*
+Name of the standalone proxy Deployment and Service used in service mode.
+*/}}
+{{- define "llm-d-router.proxyName" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
+{{ $base }}-proxy
+{{- end -}}
+
+{{/*
+Selector labels for the service-mode proxy Deployment and Service. Distinct
+from the EPP selector so the proxy and EPP pods are never co-selected.
+*/}}
+{{- define "llm-d-router.proxySelectorLabels" -}}
+llm-d-router-proxy: {{ include "llm-d-router.proxyName" . }}
+{{- end -}}
+
+{{/*
+ext_proc upstream host the proxy uses to reach EPP. Loopback in sidecar mode;
+the EPP Service FQDN in service mode.
+*/}}
+{{- define "llm-d-router.proxy.extProcHost" -}}
+{{- if eq (include "llm-d-router.proxyMode" .) "service" -}}
+{{- $domain := .Values.router.clusterDomain | default "cluster.local" -}}
+{{- printf "%s.%s.svc.%s" (include "llm-d-router.name" .) .Release.Namespace $domain -}}
+{{- else -}}
+127.0.0.1
+{{- end -}}
+{{- end -}}
+
+{{/*
+ext_proc cluster discovery type. STATIC for the loopback sidecar; STRICT_DNS so
+the proxy resolves the EPP Service FQDN in service mode.
+*/}}
+{{- define "llm-d-router.proxy.extProcClusterType" -}}
+{{- if eq (include "llm-d-router.proxyMode" .) "service" -}}
+STRICT_DNS
+{{- else -}}
+STATIC
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the proxy fails open (passes traffic through) when EPP is unreachable.
+Defaults to true in service mode for active/passive resiliency, false in
+sidecar mode; overridable via router.proxy.failOpen.
+*/}}
+{{- define "llm-d-router.proxy.failOpen" -}}
+{{- $proxy := .Values.router.proxy | default dict -}}
+{{- $failOpen := index $proxy "failOpen" -}}
+{{- if kindIs "bool" $failOpen -}}
+{{- $failOpen -}}
+{{- else if eq (include "llm-d-router.proxyMode" .) "service" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return "true" if EPP is configured with secure (TLS) serving, "false" if
+router.epp.flags.secure-serving is explicitly set to false. Defaults to true
+so that the Envoy ext_proc cluster uses TLS by default.
+*/}}
+{{- define "llm-d-router.proxy.eppSecureServing" -}}
+{{- $flags := .Values.router.epp.flags | default dict -}}
+{{- $secureServing := index $flags "secure-serving" -}}
+{{- if and (not (kindIs "invalid" $secureServing)) (eq (toString $secureServing) "false") -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Envoy health-check tls_options block for the ext_proc cluster.
+Emitted only when EPP runs with TLS (secure-serving != false).
+Callers must indent to match the surrounding YAML context.
+*/}}
+{{- define "llm-d-router.proxy.envoyExtProcTLSOptions" -}}
+{{- if eq (include "llm-d-router.proxy.eppSecureServing" .) "true" -}}
+tls_options:
+  alpn_protocols: ["h2"]
+{{- end -}}
+{{- end -}}
+
+{{/*
+Envoy transport_socket block for the ext_proc cluster.
+Emitted only when EPP runs with TLS (secure-serving != false).
+Callers must indent to match the surrounding YAML context.
+*/}}
+{{- define "llm-d-router.proxy.envoyExtProcTransportSocket" -}}
+{{- if eq (include "llm-d-router.proxy.eppSecureServing" .) "true" -}}
+transport_socket:
+  name: "envoy.transport_sockets.tls"
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    common_tls_context:
+      validation_context:
+{{- end -}}
+{{- end -}}
+
+{{/*
+Normalize a scalar, comma-separated string, or list of ports into a
+comma-separated numeric string.
+*/}}
+{{- define "llm-d-router.normalizedPortList" -}}
+{{- $path := .path -}}
+{{- $value := .value -}}
+{{- if empty $value -}}
+  {{- fail (printf "%s is required" $path) -}}
+{{- end -}}
+{{- $rawPorts := list -}}
+{{- if kindIs "slice" $value -}}
+  {{- $rawPorts = $value -}}
+{{- else -}}
+  {{- $rawPorts = splitList "," (toString $value) -}}
+{{- end -}}
+{{- $ports := list -}}
+{{- range $raw := $rawPorts -}}
+  {{- $rawString := trim (toString $raw) -}}
+  {{- if not (regexMatch "^[0-9]+$" $rawString) -}}
+    {{- fail (printf "%s must contain only numeric ports, got %q" $path $rawString) -}}
+  {{- end -}}
+  {{- $port := int $rawString -}}
+  {{- if or (lt $port 1) (gt $port 65535) -}}
+    {{- fail (printf "%s must contain ports between 1 and 65535, got %d" $path $port) -}}
+  {{- end -}}
+  {{- $ports = append $ports (toString $port) -}}
+{{- end -}}
+{{- if eq (len $ports) 0 -}}
+  {{- fail (printf "%s must contain at least one port" $path) -}}
+{{- end -}}
+{{- join "," $ports -}}
+{{- end -}}
+
+{{/*
+Return the standalone proxy listener port exposed by the EPP Service.
+The port is selected by the Service port named "http" so selection is
+deterministic even when additional Service ports are configured.
+*/}}
+{{- define "llm-d-router.standaloneProxyListenerPort" -}}
+{{- $servicePorts := .Values.router.extraServicePorts | default list -}}
+{{- $found := false -}}
+{{- $listenerPort := "" -}}
+{{- $targetPort := "" -}}
+{{- $hasTargetPort := false -}}
+{{- range $index, $servicePort := $servicePorts -}}
+  {{- if eq (toString (index $servicePort "name")) "http" -}}
+    {{- if $found -}}
+      {{- fail ".Values.router.extraServicePorts must contain exactly one port named \"http\" when proxyType=agentgateway" -}}
+    {{- end -}}
+    {{- $found = true -}}
+    {{- if not (hasKey $servicePort "port") -}}
+      {{- fail (printf ".Values.router.extraServicePorts[%d].port is required for the port named \"http\"" $index) -}}
+    {{- end -}}
+    {{- $listenerPort = index $servicePort "port" -}}
+    {{- if hasKey $servicePort "targetPort" -}}
+      {{- $hasTargetPort = true -}}
+      {{- $targetPort = index $servicePort "targetPort" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- fail ".Values.router.extraServicePorts must contain exactly one port named \"http\" when proxyType=agentgateway" -}}
+{{- end -}}
+{{- if kindIs "slice" $listenerPort -}}
+  {{- fail ".Values.router.extraServicePorts[name=http].port must be a single numeric port" -}}
+{{- end -}}
+{{- $listenerPortString := trim (toString $listenerPort) -}}
+{{- if not (regexMatch "^[0-9]+$" $listenerPortString) -}}
+  {{- fail (printf ".Values.router.extraServicePorts[name=http].port must be numeric, got %q" $listenerPortString) -}}
+{{- end -}}
+{{- $listenerPortNumber := int $listenerPortString -}}
+{{- if or (lt $listenerPortNumber 1) (gt $listenerPortNumber 65535) -}}
+  {{- fail (printf ".Values.router.extraServicePorts[name=http].port must be between 1 and 65535, got %d" $listenerPortNumber) -}}
+{{- end -}}
+{{- if $hasTargetPort -}}
+  {{- $targetPortString := trim (toString $targetPort) -}}
+  {{- if and (ne $targetPortString $listenerPortString) (ne $targetPortString "http") -}}
+    {{- fail (printf ".Values.router.extraServicePorts[name=http].targetPort must be omitted, %q, or \"http\" when proxyType=agentgateway, got %q" $listenerPortString $targetPortString) -}}
+  {{- end -}}
+{{- end -}}
+{{- $listenerPortString -}}
+{{- end -}}
+
+{{/*
+Return the standalone EPP model-server target ports.
+*/}}
+{{- define "llm-d-router.standaloneEndpointTargetPorts" -}}
+{{- $ports := list -}}
+{{- range .Values.router.modelServers.targetPorts -}}
+{{- $ports = append $ports (toString .number) -}}
+{{- end -}}
+{{- join "," $ports -}}
+{{- end -}}
+
+{{/*
+Return the agentgateway standalone logical backend service name.
+Derives the name from .Values.router.modelServers.matchLabels.app,
+falling back to .Release.Name if not set.
+*/}}
+{{- define "llm-d-router.agentgateway.logicalBackendName" -}}
+{{- $appLabel := "" -}}
+{{- if and .Values.router.modelServers .Values.router.modelServers.matchLabels -}}
+  {{- $appLabel = index .Values.router.modelServers.matchLabels "app" | default "" -}}
+{{- end -}}
+{{- if not (empty $appLabel) -}}
+  {{- $appLabel -}}
+{{- else -}}
+  {{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the resolved proxy configuration for the current chart.
+Standalone uses proxy presets merged with explicit proxy overrides.
+*/}}
+{{- define "llm-d-router.proxy" -}}
+{{- $proxy := deepCopy (.Values.router.proxy | default dict) -}}
+{{- $resolved := $proxy -}}
+{{- if hasPrefix "llm-d-router-standalone" .Chart.Name -}}
+  {{- $proxyType := include "llm-d-router.proxyType" . -}}
+  {{- $presets := index $proxy "presets" | default dict -}}
+  {{- $preset := deepCopy ((index $presets $proxyType) | default dict) -}}
+  {{- $userArgs := index $proxy "args" | default list -}}
+  {{- $presetArgs := index $preset "args" | default list -}}
+  {{- $resolved = mergeOverwrite $preset $proxy -}}
+  {{- if empty $userArgs -}}
+    {{- $_ := set $resolved "args" $presetArgs -}}
+  {{- end -}}
+  {{- if eq $proxyType "agentgateway" -}}
+    {{- $listenerPort := include "llm-d-router.standaloneProxyListenerPort" . | int -}}
+    {{- $ports := index $resolved "ports" | default list -}}
+    {{- $resolvedPorts := list (dict "containerPort" $listenerPort "name" "http") -}}
+    {{- range $index, $port := $ports -}}
+      {{- if gt $index 0 -}}
+        {{- $resolvedPorts = append $resolvedPorts $port -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $_ := set $resolved "ports" $resolvedPorts -}}
+  {{- end -}}
+{{- end -}}
+{{- $resolved = omit $resolved "agentgateway" "presets" "proxyType" -}}
+{{- toYaml $resolved -}}
+{{- end -}}
+
+{{/*
+Return the rendered proxy ConfigMap data.
+*/}}
+{{- define "llm-d-router.proxyConfigMapData" -}}
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- $configMap := index $proxy "configMap" | default dict -}}
+{{- $data := deepCopy ((index $configMap "data") | default dict) -}}
+{{- if hasPrefix "llm-d-router-standalone" .Chart.Name -}}
+  {{- $proxyType := include "llm-d-router.proxyType" . -}}
+  {{- if eq $proxyType "agentgateway" -}}
+    {{- $generated := dict "config.yaml" (include "llm-d-router.proxy.agentgatewayConfig" .) -}}
+    {{- $data = mergeOverwrite $data $generated -}}
+  {{- else if eq $proxyType "envoy" -}}
+    {{- /* Render only the chart-owned envoy.yaml so the ext_proc target and
+           fail-open directives resolve; user-supplied keys stay literal. */ -}}
+    {{- if hasKey $data "envoy.yaml" -}}
+      {{- $_ := set $data "envoy.yaml" (tpl (toString (index $data "envoy.yaml")) $) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- toYaml $data -}}
+{{- end -}}
+
+
+
+{{/*
+Render the default standalone agentgateway proxy config template.
+*/}}
+{{- define "llm-d-router.proxy.agentgatewayConfig" -}}
+{{- $serviceName := include "llm-d-router.agentgateway.logicalBackendName" . -}}
+{{- $serviceNamespace := .Release.Namespace -}}
+{{- $servicePorts := splitList "," (include "llm-d-router.standaloneEndpointTargetPorts" .) -}}
+{{- $backendPort := index $servicePorts 0 -}}
+{{- $listenerPort := include "llm-d-router.standaloneProxyListenerPort" . | int -}}
+config:
+  statsAddr: "0.0.0.0:15020"
+  readinessAddr: "0.0.0.0:15021"
+binds:
+- port: {{ $listenerPort }}
+  listeners:
+  - name: default
+    protocol: HTTP
+    routes:
+    - name: standalone-epp
+      matches:
+      - path:
+          pathPrefix: /
+      backends:
+      - service:
+          name: {{ printf "%s/%s" $serviceNamespace $serviceName | quote }}
+          port: {{ $backendPort }}
+        policies:
+          inferenceRouting:
+            endpointPicker:
+              host: {{ printf "%s:%v" (include "llm-d-router.proxy.extProcHost" .) (.Values.router.epp.extProcPort | default 9002) | quote }}
+            destinationMode: passthrough
+services:
+- name: {{ $serviceName | quote }}
+  namespace: {{ $serviceNamespace | quote }}
+  hostname: {{ $serviceName | quote }}
+  vips: []
+  ports:
+    {{- range $servicePort := $servicePorts }}
+    {{ $servicePort }}: {{ $servicePort }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+EPP resource validations
+*/}}
+{{- define "llm-d-router.validations.epp.resources" -}}
+{{- if not .Values.router.epp.resources }}
+{{- fail ".Values.router.epp.resources is required. EPP is a critical component that must have resource requests set." }}
+{{- end }}
+{{- if not .Values.router.epp.resources.requests }}
+{{- fail ".Values.router.epp.resources.requests is required. EPP is a critical component that must have resource requests set." }}
+{{- end }}
+{{- $_ := required ".Values.router.epp.resources.requests.cpu is required. EPP is a critical component that must have CPU requests set." .Values.router.epp.resources.requests.cpu }}
+{{- $_ := required ".Values.router.epp.resources.requests.memory is required. EPP is a critical component that must have memory requests set." .Values.router.epp.resources.requests.memory }}
+{{- end -}}
+
+{{/*
+Helper to retrieve GKE preferredBackends configuration safely across chart contexts.
+*/}}
+{{- define "llm-d-router.gkePreferredBackends" -}}
+{{- $provider := .Values.provider | default dict -}}
+{{- $gke := index $provider "gke" | default dict -}}
+{{- index $gke "preferredBackends" | default dict | toYaml -}}
+{{- end -}}
+
+{{/*
+EPP generic validations
+*/}}
+{{- define "llm-d-router.validations.epp.preferredBackends" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+  {{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+  {{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+  {{- if lt $preferredReplicas 1 }}
+    {{- fail ".Values.provider.gke.preferredBackends.preferredReplicas must be at least 1 when preferredBackends.enabled is true" }}
+  {{- end }}
+  {{- if lt $defaultReplicas 1 }}
+    {{- fail ".Values.provider.gke.preferredBackends.defaultReplicas must be at least 1 when preferredBackends.enabled is true" }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "llm-d-router.validations.epp" -}}
+{{- include "llm-d-router.validations.deprecations" . }}
+{{- include "llm-d-router.validations.epp.resources" . }}
+{{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
+{{- include "llm-d-router.validations.epp.tokenizer" . }}
+{{- include "llm-d-router.validations.epp.preferredBackends" . }}
+{{- end -}}
+
+{{/*
+Tokenizer validations: require modelName for the render sidecar's command args.
+*/}}
+{{- define "llm-d-router.validations.epp.tokenizer" -}}
+{{- $tokenizer := .Values.router.tokenizer | default dict }}
+{{- if and (dig "enabled" false $tokenizer) (not (dig "modelName" "" $tokenizer)) }}
+{{- fail ".Values.router.tokenizer.modelName is required when the tokenizer is enabled." }}
+{{- end }}
+{{- end -}}
+
+{{/*
+EPP inferenceObjectives validations
+*/}}
+{{- define "llm-d-router.validations.epp.inferenceObjectives" -}}
+{{- if and (eq .Values.router.inferencePool.create false) .Values.router.inferenceObjectives }}
+{{- fail ".Values.router.inferenceObjectives can only be configured when .Values.router.inferencePool.create is true." }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Deprecation validations
+*/}}
+{{- define "llm-d-router.validations.deprecations" -}}
+{{- if .Values.inferenceExtension }}
+{{- fail "Top-level 'inferenceExtension' is deprecated. Please migrate your values to 'router.epp' and other 'router.*' fields." }}
+{{- end }}
+{{- if .Values.inferencePool }}
+{{- fail "Top-level 'inferencePool' is deprecated. Please migrate your values to 'router.modelServers' and 'router.inferencePool'." }}
+{{- end }}
+{{- if .Values.experimentalHttpRoute }}
+  {{- if hasPrefix "llm-d-router-gateway" .Chart.Name }}
+    {{- fail "Top-level 'experimentalHttpRoute' is deprecated. Please migrate your values to 'httpRoute'." }}
+  {{- else }}
+    {{- fail "Top-level 'experimentalHttpRoute' is deprecated and not supported in this chart." }}
+  {{- end }}
+{{- end }}
+{{- if .Values.inferenceObjectives }}
+{{- fail "Top-level 'inferenceObjectives' is deprecated. Please migrate your values to 'router.inferenceObjectives'." }}
+{{- end }}
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_inferenceobjective.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_inferenceobjective.yaml
@@ -1,0 +1,17 @@
+{{- define "llm-d-router.inferenceobjective-resource" -}}
+{{- range .Values.router.inferenceObjectives }}
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" $ | nindent 4 }}
+spec:
+  priority: {{ .priority }}
+  poolRef:
+    group: "inference.networking.k8s.io"
+    name: {{ $.Release.Name }}
+---
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_inferencepool.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_inferencepool.yaml
@@ -1,0 +1,47 @@
+{{- define "llm-d-router.inferencepool" -}}
+apiVersion: "inference.networking.k8s.io/v1"
+kind: InferencePool
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  targetPorts:
+  {{- range .Values.router.modelServers.targetPorts }}
+  - number: {{ .number }}
+  {{- end }}
+  {{- if .Values.router.modelServers.protocol }}
+  {{- if eq .Values.router.modelServers.protocol "grpc" }}
+  appProtocol: "kubernetes.io/h2c"
+  {{- else if eq .Values.router.modelServers.protocol "http" }}
+  appProtocol: "http"
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- if .Values.router.modelServers.matchLabels }}
+      {{- range $key, $value := .Values.router.modelServers.matchLabels }}
+      {{ $key }}: {{ quote $value }}
+      {{- end }}
+      {{- end }}
+  endpointPickerRef:
+    {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+    {{- if $gkePB.enabled }}
+    name: {{ printf "%s-backup" (include "llm-d-router.name" .) }}
+    {{- else }}
+    name: {{ include "llm-d-router.name" . }}
+    {{- end }}
+    port:
+      number: {{ .Values.router.epp.extProcPort | default 9002 }}
+    failureMode: {{ .Values.router.inferencePool.failureMode | default "FailOpen" }}
+---
+{{- end }}
+
+{{- define "llm-d-router.inferencepool-resource" -}}
+{{- if ne .Values.router.inferencePool.create false }}
+{{- include "llm-d-router.validations.gateway.common" . }}
+{{- include "llm-d-router.inferencepool" . }}
+{{- include "llm-d-router.inferenceobjective-resource" . }}
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_latency-predictor.tpl
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_latency-predictor.tpl
@@ -1,0 +1,112 @@
+{{/*
+Latency Predictor Env
+*/}}
+{{- define "llm-d-router.latencyPredictor.env" -}}
+{{- if .Values.router.latencyPredictor.enabled }}
+- name: PREDICTION_SERVER_URL
+  value: "{{- $count := int .Values.router.latencyPredictor.predictionServers.count -}}
+          {{- $startPort := int .Values.router.latencyPredictor.predictionServers.startPort -}}
+          {{- range $i := until $count -}}
+            {{- if $i }},{{ end }}http://localhost:{{ add $startPort $i }}
+          {{- end }}"
+- name: TRAINING_SERVER_URL
+  value: "http://localhost:{{ .Values.router.latencyPredictor.trainingServer.port }}"
+{{- range $key, $value := .Values.router.latencyPredictor.eppEnv }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Latency Predictor Sidecar Containers
+*/}}
+{{- define "llm-d-router.latencyPredictor.containers" -}}
+{{- if .Values.router.latencyPredictor.enabled }}
+# Training Server Sidecar Container
+- name: training-server
+  image: {{ .Values.router.latencyPredictor.trainingServer.image.registry }}/{{ .Values.router.latencyPredictor.trainingServer.image.repository }}:{{ .Values.router.latencyPredictor.trainingServer.image.tag }}
+  imagePullPolicy: {{ .Values.router.latencyPredictor.trainingServer.image.pullPolicy }}
+  ports:
+  - containerPort: {{ .Values.router.latencyPredictor.trainingServer.port }}
+    name: training-port
+  livenessProbe:
+    {{- toYaml .Values.router.latencyPredictor.trainingServer.livenessProbe | nindent 4 }}
+  readinessProbe:
+    {{- toYaml .Values.router.latencyPredictor.trainingServer.readinessProbe | nindent 4 }}
+  resources:
+    {{- toYaml .Values.router.latencyPredictor.trainingServer.resources | nindent 4 }}
+  envFrom:
+  - configMapRef:
+      name: {{ include "llm-d-router.name" . }}-latency-predictor-training
+  env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: SERVER_TYPE
+    value: "training"
+  volumeMounts:
+  - name: training-server-storage
+    mountPath: /models
+{{- range $i := until (int .Values.router.latencyPredictor.predictionServers.count) }}
+# Prediction Server Sidecar Container {{ add $i 1 }}
+- name: prediction-server-{{ add $i 1 }}
+  image: {{ $.Values.router.latencyPredictor.predictionServers.image.registry }}/{{ $.Values.router.latencyPredictor.predictionServers.image.repository }}:{{ $.Values.router.latencyPredictor.predictionServers.image.tag }}
+  imagePullPolicy: {{ $.Values.router.latencyPredictor.predictionServers.image.pullPolicy }}
+  command: ["uvicorn"]
+  args: ["llm_d_latency_predictor.prediction_server:app", "--host", "0.0.0.0", "--port", "{{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}"]
+  ports:
+  - containerPort: {{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}
+    name: predict-port-{{ add $i 1 }}
+  livenessProbe:
+    httpGet:
+      path: {{ $.Values.router.latencyPredictor.predictionServers.livenessProbe.httpGet.path }}
+      port: {{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}
+    initialDelaySeconds: {{ $.Values.router.latencyPredictor.predictionServers.livenessProbe.initialDelaySeconds }}
+    periodSeconds: {{ $.Values.router.latencyPredictor.predictionServers.livenessProbe.periodSeconds }}
+  readinessProbe:
+    httpGet:
+      path: {{ $.Values.router.latencyPredictor.predictionServers.readinessProbe.httpGet.path }}
+      port: {{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}
+    initialDelaySeconds: {{ $.Values.router.latencyPredictor.predictionServers.readinessProbe.initialDelaySeconds }}
+    periodSeconds: {{ $.Values.router.latencyPredictor.predictionServers.readinessProbe.periodSeconds }}
+    failureThreshold: {{ $.Values.router.latencyPredictor.predictionServers.readinessProbe.failureThreshold }}
+  resources:
+    {{- toYaml $.Values.router.latencyPredictor.predictionServers.resources | nindent 4 }}
+  envFrom:
+  - configMapRef:
+      name: {{ include "llm-d-router.name" $ }}-latency-predictor-prediction
+  env:
+  - name: PREDICT_PORT
+    value: "{{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}"
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: SERVER_TYPE
+    value: "prediction-{{ add $i 1 }}"
+  - name: TRAINING_SERVER_URL
+    value: "http://localhost:{{ $.Values.router.latencyPredictor.trainingServer.port }}"
+  volumeMounts:
+  - name: prediction-server-{{ add $i 1 }}-storage
+    mountPath: /server_models
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Latency Predictor Volumes
+*/}}
+{{- define "llm-d-router.latencyPredictor.volumes" -}}
+{{- if .Values.router.latencyPredictor.enabled }}
+- name: training-server-storage
+  emptyDir: 
+    sizeLimit: {{ .Values.router.latencyPredictor.trainingServer.volumeSize }}
+{{- range $i := until (int .Values.router.latencyPredictor.predictionServers.count) }}
+- name: prediction-server-{{ add $i 1 }}-storage
+  emptyDir: 
+    sizeLimit: {{ $.Values.router.latencyPredictor.predictionServers.volumeSize }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_leader-election-rbac.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_leader-election-rbac.yaml
@@ -1,0 +1,33 @@
+{{- define "llm-d-epp.leader-election-rbac" -}}
+{{- if (.Values.router.epp.ha.enableLeaderElection | default false) }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "llm-d-router.name" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+rules:
+- apiGroups: [ "coordination.k8s.io" ]
+  resources: [ "leases" ]
+  verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+- apiGroups: [ "" ]
+  resources: [ "events" ]
+  verbs: [ "create", "patch" ]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "llm-d-router.name" . }}-leader-election-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "llm-d-router.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "llm-d-router.name" . }}-leader-election
+---
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_proxy-deployment.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_proxy-deployment.yaml
@@ -1,0 +1,95 @@
+{{- define "llm-d-epp.proxy-deployment" -}}
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- $proxyType := include "llm-d-router.proxyType" . | trim -}}
+{{- $proxyConfigMap := index $proxy "configMap" | default dict -}}
+{{- $proxyConfigMapName := index $proxyConfigMap "name" | default "" -}}
+{{- if and $proxy.enabled (eq (include "llm-d-router.proxyMode" .) "service") -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-router.proxyName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.router.proxy.replicas | default 2 }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.proxySelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.labels" . | nindent 8 }}
+        {{- include "llm-d-router.proxySelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ $proxy.name }}
+          image: {{ $proxy.image }}
+          imagePullPolicy: {{ $proxy.imagePullPolicy | default "IfNotPresent" }}
+        {{- with $proxy.command }}
+          command:
+            - {{ . | quote }}
+        {{- end }}
+        {{- with $proxy.args }}
+          args:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+        {{- end }}
+        {{- with $proxy.env }}
+          env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $proxy.ports }}
+          ports:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $proxy.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.startupProbe }}
+          startupProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- if or (and (eq $proxyType "agentgateway") $proxyConfigMapName) $proxy.volumeMounts }}
+          volumeMounts:
+          {{- if and (eq $proxyType "agentgateway") $proxyConfigMapName }}
+            - name: agentgateway-config-template
+              mountPath: /config
+              readOnly: true
+          {{- end }}
+          {{- with $proxy.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- if or (and (eq $proxyType "agentgateway") $proxyConfigMapName) $proxy.volumes }}
+      volumes:
+      {{- if and (eq $proxyType "agentgateway") $proxyConfigMapName }}
+        - name: agentgateway-config-template
+          configMap:
+            name: {{ $proxyConfigMapName }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+      {{- end }}
+      {{- with $proxy.volumes }}
+      {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- end }}
+---
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_proxy-service.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_proxy-service.yaml
@@ -1,0 +1,22 @@
+{{- define "llm-d-epp.proxy-service" -}}
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- if and $proxy.enabled (eq (include "llm-d-router.proxyMode" .) "service") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-d-router.proxyName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+  ports:
+    {{- with .Values.router.extraServicePorts }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+---
+{{- end -}}
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_rbac.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_rbac.yaml
@@ -1,0 +1,76 @@
+{{- define "llm-d-router.rbac" -}}
+{{- if .Values.router.monitoring.prometheus.enabled }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "llm-d-router.cluster-rbac-name" . }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+    - authentication.k8s.io
+  resources:
+    - tokenreviews
+  verbs:
+    - create
+- apiGroups:
+    - authorization.k8s.io
+  resources:
+    - subjectaccessreviews
+  verbs:
+    - create
+- nonResourceURLs:
+    - "/metrics"
+  verbs:
+    - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "llm-d-router.cluster-rbac-name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "llm-d-router.cluster-rbac-name" . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-sa" (include "llm-d-router.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-sa" (include "llm-d-router.name" .) }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-sa" (include "llm-d-router.name" .) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+---
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_sa-token-secret.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_sa-token-secret.yaml
@@ -1,0 +1,16 @@
+{{- define "llm-d-epp.sa-token-secret" -}}
+{{- $monitoringProviderName := include "llm-d-router.monitoring.provider.name" . | lower -}}
+{{- if and .Values.router.monitoring.prometheus.enabled .Values.router.monitoring.prometheus.auth.enabled (eq $monitoringProviderName "prometheusoperator") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.router.monitoring.prometheus.auth.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "llm-d-router.name" . }}
+type: kubernetes.io/service-account-token
+---
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_service.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_service.yaml
@@ -1,0 +1,68 @@
+{{- define "llm-d-epp.service" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 0 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- if eq (int $i) 0 }}
+  {{- $serviceName = include "llm-d-router.name" $ }}
+{{- else if ge (int $i) (int $preferredReplicas) }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" $ | nindent 4 }}
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports":{"{{ $.Values.router.epp.extProcPort | default 9002 }}":{}}}'
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ printf "%s-%d" (include "llm-d-router.name" $) (int $i) }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ $.Values.router.epp.extProcPort | default 9002 }}
+      appProtocol: kubernetes.io/h2c
+    - name: http-metrics
+      protocol: TCP
+      port: {{ $.Values.router.metricsPort | default 9090 }}
+    {{- with $.Values.router.extraServicePorts }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+---
+{{- end }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "llm-d-router.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ .Values.router.epp.extProcPort | default 9002 }}
+      appProtocol: kubernetes.io/h2c
+    - name: http-metrics
+      protocol: TCP
+      port: {{ .Values.router.metricsPort | default 9090 }}
+    {{- with .Values.router.extraServicePorts }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_servicemonitor.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/templates/_servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- define "llm-d-epp.service-monitor" -}}
+{{- $monitoringProviderName := include "llm-d-router.monitoring.provider.name" . | lower -}}
+{{- if and .Values.router.monitoring.prometheus.enabled (eq $monitoringProviderName "prometheusoperator") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "llm-d-router.name" . }}-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- with .Values.router.monitoring.prometheus.extraLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.router.monitoring.interval }}
+    port: "http-metrics"
+    path: "/metrics"
+    {{- if .Values.router.monitoring.prometheus.auth.enabled }}
+    authorization:
+      credentials:
+        key: token
+        name: {{ .Values.router.monitoring.prometheus.auth.secretName }}
+    {{- end }}
+  jobLabel: {{ include "llm-d-router.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.labels" . | nindent 6 }}
+---
+{{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/values.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/charts/router/values.yaml
@@ -1,0 +1,259 @@
+extraServicePorts: []
+
+# Kubernetes cluster DNS domain, used to build in-cluster Service FQDNs.
+clusterDomain: cluster.local
+
+epp:
+  replicas: 1
+  image:
+    registry: ghcr.io/llm-d
+    repository: llm-d-router-endpoint-picker
+    tag: main
+    pullPolicy: Always
+  extProcPort: 9002
+  # gRPC port serving EPP liveness and readiness checks, 9003 if unset.
+  # grpcHealthPort: 9003
+
+  parsers: [] # e.g. ["openai-parser", "anthropic-parser"], or empty for auto-selection
+
+  # Metrics DataSource Configuration
+  # These values configure how the EPP scrapes metrics from model server pods.
+  metricsDataSource:
+    # scheme is the HTTP scheme used to scrape metrics (http or https).
+    scheme: "http"
+    # path is the URL path on the model server pod that exposes Prometheus metrics.
+    path: "/metrics"
+    # insecureSkipVerify disables TLS certificate verification when scheme is https.
+    insecureSkipVerify: true
+
+  # Example flags:
+  # flags:
+  #  # Log verbosity
+  #  v: 2
+  
+  # Example environment variables:
+  # env:
+  #   ENABLE_EXPERIMENTAL_FEATURE: "true"
+  env: []
+  
+  pluginsConfigFile: "default-plugins.yaml"
+  pluginsCustomConfig: {}
+  
+  # Define additional container ports
+  extraContainerPorts: []
+  
+  # Example defining a custom EPP config file
+  # pluginsCustomConfig:
+  #   custom-plugins.yaml: |
+  #     apiVersion: inference.networking.x-k8s.io/v1alpha1
+  #     kind: EndpointPickerConfig
+  #     plugins:
+  #     - type: custom-scorer
+  #       parameters:
+  #         custom-threshold: 64
+  #     schedulingProfiles:
+  #     - name: default
+  #       plugins:
+  #       - pluginRef: custom-scorer
+  
+  # EPP container resources: CPU limits unset for burst capacity, memory capped at 16Gi
+  resources:
+    requests:
+      cpu: "8"
+      memory: 8Gi
+    limits:
+      memory: 16Gi
+
+  affinity: {}
+  tolerations: []
+
+  # Annotations added to the EPP pod template. Useful for clusters that rely on
+  # annotation-based Prometheus scraping (prometheus.io/{scrape,port,path}) or
+  # Istio metrics-merging, rather than a ServiceMonitor or GMP.
+  podAnnotations: {}
+
+# By default no proxy is configured
+proxy:
+  enabled: false    
+
+# Tokenizer sidecar. Runs vLLM's `vllm launch render <modelName>` and exposes
+# `/render` over loopback HTTP to EPP. modelName is passed as the first
+# positional arg to the render command (required when enabled). EPP is wired to
+# the sidecar via `router.epp.pluginsCustomConfig`.
+tokenizer:
+  enabled: false
+  modelName: ""
+  image:
+    registry: docker.io
+    repository: vllm/vllm-openai-cpu
+    tag: v0.19.1
+    pullPolicy: IfNotPresent
+  port: 8000
+  command: []
+  args: []
+  # Extra args appended to the vllm-render container after the default or overridden args.
+  extraArgs: []
+  # Pod-level init containers rendered when the tokenizer is enabled.
+  initContainers: []
+  # Pod-level volumes rendered alongside model-cache when the tokenizer is enabled.
+  volumes: []
+  env:
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: llm-d-hf-token
+          key: HF_TOKEN
+  resources:
+    requests:
+      cpu: "4"
+      memory: 8Gi
+  volumeMounts: []
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: render-http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 60
+
+# Monitoring configuration for EPP
+monitoring:
+  interval: "10s"
+  # Monitoring provider selection.
+  # Options: ["gmp", "prometheusoperator"].
+  #     gmp: Google Managed Prometheus
+  #     prometheusoperator: Open Source Prometheus Operator
+  # If not set, defaults to "prometheusoperator". For backwards compatibility,
+  # legacy provider.name=gke still maps to "gmp" when this field is unset.
+  provider:
+    name: ""
+    gmp:
+      autopilot: false
+  # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+  prometheus:
+    enabled: false
+    auth:
+      # Set to false to allow unauthenticated /metrics access. Required for annotation-based
+      # Prometheus scraping and Istio metrics-merging, which do not send Bearer tokens.
+      enabled: true
+      # Service account token secret for authentication
+      secretName: inference-gateway-sa-metrics-reader-secret
+    # additional labels for the ServiceMonitor
+    extraLabels: {}
+
+tracing:
+  enabled: false
+  otelExporterEndpoint: "http://localhost:4317"
+  sampling:
+    sampler: "parentbased_traceidratio"
+    samplerArg: "0.1"
+
+inferencePool:
+  create: true
+  failureMode: "FailOpen"
+
+inferenceObjectives: []
+# - name: high-priority
+#   priority: 5
+# - name: low-priority
+#   priority: 1
+
+modelServers:
+  type: vllm # vllm, sglang, triton-tensorrt-llm, trtllm-serve, triton
+  protocol: http # http, grpc
+  targetPorts:
+    - number: 8000
+  # matchLabels: # REQUIRED in parent charts if creating inference pool
+  #   app: vllm-qwen3-32b
+
+latencyPredictor:
+  enabled: false
+  # Training Server Configuration
+  trainingServer:
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-latency-predictor-training-server-dev
+      tag: latest
+      pullPolicy: Always
+    port: 8000
+    resources:
+      requests:
+        cpu: "2000m"
+        memory: "4Gi"
+      limits:
+        cpu: "4000m"
+        memory: "8Gi"
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 20
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 8000
+      initialDelaySeconds: 45
+      periodSeconds: 10
+    volumeSize: "20Gi"
+    config:
+      LATENCY_RETRAINING_INTERVAL_SEC: "10"
+      LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
+      LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
+      LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
+      LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
+      LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
+      LATENCY_MODEL_TYPE: "xgboost"
+      LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "500"
+      LATENCY_OBJECTIVE_TYPE: "mean"
+
+  # Prediction Server Configuration
+  predictionServers:
+    count: 1
+    startPort: 8001
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-latency-predictor-prediction-server-dev
+      tag: latest
+      pullPolicy: Always
+    resources:
+      requests:
+        cpu: "8000m"
+        memory: "4Gi"
+      limits:
+        cpu: "28000m"
+        memory: "8Gi"
+    livenessProbe:
+      httpGet:
+        path: /healthz
+      initialDelaySeconds: 15
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 5
+    readinessProbe:
+      httpGet:
+        path: /readyz
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    volumeSize: "10Gi"
+    config:
+      LATENCY_MODEL_TYPE: "xgboost"
+      PREDICT_HOST: "0.0.0.0"
+      LOCAL_TTFT_MODEL_PATH: "/server_models/ttft.joblib"
+      LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
+      LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
+      LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
+      UVICORN_WORKERS: "28"
+      OMP_NUM_THREADS: "1"
+      MODEL_SYNC_INTERVAL_SEC: "30"
+      LATENCY_OBJECTIVE_TYPE: "mean"
+
+  # EPP Environment Variables for Latency Predictor
+  eppEnv:
+    LATENCY_MAX_SAMPLE_SIZE: "10000"
+    LATENCY_MAX_CONCURRENT_DISPATCHES: "36"
+    LATENCY_COALESCE_WINDOW_MS: "1"
+

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/NOTES.txt
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/NOTES.txt
@@ -1,0 +1,1 @@
+llm-d-router-gateway {{ .Release.Name }} deployed.

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/_helpers.tpl
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create a default fully qualified app name for inferenceGateway.
+*/}}
+{{- define "llm-d-router-gateway.fullname" -}}
+  {{- if .Values.httpRoute.inferenceGatewayName -}}
+    {{- .Values.httpRoute.inferenceGatewayName | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- printf "%s-inference-gateway" .Release.Name| trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/_validations.tpl
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/_validations.tpl
@@ -1,0 +1,8 @@
+{{/*
+common validations
+*/}}
+{{- define "llm-d-router.validations.gateway.common" -}}
+{{- if or (empty $.Values.router.modelServers) (not $.Values.router.modelServers.matchLabels) }}
+{{- fail ".Values.router.modelServers.matchLabels is required" }}
+{{- end }}
+{{- end -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/epp.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/epp.yaml
@@ -1,0 +1,8 @@
+{{ include "llm-d-router.validations.epp" $ }}
+{{ include "llm-d-router.inferencepool-resource" . }}
+{{ include "llm-d-epp.config" . }}
+{{ include "llm-d-epp.deployment" . }}
+{{ include "llm-d-epp.leader-election-rbac" . }}
+{{ include "llm-d-epp.sa-token-secret" . }}
+{{ include "llm-d-epp.service" . }}
+{{ include "llm-d-epp.service-monitor" . }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/gke.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/gke.yaml
@@ -1,0 +1,164 @@
+{{- if eq (lower .Values.provider.name) "gke" }}
+---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: inference.networking.k8s.io
+    kind: InferencePool
+    name: {{ .Release.Name }}
+  default:
+    # Set a more aggressive health check than the default 5s for faster switch
+    # over during EPP rollout.
+    timeoutSec: 2
+    checkIntervalSec: 2
+    {{- $port := .Values.router.modelServers.targetPortNumber }}
+    {{- if .Values.router.modelServers.targetPorts }}
+      {{- $port = (index .Values.router.modelServers.targetPorts 0).number }}
+    {{- end }}
+    {{- if eq .Values.router.modelServers.protocol "http" }}
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /health
+        port: {{ $port }}
+    {{- else if and (eq (lower .Values.router.modelServers.type) "vllm") (eq .Values.router.modelServers.protocol "grpc") }}
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: {{ $port }}
+        grpcServiceName: "/vllm.grpc.engine.VllmEngine/HealthCheck"
+    {{- end }}
+{{- $eppHealthPort := int (.Values.router.epp.grpcHealthPort | default 9003) }}
+{{- /* The GKE gateway controller health-checks the EPP backend on gRPC port
+9003 by default, so an explicit HealthCheckPolicy is only needed for other ports. */}}
+{{- if ne $eppHealthPort 9003 }}
+---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ .Release.Name }}-epp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "llm-d-router.name" . }}
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: {{ $eppHealthPort }}
+{{- end }}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 1 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- if ge (int $i) (int $preferredReplicas) }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
+---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" $ | nindent 4 }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $serviceName }}
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: {{ $eppHealthPort }}
+{{- end }}
+{{- end }}
+---
+{{- if not $gkePB.enabled }}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: inference.networking.k8s.io
+    kind: InferencePool
+    name: {{ .Release.Name }}
+  default:
+    timeoutSec: 300    # 5-minute timeout (adjust as needed)
+    logging:
+      enabled: true    # log all requests by default
+---
+{{- end }}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 0 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- $policyName := printf "%s-preferred-%d" $.Release.Name (int $i) }}
+{{- $pref := "PREFERRED" }}
+{{- if eq (int $i) 0 }}
+  {{- $serviceName = include "llm-d-router.name" $ }}
+  {{- $policyName = $.Release.Name }}
+{{- else if ge (int $i) (int $preferredReplicas) }}
+  {{- $pref = "DEFAULT" }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+    {{- $policyName = printf "%s-backup" $.Release.Name }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+    {{- $policyName = printf "%s-backup-%d" $.Release.Name (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $serviceName }}
+  default:
+    timeoutSec: 300
+    backendPreference: {{ $pref }}
+    {{- if $gkePB.balancingMode }}
+    balancingMode: {{ $gkePB.balancingMode }}
+    {{- end }}
+    {{- if $gkePB.maxRatePerEndpoint }}
+    maxRatePerEndpoint: {{ $gkePB.maxRatePerEndpoint }}
+    {{- end }}
+    {{- if $gkePB.capacityScalerPercent }}
+    capacityScalerPercent: {{ $gkePB.capacityScalerPercent }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- include "llm-d-router.gke" . -}}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/httproute.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httpRoute.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ include "llm-d-router-gateway.fullname" . }}
+    {{- if .Values.httpRoute.inferenceGatewayNamespace }}
+    namespace: {{ .Values.httpRoute.inferenceGatewayNamespace }}
+    {{- end }}
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: {{ .Release.Name }}
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+      {{- if or .Values.httpRoute.baseModel .Values.httpRoute.headerMatches }}
+      headers:
+      {{- $headerMatches := deepCopy (.Values.httpRoute.headerMatches | default dict) }}
+      {{- if .Values.httpRoute.baseModel }}
+        - type: Exact
+          name: X-Gateway-Base-Model-Name
+          value: {{ .Values.httpRoute.baseModel }}
+      {{- end }}
+      {{- range $key, $value := $headerMatches }}
+        - type: Exact
+          name: {{ $key }}
+          value: {{ $value }}
+      {{- end }}
+      {{- end }}
+    {{- if ne (lower .Values.provider.name) "gke" }}
+    timeouts:
+      request: {{ .Values.httpRoute.requestTimeout }}
+    {{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/istio.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/istio.yaml
@@ -1,0 +1,19 @@
+{{- if eq .Values.provider.name "istio" }}
+{{- $istio := (index .Values "provider" "istio") | default (dict) -}}
+{{- $dr := (index $istio "destinationRule") | default (dict) -}}
+
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+spec:
+  host: {{ (index $dr "host") | default (printf "%s.%s.svc.cluster.local" (include "llm-d-router.name" .) .Release.Namespace) }}
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+    {{- with (index (index $dr "trafficPolicy") "connectionPool") }}
+    connectionPool:
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/rbac.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/templates/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-non-sa" (include "llm-d-router.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["inference.networking.x-k8s.io"]
+  resources: ["inferenceobjectives", "inferencemodelrewrites"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["llm-d.ai"]
+  resources: ["inferenceobjectives", "inferencemodelrewrites"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["inference.networking.k8s.io"]
+  resources: ["inferencepools"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-non-sa" (include "llm-d-router.name" .) }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-non-sa" (include "llm-d-router.name" .) }}
+---
+{{- include "llm-d-router.rbac" . -}}

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/values.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/charts/llm-d-router-gateway/values.yaml
@@ -1,0 +1,76 @@
+router:
+  modelServers:
+    matchLabels:
+      app: inferx
+  # matchLabels: # REQUIRED
+  #   app: vllm-qwen3-32b
+  epp:
+    image:
+      registry: ghcr.m.daocloud.io
+      repository: llm-d/llm-d-router-endpoint-picker
+      tag: v0.10.0
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "1"
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+    ha:
+      enableLeaderElection: false
+  latencyPredictor:
+    trainingServer:
+      image:
+        registry: ghcr.m.daocloud.io/llm-d
+        repository: llm-d-latency-predictor-training-server
+        tag: v0.10.0
+        pullPolicy: IfNotPresent
+    predictionServers:
+      image:
+        registry: ghcr.m.daocloud.io/llm-d
+        repository: llm-d-latency-predictor-prediction-server
+        tag: v0.10.0
+        pullPolicy: IfNotPresent
+# Gateway provider selection.
+# This section configures the gateway implementation only; it is not a generic infrastructure provider setting.
+# Options: ["gke", "istio", "none"]
+provider:
+  name: none
+  # Istio-specific configuration.
+  # This block is only used if name is "istio".
+  istio:
+    destinationRule:
+      # Provide a way to override the default calculated host
+      host: ""
+      # Optional: Enables customization of the traffic policy
+      trafficPolicy: {}
+      # connectionPool:
+      #   http:
+      #     maxRequestsPerConnection: 256000
+  # GKE-specific configuration.
+  # This block is only used if name is "gke".
+  gke:
+    preferredBackends:
+      enabled: false
+      # Number of primary active pod instances pinned to the PREFERRED load balancing tier.
+      # Setting >1 scales concurrent active routing.
+      preferredReplicas: 1
+      # Number of standby pod instances pinned to the DEFAULT load balancing tier.
+      # Setting >1 scales warm standby failover capacity.
+      defaultReplicas: 1
+      # Benchmark capacity and threshold settings for PREFERRED load balancing tier.
+      # When incoming traffic exceeds capacityScalerPercent of maxRatePerEndpoint, excess traffic spills over to DEFAULT standby pods.
+      balancingMode: RATE
+      maxRatePerEndpoint: 100
+      capacityScalerPercent: 100
+# httpRoute section is used to deploy an HTTPRoute resource as part of the gateway chart.
+httpRoute:
+  create: false # a flag to indicate whether to create the httproute as part of the chart or not.
+  inferenceGatewayName: inference-gateway
+  inferenceGatewayNamespace: ""
+  # HTTPRoute request timeout. Defaults to "300s". Unused when provider.name is gke.
+  requestTimeout: "300s"
+  # Example header matches:
+  # headerMatches:
+  #  x-my-custom-route-header: route-name

--- a/charts/llm-d-router-gateway/llm-d-router-gateway/values.yaml
+++ b/charts/llm-d-router-gateway/llm-d-router-gateway/values.yaml
@@ -1,0 +1,78 @@
+# child values
+llm-d-router-gateway:
+  router:
+    modelServers:
+      matchLabels:
+        app: inferx
+    # matchLabels: # REQUIRED
+    #   app: vllm-qwen3-32b
+    epp:
+      image:
+        registry: ghcr.m.daocloud.io
+        repository: llm-d/llm-d-router-endpoint-picker
+        tag: v0.10.0
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: "1"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      ha:
+        enableLeaderElection: false
+    latencyPredictor:
+      trainingServer:
+        image:
+          registry: ghcr.m.daocloud.io/llm-d
+          repository: llm-d-latency-predictor-training-server
+          tag: v0.10.0
+          pullPolicy: IfNotPresent
+      predictionServers:
+        image:
+          registry: ghcr.m.daocloud.io/llm-d
+          repository: llm-d-latency-predictor-prediction-server
+          tag: v0.10.0
+          pullPolicy: IfNotPresent
+  # Gateway provider selection.
+  # This section configures the gateway implementation only; it is not a generic infrastructure provider setting.
+  # Options: ["gke", "istio", "none"]
+  provider:
+    name: none
+    # Istio-specific configuration.
+    # This block is only used if name is "istio".
+    istio:
+      destinationRule:
+        # Provide a way to override the default calculated host
+        host: ""
+        # Optional: Enables customization of the traffic policy
+        trafficPolicy: {}
+        # connectionPool:
+        #   http:
+        #     maxRequestsPerConnection: 256000
+    # GKE-specific configuration.
+    # This block is only used if name is "gke".
+    gke:
+      preferredBackends:
+        enabled: false
+        # Number of primary active pod instances pinned to the PREFERRED load balancing tier.
+        # Setting >1 scales concurrent active routing.
+        preferredReplicas: 1
+        # Number of standby pod instances pinned to the DEFAULT load balancing tier.
+        # Setting >1 scales warm standby failover capacity.
+        defaultReplicas: 1
+        # Benchmark capacity and threshold settings for PREFERRED load balancing tier.
+        # When incoming traffic exceeds capacityScalerPercent of maxRatePerEndpoint, excess traffic spills over to DEFAULT standby pods.
+        balancingMode: RATE
+        maxRatePerEndpoint: 100
+        capacityScalerPercent: 100
+  # httpRoute section is used to deploy an HTTPRoute resource as part of the gateway chart.
+  httpRoute:
+    create: false # a flag to indicate whether to create the httproute as part of the chart or not.
+    inferenceGatewayName: inference-gateway
+    inferenceGatewayNamespace: ""
+    # HTTPRoute request timeout. Defaults to "300s". Unused when provider.name is gke.
+    requestTimeout: "300s"
+    # Example header matches:
+    # headerMatches:
+    #  x-my-custom-route-header: route-name

--- a/charts/llm-d-router-gateway/parent/.relok8s-images.yaml
+++ b/charts/llm-d-router-gateway/parent/.relok8s-images.yaml
@@ -1,0 +1,1 @@
+- "{{ .llm-d-router-gateway.router.epp.image.registry }}/{{ .llm-d-router-gateway.router.epp.image.repository }}:{{ .llm-d-router-gateway.router.epp.image.tag }}"

--- a/test/llm-d-router-gateway/install.sh
+++ b/test/llm-d-router-gateway/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+CURRENT_FILENAME=$( basename "$0" )
+CURRENT_DIR_PATH=$(cd `dirname $0` ; pwd )
+
+KIND_KUBECONFIG=$1
+CHART_VERSION=$3
+
+[ -f "$KIND_KUBECONFIG" ] || {
+  echo "error, failed to find kubeconfig $KIND_KUBECONFIG "
+  exit 1
+}
+[ -n "$CHART_VERSION" ] || {
+  echo "error, failed to find chart version $CHART_VERSION "
+  exit 1
+}
+
+echo "KIND_KUBECONFIG: $KIND_KUBECONFIG"
+echo "CHART_VERSION: $CHART_VERSION"
+
+helm repo update chart-museum --kubeconfig ${KIND_KUBECONFIG}
+HELM_MUST_OPTION=" --version ${CHART_VERSION} --timeout 10m0s --wait --debug --kubeconfig ${KIND_KUBECONFIG} "
+
+#==================== add your deploy code bellow =============
+#==================== notice , prometheus CRD has been deployed , so you no need to =============
+
+set -x
+
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/manifests.yaml \
+  --kubeconfig ${KIND_KUBECONFIG}
+
+helm install llm-d-router-gateway chart-museum/llm-d-router-gateway ${HELM_MUST_OPTION} \
+  --set llm-d-router-gateway.router.modelServers\.matchLabels.app=vllm-llama3-8b-instruct \
+  --set llm-d-router-gateway.router.epp.replicas=2 \
+  --set llm-d-router-gateway.router.epp.deploymentStrategy.type=RollingUpdate \
+  --namespace llm-d-router-gateway --create-namespace
+
+if (($?==0)) ; then
+  echo "succeeded to deploy $CHART_DIR"
+else
+  echo "error, failed to deploy $CHART_DIR"
+  exit 1
+fi


### PR DESCRIPTION
<!-- * chart 适配注意

1. 修改 values.yaml 文件，其中的仓库指向 m.daocloud 仓库的镜像。

    并且，设置开源镜像的自动化同步

2. values.yaml 调优各种配置值，使得安装最简单，例如 一些功能开关、CPU 和 memory 满足 kubecost 最小要求

3. Chart.yaml 文件中如果缺失 keywords，可进行添加分类，使得应用商店中能按照组件来寻找

4. 如果 chart 中 有 serviceMonitor、prometheusRules 等对象，请设置上 label “operator.insight.io/managed-by: insight”

-->
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #